### PR TITLE
REM-950 - Add option to automatically add summary field to new reminders

### DIFF
--- a/app/src/main/java/com/elementary/tasks/core/data/platform/ReminderCreatorConfig.kt
+++ b/app/src/main/java/com/elementary/tasks/core/data/platform/ReminderCreatorConfig.kt
@@ -152,6 +152,14 @@ data class ReminderCreatorConfig(private val value: String) {
     updateBitAndByte(2, SEND_EMAIL_BIT, enabled)
   }
 
+  fun isAutoAddSummary(): Boolean {
+    return bytes.isBitSet(3, AUTO_ADD_SUMMARY)
+  }
+
+  fun setAutoAddSummary(enabled: Boolean) {
+    updateBitAndByte(3, AUTO_ADD_SUMMARY, enabled)
+  }
+
   private fun updateBitAndByte(byte: Int, bit: Int, enabled: Boolean) {
     if (enabled) {
       bytes.setBit(byte, bit)
@@ -196,5 +204,8 @@ data class ReminderCreatorConfig(private val value: String) {
     private const val OPEN_APP_BIT = 2
     private const val OPEN_LINK_BIT = 3
     private const val SEND_EMAIL_BIT = 4
+
+    // fourth byte
+    private const val AUTO_ADD_SUMMARY = 0
   }
 }

--- a/app/src/main/java/com/elementary/tasks/reminder/KoinModule.kt
+++ b/app/src/main/java/com/elementary/tasks/reminder/KoinModule.kt
@@ -125,6 +125,7 @@ val reminderModule = module {
       get(),
       get(),
       get(),
+      get(),
       get()
     )
   }

--- a/app/src/main/java/com/elementary/tasks/reminder/build/BuilderConfigureActivity.kt
+++ b/app/src/main/java/com/elementary/tasks/reminder/build/BuilderConfigureActivity.kt
@@ -103,6 +103,10 @@ class BuilderConfigureActivity : BindingActivity<ActivityConfigureReminderCreato
     initParam(binding.sendEmailParam, config.isSendEmailEnabled()) {
       config.setSendEmailEnabled(it)
     }
+
+    initParam(binding.summaryParam, config.isAutoAddSummary()) {
+      config.setAutoAddSummary(it)
+    }
   }
 
   private fun initParam(prefsView: PrefsView, enabled: Boolean, onClick: (Boolean) -> Unit) {

--- a/app/src/main/res/layout/activity_configure_reminder_creator.xml
+++ b/app/src/main/res/layout/activity_configure_reminder_creator.xml
@@ -42,6 +42,17 @@
                 android:textAppearance="?textAppearanceTitleMedium" />
 
             <com.elementary.tasks.core.views.PrefsView
+                android:id="@+id/summaryParam"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:prefs_divider_bottom="true"
+                app:prefs_icon="@drawable/ic_fluent_text"
+                app:prefs_primary_text="@string/summary_field"
+                app:prefs_secondary_text_on="@string/automatically_add_summary_field_when_create_the_reminder"
+                app:prefs_secondary_text_off="@string/do_not_add_summary_field_when_create_the_reminder"
+                app:prefs_type="check_switch" />
+
+            <com.elementary.tasks.core.views.PrefsView
                 android:id="@+id/beforeParam"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="do_not_add_summary_field_when_create_the_reminder">Do not add summary field when create the reminder</string>
+    <string name="automatically_add_summary_field_when_create_the_reminder">Automatically add summary field when create the reminder</string>
+    <string name="summary_field">Summary field</string>
+</resources>


### PR DESCRIPTION
- Introduces a new preference in the Reminder Creator configuration to automatically add an empty summary field when creating a new reminder via deep links (date/time or to-do type).
- Adds a "Summary field" option to the "Configure Reminder Creator" screen.
- Updates `ReminderCreatorConfig` to store and manage the new "Auto Add Summary" preference.
- Modifies `BuildReminderViewModel` to check this preference and add an empty summary item to the builder if enabled and a summary doesn't already exist.
- Adds new string resources for the summary field preference.