### PR TITLE
fix: restore locale/theme gating for reminder and birthday action screens

### DIFF
--- a/app/src/main/java/com/elementary/tasks/birthdays/dialog/BirthdayActionActivity.kt
+++ b/app/src/main/java/com/elementary/tasks/birthdays/dialog/BirthdayActionActivity.kt
@@ -11,14 +11,14 @@ import com.github.naz013.common.Permissions
 import com.github.naz013.common.intent.IntentKeys
 import com.github.naz013.feature.common.livedata.observeEvent
 import com.github.naz013.logging.Logger
-import com.github.naz013.ui.common.compose.ComposeActivity
+import com.github.naz013.ui.common.compose.LightThemedComposeActivity
 import com.github.naz013.ui.common.context.buildIntent
 import com.github.naz013.ui.common.context.startActivity
 import org.koin.androidx.compose.koinViewModel
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 
-class BirthdayActionActivity : ComposeActivity() {
+class BirthdayActionActivity : LightThemedComposeActivity() {
 
   private val viewModel by viewModel<BirthdayActionViewModel> { parametersOf(getId(), isTest()) }
   private val permissionFlowDelegate by lazy { PermissionFlowDelegateImpl(this) }

--- a/app/src/main/java/com/elementary/tasks/reminder/dialog/ReminderActionActivity.kt
+++ b/app/src/main/java/com/elementary/tasks/reminder/dialog/ReminderActionActivity.kt
@@ -15,7 +15,7 @@ import com.github.naz013.logging.Logger
 import com.github.naz013.navigation.ActivityDestination
 import com.github.naz013.navigation.DestinationScreen
 import com.github.naz013.navigation.Navigator
-import com.github.naz013.ui.common.compose.ComposeActivity
+import com.github.naz013.ui.common.compose.LightThemedComposeActivity
 import com.github.naz013.ui.common.context.buildIntent
 import com.github.naz013.ui.common.context.startActivity
 import org.koin.android.ext.android.inject
@@ -23,7 +23,7 @@ import org.koin.androidx.compose.koinViewModel
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 
-class ReminderActionActivity : ComposeActivity() {
+class ReminderActionActivity : LightThemedComposeActivity() {
 
   private val viewModel by viewModel<ReminderActionActivityViewModel> {
     parametersOf(getId(), isTest())

--- a/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/LightThemedComposeActivity.kt
+++ b/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/LightThemedComposeActivity.kt
@@ -1,0 +1,20 @@
+package com.github.naz013.ui.common.compose
+
+import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.runtime.Composable
+import com.github.naz013.ui.common.activity.LightThemedActivity
+
+abstract class LightThemedComposeActivity : LightThemedActivity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    enableEdgeToEdge()
+    super.onCreate(savedInstanceState)
+    composeView {
+      ActivityContent()
+    }
+  }
+
+  @Composable
+  abstract fun ActivityContent()
+}


### PR DESCRIPTION
## Summary
- `ReminderActionActivity` and `BirthdayActionActivity` extended `ComposeActivity`, which extends `AppCompatActivity` directly instead of `LightThemedActivity`. Both are launched directly from notification taps (`ReminderHandlerQ`/`ReminderHandlerSilent`, `BirthdayHandlerQ`/`BirthdayHandlerSilent`), a cold-start-capable entry point.
- Investigated whether this was an intentional gap: `requireLogin()` defaults to `false` in `LightThemedActivity` and is never overridden `true` anywhere in the codebase, so PIN-lock gating is not actually lost by these screens — it's inert everywhere. The real, verifiable regression is losing per-activity locale attachment (`Language.onAttach`) and night-mode/dynamic-color reassertion, since neither is set at `Application` scope. A cold process start straight into one of these two screens via notification tap can render in the wrong language/theme.
- Making `ComposeActivity` itself extend `LightThemedActivity` isn't safe: it's also used by the standalone `reviewsadmin` and `cloudtestadmin` debug apps, which have separate Koin graphs that don't bind `AuthPreferences`/`ThemePreferences` — they'd crash on `onResume`.
- Fix: added `LightThemedComposeActivity`, a new base class extending `LightThemedActivity` with the same Compose-hosting `onCreate`, and switched only `ReminderActionActivity`/`BirthdayActionActivity` to it. `ComposeActivity` is untouched.

## Test plan
- [ ] `./gradlew ktlintCheck` — new file matches existing `ComposeActivity.kt` style (same two pre-existing rule violations, no new ones)
- [ ] `./gradlew :app:testProDebugUnitTest`
- [ ] Manually verify: switch in-app language to a non-system language, trigger a reminder/birthday notification from a cold app start, tap it, confirm the action screen renders in the chosen language
- [ ] Manually verify `reviewsadmin`/`cloudtestadmin` still launch (unaffected by this change)
