### PR TITLE
REM-1065 - Track widget interactions for GA4 usage analytics

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -85,7 +85,7 @@ jobs:
 
     - name: Publish coverage to PR comment
       uses: mi-kas/kover-report@v2
-      if: always()
+      if: always() && github.event.before != '0000000000000000000000000000000000000000'
       with:
         path: ${{ github.workspace }}/build/reports/kover/report.xml
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/analytics/src/main/kotlin/com/github/naz013/analytics/AnalyticEvent.kt
+++ b/analytics/src/main/kotlin/com/github/naz013/analytics/AnalyticEvent.kt
@@ -66,6 +66,20 @@ data class WidgetUsedEvent(
   }
 }
 
+/** Send on every real tap on a widget already placed on the home screen (item/button clicks),
+ *  as opposed to [WidgetUsedEvent] which fires when the widget is added/reconfigured. Lets GA
+ *  distinguish "most added" from "most actively used" widget types. */
+data class WidgetInteractedEvent(
+  val widget: Widget
+) : AnalyticEvent(Event.WIDGET_INTERACTED) {
+
+  override fun getParams(): Bundle {
+    return Bundle().apply {
+      putString(Parameter.TYPE, widget.value)
+    }
+  }
+}
+
 data class PresetUsed(
   val presetAction: PresetAction
 ) : AnalyticEvent(Event.PRESET_USED) {
@@ -138,7 +152,8 @@ enum class Event(val value: String) {
   REMINDER_USED("reminder_used"),
   SCREEN_OPENED("screen_opened"),
   PRESET_USED("preset_used"),
-  WIDGET_USED("widget_used")
+  WIDGET_USED("widget_used"),
+  WIDGET_INTERACTED("widget_interacted")
 }
 
 enum class PresetAction(val value: String) {

--- a/analytics/src/test/kotlin/com/github/naz013/analytics/AnalyticEventTest.kt
+++ b/analytics/src/test/kotlin/com/github/naz013/analytics/AnalyticEventTest.kt
@@ -1,0 +1,23 @@
+package com.github.naz013.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AnalyticEventTest {
+
+  @Test
+  fun `widget interacted event name is distinct from widget used event name`() {
+    val interacted = WidgetInteractedEvent(Widget.CALENDAR)
+    val used = WidgetUsedEvent(Widget.CALENDAR)
+
+    assertEquals("widget_interacted", interacted.getName())
+    assertEquals("widget_used", used.getName())
+  }
+
+  @Test
+  fun `widget interacted event keeps the widget it was created with`() {
+    val event = WidgetInteractedEvent(Widget.EVENTS)
+
+    assertEquals(Widget.EVENTS, event.widget)
+  }
+}

--- a/appwidgets/detekt-baseline.xml
+++ b/appwidgets/detekt-baseline.xml
@@ -2,27 +2,9 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>ArgumentListWrapping:CombinedWidgetConfigScreen.kt$(R.dimen.home_screen_widget_corner_radius)</ID>
-    <ID>ArgumentListWrapping:CombinedWidgetConfigScreen.kt$(dimensionResource(R.dimen.home_screen_widget_corner_radius))</ID>
-    <ID>ArgumentListWrapping:CombinedWidgetConfigScreen.kt$(state.backgroundColor, RoundedCornerShape(dimensionResource(R.dimen.home_screen_widget_corner_radius)))</ID>
-    <ID>ArgumentListWrapping:TasksWidgetConfigActivity.kt$TasksWidgetConfigActivity$(R.string.you_not_logged_to_google_tasks)</ID>
-    <ID>ArgumentListWrapping:TasksWidgetConfigActivity.kt$TasksWidgetConfigActivity$(this@TasksWidgetConfigActivity, getString(R.string.you_not_logged_to_google_tasks), Toast.LENGTH_SHORT)</ID>
-    <ID>BlockCommentInitialStarAlignment:Theme.kt$/* Other default colors to override background = Color(0xFFFFFBFE), surface = Color(0xFFFFFBFE), onPrimary = Color.White, onSecondary = Color.White, onTertiary = Color.White, onBackground = Color(0xFF1C1B1F), onSurface = Color(0xFF1C1B1F), */</ID>
-    <ID>CommentWrapping:CalendarNextReceiver.kt$CalendarNextReceiver$/* dayOfMonth = */</ID>
-    <ID>CommentWrapping:CalendarNextReceiver.kt$CalendarNextReceiver$/* month = */</ID>
-    <ID>CommentWrapping:CalendarNextReceiver.kt$CalendarNextReceiver$/* year = */</ID>
-    <ID>CommentWrapping:CalendarPreviousReceiver.kt$CalendarPreviousReceiver$/* dayOfMonth = */</ID>
-    <ID>CommentWrapping:CalendarPreviousReceiver.kt$CalendarPreviousReceiver$/* month = */</ID>
-    <ID>CommentWrapping:CalendarPreviousReceiver.kt$CalendarPreviousReceiver$/* year = */</ID>
-    <ID>CommentWrapping:NoteTextDrawable.kt$NoteTextDrawable$/* end = */</ID>
-    <ID>CommentWrapping:NoteTextDrawable.kt$NoteTextDrawable$/* paint = */</ID>
-    <ID>CommentWrapping:NoteTextDrawable.kt$NoteTextDrawable$/* source = */</ID>
-    <ID>CommentWrapping:NoteTextDrawable.kt$NoteTextDrawable$/* start = */</ID>
-    <ID>CommentWrapping:NoteTextDrawable.kt$NoteTextDrawable$/* width = */</ID>
     <ID>CyclomaticComplexMethod:AppWidgetActionActivity.kt$AppWidgetActionActivity$override fun onCreate(savedInstanceState: Bundle?)</ID>
     <ID>CyclomaticComplexMethod:WidgetUtils.kt$WidgetUtils$@DrawableRes fun newWidgetBg(code: Int): Int</ID>
     <ID>CyclomaticComplexMethod:WidgetUtils.kt$WidgetUtils$fun getComposeColor(code: Int): Color</ID>
-    <ID>ImportOrdering:CalendarMonthFactory.kt$import android.appwidget.AppWidgetManager import android.content.Context import android.content.Intent import android.graphics.Color import android.os.Build import android.os.Bundle import android.util.TypedValue import android.widget.RemoteViews import android.widget.RemoteViewsService import androidx.core.content.ContextCompat import com.github.naz013.appwidgets.AppWidgetActionActivity import com.github.naz013.appwidgets.AppWidgetPreferences import com.github.naz013.appwidgets.Direction import com.github.naz013.appwidgets.R import com.github.naz013.appwidgets.WidgetPrefsHolder import com.github.naz013.appwidgets.WidgetUtils import com.github.naz013.common.datetime.DateTimeManager import com.github.naz013.domain.calendar.StartDayOfWeekProtocol import com.github.naz013.logging.Logger import com.github.naz013.navigation.DeepLinkDestination import com.github.naz013.navigation.DayViewScreen import com.github.naz013.ui.common.context.dp2px import com.github.naz013.ui.common.theme.ThemeProvider import org.threeten.bp.LocalDate import org.threeten.bp.LocalDateTime import org.threeten.bp.LocalTime</ID>
     <ID>LongMethod:AppWidgetActionActivity.kt$AppWidgetActionActivity$override fun onCreate(savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:CalendarMonthFactory.kt$CalendarMonthFactory$override fun getViewAt(i: Int): RemoteViews</ID>
     <ID>LongMethod:CalendarWidget.kt$CalendarWidget.Companion$fun updateWidget( context: Context, appWidgetManager: AppWidgetManager, sp: CalendarWidgetPrefsProvider )</ID>
@@ -38,8 +20,6 @@
     <ID>LongParameterList:WidgetUtils.kt$WidgetUtils$( context: Context, rv: RemoteViews, @DrawableRes iconId: Int, @ColorRes color: Int, @IdRes viewId: Int, cls: Class&lt;*&gt;, extras: ((Intent) -&gt; Intent)? = null )</ID>
     <ID>LongParameterList:WidgetUtils.kt$WidgetUtils$( context: Context, rv: RemoteViews, @DrawableRes iconId: Int, @ColorRes color: Int, @IdRes viewId: Int, intent: Intent, requestCode: Int = RandomRequestCode.generate() )</ID>
     <ID>LongParameterList:WidgetUtils.kt$WidgetUtils$( context: Context, rv: RemoteViews, @IdRes viewId: Int, icon: Bitmap?, cls: Class&lt;*&gt;, extras: ((Intent) -&gt; Intent)? = null )</ID>
-    <ID>MaxLineLength:CombinedWidgetConfigScreen.kt$.</ID>
-    <ID>MaxLineLength:TasksWidgetConfigActivity.kt$TasksWidgetConfigActivity$Toast.makeText(this@TasksWidgetConfigActivity, getString(R.string.you_not_logged_to_google_tasks), Toast.LENGTH_SHORT).show()</ID>
     <ID>MayBeConst:NoteTextDrawable.kt$NoteTextDrawable.Companion$private val SHADE_FACTOR = 0.9f</ID>
     <ID>NestedBlockDepth:CalendarMonthFactory.kt$CalendarMonthFactory$override fun getViewAt(i: Int): RemoteViews</ID>
     <ID>SerialVersionUIDInSerializableClass:WidgetIntentProtocol.kt$Direction : Serializable</ID>
@@ -54,6 +34,5 @@
     <ID>UnusedPrivateMember:NotesWidgetConfigScreen.kt$@Preview(showBackground = true) @Composable private fun NotesWidgetConfigScreenPreview()</ID>
     <ID>UnusedPrivateMember:SingleNoteWidgetConfigScreen.kt$@Preview(showBackground = true) @Composable private fun SingleNoteWidgetConfigScreenPreview()</ID>
     <ID>UnusedPrivateMember:TasksWidgetConfigScreen.kt$@Preview(showBackground = true) @Composable private fun TasksWidgetConfigScreenPreview()</ID>
-    <ID>UnusedPrivateProperty:AppWidgetPreviewUpdaterImpl.kt$AppWidgetPreviewUpdaterImpl$private val context: Context</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/AppWidgetActionActivity.kt
+++ b/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/AppWidgetActionActivity.kt
@@ -3,6 +3,9 @@ package com.github.naz013.appwidgets
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import com.github.naz013.analytics.AnalyticsEventSender
+import com.github.naz013.analytics.Widget
+import com.github.naz013.analytics.WidgetInteractedEvent
 import com.github.naz013.common.intent.IntentKeys
 import com.github.naz013.feature.common.android.readSerializable
 import com.github.naz013.logging.Logger
@@ -16,6 +19,7 @@ import org.koin.android.ext.android.inject
 internal class AppWidgetActionActivity : LightThemedActivity() {
 
   private val navigator by inject<Navigator>()
+  private val analyticsEventSender by inject<AnalyticsEventSender>()
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -30,6 +34,9 @@ internal class AppWidgetActionActivity : LightThemedActivity() {
     if (direction == null) {
       finish()
       return
+    }
+    intent.readSerializable(WIDGET_TYPE, Widget::class.java)?.also { widget ->
+      analyticsEventSender.send(WidgetInteractedEvent(widget))
     }
     val data = intent.readSerializable(DATA, WidgetIntentProtocol::class.java)
     Logger.d("AppWidgetActionActivity", "Received data = $data")
@@ -158,6 +165,7 @@ internal class AppWidgetActionActivity : LightThemedActivity() {
 
     const val DIRECTION = "arg_direction"
     const val DATA = "arg_data"
+    const val WIDGET_TYPE = "arg_widget_type"
 
     fun createIntent(context: Context): Intent {
       return context.intentForClass(AppWidgetActionActivity::class.java)

--- a/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/AppWidgetPreviewUpdaterImpl.kt
+++ b/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/AppWidgetPreviewUpdaterImpl.kt
@@ -1,11 +1,8 @@
 package com.github.naz013.appwidgets
 
-import android.content.Context
 import com.github.naz013.logging.Logger
 
-class AppWidgetPreviewUpdaterImpl(
-  private val context: Context
-) : AppWidgetPreviewUpdater {
+class AppWidgetPreviewUpdaterImpl : AppWidgetPreviewUpdater {
 
   override suspend fun updateEventsWidgetPreview() {
     Logger.d("AppWidgetPreviewUpdater", "Updating events widget preview")

--- a/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/KoinModule.kt
+++ b/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/KoinModule.kt
@@ -33,7 +33,7 @@ val appWidgetsModule = module {
   factory { UiReminderWidgetListAdapter(get()) }
 
   factory { AppWidgetUpdaterImpl(get(), get()) as AppWidgetUpdater }
-  factory { AppWidgetPreviewUpdaterImpl(get()) as AppWidgetPreviewUpdater }
+  factory { AppWidgetPreviewUpdaterImpl() as AppWidgetPreviewUpdater }
 
   factory { RecyclableUiNoteWidgetAdapter(get(), get(), get(), get(), get()) }
   factory { UiNoteWidgetAdapter(get(), get(), get(), get(), get()) }

--- a/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/birthdays/BirthdaysFactory.kt
+++ b/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/birthdays/BirthdaysFactory.kt
@@ -9,6 +9,7 @@ import android.widget.RemoteViews
 import android.widget.RemoteViewsService
 import androidx.annotation.ColorInt
 import androidx.core.content.ContextCompat
+import com.github.naz013.analytics.Widget
 import com.github.naz013.appwidgets.AppWidgetActionActivity
 import com.github.naz013.appwidgets.Direction
 import com.github.naz013.appwidgets.R
@@ -105,6 +106,7 @@ internal class BirthdaysFactory(
     val fillInIntent = Intent()
     fillInIntent.putExtra(AppWidgetActionActivity.DATA, data)
     fillInIntent.putExtra(AppWidgetActionActivity.DIRECTION, Direction.BIRTHDAY_PREVIEW)
+    fillInIntent.putExtra(AppWidgetActionActivity.WIDGET_TYPE, Widget.BIRTHDAYS)
     rv.setOnClickFillInIntent(R.id.itemBackgroundView, fillInIntent)
     return rv
   }

--- a/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/birthdays/BirthdaysWidget.kt
+++ b/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/birthdays/BirthdaysWidget.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.widget.RemoteViews
 import androidx.core.content.ContextCompat
+import com.github.naz013.analytics.Widget
 import com.github.naz013.appwidgets.AppWidgetActionActivity
 import com.github.naz013.appwidgets.Direction
 import com.github.naz013.appwidgets.R
@@ -87,6 +88,7 @@ internal class BirthdaysWidget : AppWidgetProvider() {
     private fun createIntent(context: Context): Intent {
       return AppWidgetActionActivity.createIntent(context).apply {
         putExtra(AppWidgetActionActivity.DIRECTION, Direction.ADD_BIRTHDAY)
+        putExtra(AppWidgetActionActivity.WIDGET_TYPE, Widget.BIRTHDAYS)
       }
     }
   }

--- a/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/calendar/CalendarMonthFactory.kt
+++ b/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/calendar/CalendarMonthFactory.kt
@@ -10,6 +10,7 @@ import android.util.TypedValue
 import android.widget.RemoteViews
 import android.widget.RemoteViewsService
 import androidx.core.content.ContextCompat
+import com.github.naz013.analytics.Widget
 import com.github.naz013.appwidgets.AppWidgetActionActivity
 import com.github.naz013.appwidgets.AppWidgetPreferences
 import com.github.naz013.appwidgets.Direction
@@ -227,6 +228,7 @@ internal class CalendarMonthFactory(
 
     val fillInIntent = Intent()
     fillInIntent.putExtra(AppWidgetActionActivity.DIRECTION, Direction.HOME)
+    fillInIntent.putExtra(AppWidgetActionActivity.WIDGET_TYPE, Widget.CALENDAR)
     fillInIntent.putExtra(DeepLinkDestination.KEY, DayViewScreen(bundle))
     rv.setOnClickFillInIntent(R.id.textView, fillInIntent)
     return rv

--- a/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/calendar/CalendarMonthFactory.kt
+++ b/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/calendar/CalendarMonthFactory.kt
@@ -20,8 +20,8 @@ import com.github.naz013.appwidgets.WidgetUtils
 import com.github.naz013.common.datetime.DateTimeManager
 import com.github.naz013.domain.calendar.StartDayOfWeekProtocol
 import com.github.naz013.logging.Logger
-import com.github.naz013.navigation.DeepLinkDestination
 import com.github.naz013.navigation.DayViewScreen
+import com.github.naz013.navigation.DeepLinkDestination
 import com.github.naz013.ui.common.context.dp2px
 import com.github.naz013.ui.common.theme.ThemeProvider
 import org.threeten.bp.LocalDate

--- a/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/calendar/CalendarNextReceiver.kt
+++ b/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/calendar/CalendarNextReceiver.kt
@@ -30,12 +30,7 @@ internal class CalendarNextReceiver : BroadcastReceiver(), KoinComponent {
 
       val year = prefsProvider.getYear()
       val month = prefsProvider.getMonth() + 1
-
-      val date = LocalDate.of(
-        /* year = */ year,
-        /* month = */ month,
-        /* dayOfMonth = */ 15
-      ).plusMonths(1)
+      val date = LocalDate.of(year, month, 15).plusMonths(1)
 
       prefsProvider.setMonth(date.monthValue - 1)
       prefsProvider.setYear(date.year)

--- a/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/calendar/CalendarNextReceiver.kt
+++ b/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/calendar/CalendarNextReceiver.kt
@@ -4,6 +4,9 @@ import android.appwidget.AppWidgetManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import com.github.naz013.analytics.AnalyticsEventSender
+import com.github.naz013.analytics.Widget
+import com.github.naz013.analytics.WidgetInteractedEvent
 import com.github.naz013.appwidgets.AppWidgetUpdater
 import com.github.naz013.appwidgets.WidgetPrefsHolder
 import org.koin.core.component.KoinComponent
@@ -14,6 +17,7 @@ internal class CalendarNextReceiver : BroadcastReceiver(), KoinComponent {
 
   private val widgetPrefsHolder by inject<WidgetPrefsHolder>()
   private val appWidgetUpdater by inject<AppWidgetUpdater>()
+  private val analyticsEventSender by inject<AnalyticsEventSender>()
 
   override fun onReceive(context: Context?, intent: Intent?) {
     if (intent != null && ACTION_NEXT == intent.action && context != null) {
@@ -36,6 +40,7 @@ internal class CalendarNextReceiver : BroadcastReceiver(), KoinComponent {
       prefsProvider.setMonth(date.monthValue - 1)
       prefsProvider.setYear(date.year)
       appWidgetUpdater.updateCalendarWidget()
+      analyticsEventSender.send(WidgetInteractedEvent(Widget.CALENDAR))
     }
   }
 

--- a/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/calendar/CalendarPreviousReceiver.kt
+++ b/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/calendar/CalendarPreviousReceiver.kt
@@ -4,6 +4,9 @@ import android.appwidget.AppWidgetManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import com.github.naz013.analytics.AnalyticsEventSender
+import com.github.naz013.analytics.Widget
+import com.github.naz013.analytics.WidgetInteractedEvent
 import com.github.naz013.appwidgets.AppWidgetUpdater
 import com.github.naz013.appwidgets.WidgetPrefsHolder
 import com.github.naz013.logging.Logger
@@ -15,6 +18,7 @@ internal class CalendarPreviousReceiver : BroadcastReceiver(), KoinComponent {
 
   private val widgetPrefsHolder by inject<WidgetPrefsHolder>()
   private val appWidgetUpdater by inject<AppWidgetUpdater>()
+  private val analyticsEventSender by inject<AnalyticsEventSender>()
 
   override fun onReceive(context: Context?, intent: Intent?) {
     Logger.d(TAG, "onReceive: $intent")
@@ -38,6 +42,7 @@ internal class CalendarPreviousReceiver : BroadcastReceiver(), KoinComponent {
       prefsProvider.setMonth(date.monthValue - 1)
       prefsProvider.setYear(date.year)
       appWidgetUpdater.updateCalendarWidget()
+      analyticsEventSender.send(WidgetInteractedEvent(Widget.CALENDAR))
     }
   }
 

--- a/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/calendar/CalendarPreviousReceiver.kt
+++ b/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/calendar/CalendarPreviousReceiver.kt
@@ -32,12 +32,7 @@ internal class CalendarPreviousReceiver : BroadcastReceiver(), KoinComponent {
 
       val year = prefsProvider.getYear()
       val month = prefsProvider.getMonth() + 1
-
-      val date = LocalDate.of(
-        /* year = */ year,
-        /* month = */ month,
-        /* dayOfMonth = */ 15
-      ).minusMonths(1)
+      val date = LocalDate.of(year, month, 15).minusMonths(1)
 
       prefsProvider.setMonth(date.monthValue - 1)
       prefsProvider.setYear(date.year)

--- a/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/calendar/CalendarWidget.kt
+++ b/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/calendar/CalendarWidget.kt
@@ -9,6 +9,7 @@ import android.os.Bundle
 import android.text.format.DateUtils
 import android.widget.RemoteViews
 import androidx.core.content.ContextCompat
+import com.github.naz013.analytics.Widget
 import com.github.naz013.appwidgets.AppWidgetActionActivity
 import com.github.naz013.appwidgets.Direction
 import com.github.naz013.appwidgets.R
@@ -235,6 +236,7 @@ internal class CalendarWidget : AppWidgetProvider(), KoinComponent {
     private fun createIntent(context: Context, direction: Direction): Intent {
       return AppWidgetActionActivity.createIntent(context).apply {
         putExtra(AppWidgetActionActivity.DIRECTION, direction)
+        putExtra(AppWidgetActionActivity.WIDGET_TYPE, Widget.CALENDAR)
       }
     }
   }

--- a/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/combinedbuttons/CombinedButtonsWidget.kt
+++ b/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/combinedbuttons/CombinedButtonsWidget.kt
@@ -5,6 +5,7 @@ import android.appwidget.AppWidgetProvider
 import android.content.Context
 import android.content.Intent
 import android.widget.RemoteViews
+import com.github.naz013.analytics.Widget
 import com.github.naz013.appwidgets.AppWidgetActionActivity
 import com.github.naz013.appwidgets.Direction
 import com.github.naz013.appwidgets.R
@@ -92,6 +93,7 @@ internal class CombinedButtonsWidget : AppWidgetProvider() {
     private fun createIntent(context: Context, direction: Direction): Intent {
       return AppWidgetActionActivity.createIntent(context).apply {
         putExtra(AppWidgetActionActivity.DIRECTION, direction)
+        putExtra(AppWidgetActionActivity.WIDGET_TYPE, Widget.COMBINED)
       }
     }
   }

--- a/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/combinedbuttons/CombinedWidgetConfigScreen.kt
+++ b/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/combinedbuttons/CombinedWidgetConfigScreen.kt
@@ -33,11 +33,11 @@ import com.github.naz013.ui.common.compose.foundation.component.ColorSlider
 
 @Composable
 internal fun CombinedWidgetConfigScreen(
+  modifier: Modifier = Modifier,
   state: CombinedWidgetConfigState,
   onBackClick: () -> Unit,
   onSaveClick: () -> Unit,
   onBackgroundColorSelected: (Int) -> Unit,
-  modifier: Modifier = Modifier,
 ) {
   val hapticFeedback = LocalHapticFeedback.current
 
@@ -62,7 +62,10 @@ internal fun CombinedWidgetConfigScreen(
         modifier = Modifier
           .width(203.dp)
           .height(57.dp)
-          .background(state.backgroundColor, RoundedCornerShape(dimensionResource(R.dimen.home_screen_widget_corner_radius))),
+          .background(
+            state.backgroundColor,
+            RoundedCornerShape(dimensionResource(R.dimen.home_screen_widget_corner_radius))
+          ),
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically,
       ) {

--- a/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/compose/Theme.kt
+++ b/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/compose/Theme.kt
@@ -17,16 +17,6 @@ private val LightColorScheme = lightColorScheme(
   primary = PrimaryLight,
   secondary = SecondaryLight,
   tertiary = TertiaryLight
-
-  /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
 )
 
 @Composable

--- a/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/events/EventsGlanceAppWidget.kt
+++ b/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/events/EventsGlanceAppWidget.kt
@@ -39,6 +39,7 @@ import androidx.glance.state.GlanceStateDefinition
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
+import com.github.naz013.analytics.Widget
 import com.github.naz013.appwidgets.AppWidgetActionActivity
 import com.github.naz013.appwidgets.Direction
 import com.github.naz013.appwidgets.GlanceAppWidgetIdExtractor
@@ -69,6 +70,9 @@ internal class EventsGlanceAppWidget : GlanceAppWidget(), KoinComponent {
   )
   private val dataKey = ActionParameters.Key<WidgetIntentProtocol>(
     AppWidgetActionActivity.DATA
+  )
+  private val widgetTypeKey = ActionParameters.Key<Widget>(
+    AppWidgetActionActivity.WIDGET_TYPE
   )
 
   override val stateDefinition: GlanceStateDefinition<EventsAppWidgetState>
@@ -170,7 +174,10 @@ internal class EventsGlanceAppWidget : GlanceAppWidget(), KoinComponent {
             .clickable(
               onClick = actionStartActivity(
                 intent = viewIntent,
-                parameters = actionParametersOf(directionKey to Direction.ADD_REMINDER)
+                parameters = actionParametersOf(
+                  directionKey to Direction.ADD_REMINDER,
+                  widgetTypeKey to Widget.EVENTS
+                )
               )
             ),
           provider = ImageProvider(R.drawable.ic_fluent_add),
@@ -264,7 +271,8 @@ internal class EventsGlanceAppWidget : GlanceAppWidget(), KoinComponent {
             intent = viewIntent,
             parameters = actionParametersOf(
               directionKey to Direction.BIRTHDAY_PREVIEW,
-              dataKey to createData(data.uuId)
+              dataKey to createData(data.uuId),
+              widgetTypeKey to Widget.EVENTS
             )
           )
         ),
@@ -322,7 +330,8 @@ internal class EventsGlanceAppWidget : GlanceAppWidget(), KoinComponent {
             intent = viewIntent,
             parameters = actionParametersOf(
               directionKey to Direction.REMINDER_PREVIEW,
-              dataKey to createData(data.uuId)
+              dataKey to createData(data.uuId),
+              widgetTypeKey to Widget.EVENTS
             )
           )
         ),
@@ -380,7 +389,8 @@ internal class EventsGlanceAppWidget : GlanceAppWidget(), KoinComponent {
             intent = viewIntent,
             parameters = actionParametersOf(
               directionKey to Direction.REMINDER_PREVIEW,
-              dataKey to createData(data.uuId)
+              dataKey to createData(data.uuId),
+              widgetTypeKey to Widget.EVENTS
             )
           )
         ),

--- a/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/googletasks/TasksFactory.kt
+++ b/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/googletasks/TasksFactory.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.widget.RemoteViews
 import android.widget.RemoteViewsService
 import androidx.core.content.ContextCompat
+import com.github.naz013.analytics.Widget
 import com.github.naz013.appwidgets.AppWidgetActionActivity
 import com.github.naz013.appwidgets.Direction
 import com.github.naz013.appwidgets.R
@@ -132,6 +133,7 @@ internal class TasksFactory(
     val fillInIntent = Intent()
     fillInIntent.putExtra(AppWidgetActionActivity.DATA, data)
     fillInIntent.putExtra(AppWidgetActionActivity.DIRECTION, Direction.GOOGLE_TASK)
+    fillInIntent.putExtra(AppWidgetActionActivity.WIDGET_TYPE, Widget.GOOGLE_TASKS)
     rv.setOnClickFillInIntent(R.id.listItemCard, fillInIntent)
     return rv
   }

--- a/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/googletasks/TasksWidget.kt
+++ b/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/googletasks/TasksWidget.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.widget.RemoteViews
 import androidx.core.content.ContextCompat
+import com.github.naz013.analytics.Widget
 import com.github.naz013.appwidgets.AppWidgetActionActivity
 import com.github.naz013.appwidgets.Direction
 import com.github.naz013.appwidgets.R
@@ -45,6 +46,7 @@ internal class TasksWidget : AppWidgetProvider() {
         val data = WidgetIntentProtocol(mapOf())
         putExtra(AppWidgetActionActivity.DATA, data)
         putExtra(AppWidgetActionActivity.DIRECTION, Direction.GOOGLE_TASK)
+        putExtra(AppWidgetActionActivity.WIDGET_TYPE, Widget.GOOGLE_TASKS)
       }
       if (WidgetUtils.isDarkBg(headerBgColor)) {
         WidgetUtils.initButton(

--- a/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/googletasks/TasksWidgetConfigActivity.kt
+++ b/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/googletasks/TasksWidgetConfigActivity.kt
@@ -1,12 +1,12 @@
 package com.github.naz013.appwidgets.googletasks
 
-import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import com.github.naz013.appwidgets.ComposeWidgetConfigActivity
 import com.github.naz013.appwidgets.R
+import com.github.naz013.ui.common.compose.foundation.snackbar.rememberToastDispatcher
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 
@@ -17,10 +17,11 @@ internal class TasksWidgetConfigActivity : ComposeWidgetConfigActivity() {
   @Composable
   override fun ActivityContent() {
     val state by viewModel.state.collectAsState()
+    val toastDispatcher = rememberToastDispatcher()
 
     if (!state.isAuthorized) {
       LaunchedEffect(Unit) {
-        Toast.makeText(this@TasksWidgetConfigActivity, getString(R.string.you_not_logged_to_google_tasks), Toast.LENGTH_SHORT).show()
+        toastDispatcher.showToast(messageRes = R.string.you_not_logged_to_google_tasks)
         finish()
       }
       return

--- a/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/notes/NotesFactory.kt
+++ b/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/notes/NotesFactory.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.widget.RemoteViews
 import android.widget.RemoteViewsService
 import androidx.core.content.ContextCompat
+import com.github.naz013.analytics.Widget
 import com.github.naz013.appwidgets.AppWidgetActionActivity
 import com.github.naz013.appwidgets.Direction
 import com.github.naz013.appwidgets.R
@@ -106,6 +107,7 @@ internal class NotesFactory(
     val fillInIntent = Intent().apply {
       putExtra(AppWidgetActionActivity.DIRECTION, Direction.NOTE_PREVIEW)
       putExtra(AppWidgetActionActivity.DATA, data)
+      putExtra(AppWidgetActionActivity.WIDGET_TYPE, Widget.NOTES)
     }
     rv.setOnClickFillInIntent(R.id.note, fillInIntent)
     rv.setOnClickFillInIntent(R.id.noteImage, fillInIntent)

--- a/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/notes/NotesWidget.kt
+++ b/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/notes/NotesWidget.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.widget.RemoteViews
 import androidx.core.content.ContextCompat
+import com.github.naz013.analytics.Widget
 import com.github.naz013.appwidgets.AppWidgetActionActivity
 import com.github.naz013.appwidgets.Direction
 import com.github.naz013.appwidgets.R
@@ -89,6 +90,7 @@ internal class NotesWidget : AppWidgetProvider() {
     private fun createIntent(context: Context): Intent {
       return AppWidgetActionActivity.createIntent(context).apply {
         putExtra(AppWidgetActionActivity.DIRECTION, Direction.ADD_NOTE)
+        putExtra(AppWidgetActionActivity.WIDGET_TYPE, Widget.NOTES)
       }
     }
   }

--- a/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/singlenote/SingleNoteWidget.kt
+++ b/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/singlenote/SingleNoteWidget.kt
@@ -5,6 +5,7 @@ import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
 import android.content.Context
 import android.widget.RemoteViews
+import com.github.naz013.analytics.Widget
 import com.github.naz013.appwidgets.AppWidgetActionActivity
 import com.github.naz013.appwidgets.Direction
 import com.github.naz013.appwidgets.R
@@ -120,6 +121,7 @@ internal class SingleNoteWidget : AppWidgetProvider(), KoinComponent {
         val intent = AppWidgetActionActivity.createIntent(context)
         intent.putExtra(AppWidgetActionActivity.DIRECTION, Direction.NOTE_PREVIEW)
         intent.putExtra(AppWidgetActionActivity.DATA, data)
+        intent.putExtra(AppWidgetActionActivity.WIDGET_TYPE, Widget.SINGLE_NOTE)
         val pendingIntent = PendingIntentWrapper.getActivity(
           context,
           uiNoteWidget.uniqueId,

--- a/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/singlenote/drawable/NoteTextDrawable.kt
+++ b/appwidgets/src/main/kotlin/com/github/naz013/appwidgets/singlenote/drawable/NoteTextDrawable.kt
@@ -192,13 +192,7 @@ internal class NoteTextDrawable(
   private fun createStaticLayout(
     text: String,
     textWidth: Int
-  ) = StaticLayout.Builder.obtain(
-    /* source = */ text,
-    /* start = */ 0,
-    /* end = */ text.length,
-    /* paint = */ textPaint,
-    /* width = */ textWidth
-  )
+  ) = StaticLayout.Builder.obtain(text, 0, text.length, textPaint, textWidth)
     .setAlignment(Layout.Alignment.ALIGN_NORMAL)
     .setTextDirection(TextDirectionHeuristics.LOCALE)
     .setBreakStrategy(LineBreaker.BREAK_STRATEGY_BALANCED)

--- a/docs/analytics-widget-usage-dashboard.md
+++ b/docs/analytics-widget-usage-dashboard.md
@@ -1,0 +1,105 @@
+# Widget Usage Analytics — Pie Chart Dashboard
+
+## Overview
+
+The `appwidgets` module ships seven home-screen widget types (Calendar, Notes, Birthdays,
+Combined Buttons, Google Tasks, Single Note, and the Glance-based "Active reminders"/Events
+widget). This document covers the two Firebase events that let you build a GA4 pie chart of
+"which widget type is used most," and how to build that dashboard.
+
+Two events exist, answering two different questions:
+
+| Event | Fires when | Answers |
+|---|---|---|
+| `widget_used` | The widget's config screen is saved (the OS auto-launches config on every add, and it re-fires if the user reopens config later) | Which widget type do people add/configure most? |
+| `widget_interacted` | The user taps something on a widget already sitting on the home screen (a list item, an "add" button, calendar prev/next) | Which widget type do people actually *use* day to day? |
+
+Both share the same `type` parameter and the same `Widget` enum values
+(`events`, `birthdays`, `notes`, `calendar`, `combined`, `google_tasks`, `single_note`), so they
+plug into the same kind of GA4 report — just filter by event name to pick which question you're
+answering.
+
+## What was implemented
+
+| Piece | Location |
+|---|---|
+| `Event.WIDGET_INTERACTED` (`"widget_interacted"`) | [analytics/src/main/kotlin/com/github/naz013/analytics/AnalyticEvent.kt](../analytics/src/main/kotlin/com/github/naz013/analytics/AnalyticEvent.kt) |
+| `WidgetInteractedEvent(widget: Widget)` | same file — reuses `Parameter.TYPE` and the existing `Widget` enum, same pattern as `WidgetUsedEvent` |
+| `widget_used` (pre-existing, unchanged) | fired from each widget's Config ViewModel `onSaveClick`, e.g. [appwidgets/.../calendar/CalendarWidgetConfigViewModel.kt](../appwidgets/src/main/kotlin/com/github/naz013/appwidgets/calendar/CalendarWidgetConfigViewModel.kt) |
+| `widget_interacted` — classic (`RemoteViews`) widgets | [appwidgets/.../AppWidgetActionActivity.kt](../appwidgets/src/main/kotlin/com/github/naz013/appwidgets/AppWidgetActionActivity.kt) reads a new `WIDGET_TYPE` intent extra and sends the event; each widget provider/factory stamps its own `Widget` value onto the click intent (e.g. `CalendarWidget.kt`, `NotesFactory.kt`, `BirthdaysFactory.kt`, `TasksFactory.kt`, `CombinedButtonsWidget.kt`, `SingleNoteWidget.kt`) |
+| `widget_interacted` — Calendar prev/next | [appwidgets/.../calendar/CalendarNextReceiver.kt](../appwidgets/src/main/kotlin/com/github/naz013/appwidgets/calendar/CalendarNextReceiver.kt) and `CalendarPreviousReceiver.kt` send it directly, since month navigation is a `BroadcastReceiver`, not a routed activity |
+| `widget_interacted` — Events (Glance) widget | [appwidgets/.../events/EventsGlanceAppWidget.kt](../appwidgets/src/main/kotlin/com/github/naz013/appwidgets/events/EventsGlanceAppWidget.kt) passes a `widgetTypeKey` through Glance's `actionParametersOf(...)` on the add-button and item-click actions, which land back on `AppWidgetActionActivity` the same way the classic widgets do |
+
+Deliberately **not** instrumented: the settings-gear tap on any widget. That already opens the
+config screen, and saving it fires `widget_used` — counting the gear tap itself as an
+"interaction" would double up the "added/configured" signal under a different event name.
+
+Resulting Firebase events: `widget_used` and `widget_interacted`, both with param
+`type = <calendar|notes|birthdays|combined|google_tasks|single_note|events>`.
+
+## Setting up the GA4 dashboard
+
+### 1. Register a custom dimension for the `type` parameter
+
+Both widget events carry their widget name in the `type` param — the same parameter name other
+events in this app already use (`feature_used`, `preset_used`, etc.), so GA4 needs it registered
+as a custom dimension once before it can be used in reports.
+
+**Admin → Custom definitions → Create custom dimensions**
+- Dimension name: `Type` (reuse the existing one if a `type`-scoped custom dimension already
+  exists from another event — the parameter name is identical, one dimension covers all of them)
+- Scope: **Event**
+- Event parameter: `type`
+
+Registration only applies to data collected after you create it, and can take a few hours to
+start populating reports.
+
+### 2. Build the "most added" pie chart
+
+**Explore → Blank (free-form)**
+- Dimension: the `Type` custom dimension from step 1
+- Metric: `Event count`
+- Filter: `Event name exactly matches widget_used`
+- Visualization: **Pie chart**, Values = `Event count`, Breakdown = `Type`
+
+This is a breakdown of which widget type gets added/reconfigured most often.
+
+### 3. Build the "most actively used" pie chart
+
+Duplicate the tab from step 2 (or start a new one) and change the filter to
+`Event name exactly matches widget_interacted`. Same dimension, same metric, same pie chart
+visualization — this one shows which widget type people actually tap into day to day, which is
+usually the more meaningful "most used" number since it's driven by ongoing behavior rather than
+a one-time setup action.
+
+Put both pies as separate tabs in the same Exploration so they're easy to flip between and
+compare — a widget that's added a lot but rarely interacted with (or vice versa) is itself a
+useful signal.
+
+### 4. Optional: pin to a persistent dashboard
+
+GA4 Explorations aren't addable to the classic Reports "dashboard" surface directly. For a
+persistent, always-visible pie chart (rather than something you have to open Explore to view),
+connect **Looker Studio** to the GA4 property and rebuild the same two charts there using a
+GA4 connector with the same `Event name` filter and `type` dimension.
+
+### 5. Optional: BigQuery export
+
+If you need combined breakdowns GA4's Explore UI can't express (e.g. "ratio of
+`widget_interacted` to `widget_used` per type, per week" as a single trend), link the property to
+**BigQuery export** (Admin → BigQuery Links) and query `event_name IN ('widget_used',
+'widget_interacted')` directly. This also sidesteps GA4's data-thresholding on small user counts.
+
+## Extending this to a new widget type
+
+If a new widget type is added to `appwidgets` later:
+1. Add the new value to the `Widget` enum in `AnalyticEvent.kt`.
+2. Fire `WidgetUsedEvent(Widget.YOUR_WIDGET)` from its config screen's save action (mirror any
+   existing `*ConfigViewModel`).
+3. Fire `WidgetInteractedEvent(Widget.YOUR_WIDGET)` from its real click paths — if it's a classic
+   `RemoteViews` widget routing through `AppWidgetActionActivity`, just stamp
+   `AppWidgetActionActivity.WIDGET_TYPE` onto its click intents like the existing providers do;
+   no changes are needed in `AppWidgetActionActivity` itself.
+4. No GA4-side changes are needed — `type` is already a registered custom dimension, so the new
+   widget's data shows up in both pie charts automatically once you have data with its `type`
+   value.


### PR DESCRIPTION
Add widget_interacted event alongside the existing widget_used event so Google Analytics can distinguish "most added" from "most actively used" home-screen widget types. Fires from every widget's real click paths (list items, add buttons, calendar navigation) across both classic RemoteViews widgets and the Glance-based Events widget.

Also adds a GA4 dashboard runbook for building the pie chart reports.