### PR TITLE
REM-1076 - Exclude already-used builder items from the selector by biType

### DIFF
--- a/app/src/main/java/com/elementary/tasks/reminder/build/logic/BuilderItemsLogic.kt
+++ b/app/src/main/java/com/elementary/tasks/reminder/build/logic/BuilderItemsLogic.kt
@@ -38,5 +38,8 @@ class BuilderItemsLogic(
 
   fun getUsed(): List<BuilderItem<*>> = builderItemsHolder.getItems()
 
-  fun getAvailable(): List<BuilderItem<*>> = items - builderItemsHolder.getItems().toSet()
+  fun getAvailable(): List<BuilderItem<*>> {
+    val usedTypes = builderItemsHolder.getItems().map { it.biType }.toSet()
+    return items.filterNot { it.biType in usedTypes }
+  }
 }

--- a/app/src/test/java/com/elementary/tasks/reminder/build/logic/BuilderItemsLogicTest.kt
+++ b/app/src/test/java/com/elementary/tasks/reminder/build/logic/BuilderItemsLogicTest.kt
@@ -1,0 +1,83 @@
+package com.elementary.tasks.reminder.build.logic
+
+import com.elementary.tasks.BaseTest
+import com.elementary.tasks.reminder.build.DateBuilderItem
+import com.elementary.tasks.reminder.build.EmailBuilderItem
+import com.elementary.tasks.reminder.build.TimeBuilderItem
+import com.elementary.tasks.reminder.build.formatter.datetime.DateFormatter
+import com.elementary.tasks.reminder.build.formatter.datetime.TimeFormatter
+import com.github.naz013.domain.reminder.BiType
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class BuilderItemsLogicTest : BaseTest() {
+  private val builderItemsHolder = BuilderItemsHolder()
+  private lateinit var logic: BuilderItemsLogic
+
+  @Before
+  override fun setUp() {
+    super.setUp()
+    logic = BuilderItemsLogic(builderItemsHolder)
+  }
+
+  private fun dateItem(formatter: DateFormatter = DateFormatter(mockk(relaxed = true))) =
+    DateBuilderItem(title = "Date", description = null, dateFormatter = formatter)
+
+  private fun timeItem(formatter: TimeFormatter = TimeFormatter(mockk(relaxed = true))) =
+    TimeBuilderItem(title = "Time", description = null, timeFormatter = formatter)
+
+  private fun emailItem() = EmailBuilderItem(title = "Email", description = null)
+
+  @Test
+  fun `an item is available when nothing has been used`() {
+    logic.setAllAvailable(listOf(dateItem(), emailItem()))
+
+    val available = logic.getAvailable()
+
+    assertTrue(available.any { it.biType == BiType.DATE })
+    assertTrue(available.any { it.biType == BiType.EMAIL })
+  }
+
+  @Test
+  fun `a used item is excluded from available even when the pool instance is object-unequal`() {
+    // Pool item and used item share biType == DATE but are built with distinct DateFormatter
+    // instances (as happens in the app: the pool is built once in initBuilder(), while Quick
+    // Start/preset flows build their own item via a separate BiFactory call). Data-class equals()
+    // on DateBuilderItem compares the formatter by reference, so the two are never equal - this
+    // used to leave "Date" visible in the "+" dialog after it was already added.
+    val pool = dateItem()
+    val used = dateItem()
+    logic.setAllAvailable(listOf(pool, emailItem()))
+    logic.setAll(listOf(used))
+
+    val available = logic.getAvailable()
+
+    assertFalse(available.any { it.biType == BiType.DATE })
+    assertTrue(available.any { it.biType == BiType.EMAIL })
+  }
+
+  @Test
+  fun `a used item added via addNew is excluded from available`() {
+    val pool = timeItem()
+    logic.setAllAvailable(listOf(pool, emailItem()))
+
+    logic.addNew(timeItem())
+
+    val available = logic.getAvailable()
+
+    assertFalse(available.any { it.biType == BiType.TIME })
+    assertTrue(available.any { it.biType == BiType.EMAIL })
+  }
+
+  @Test
+  fun `canAdd is false once every pool item has been used`() {
+    logic.setAllAvailable(listOf(dateItem()))
+
+    logic.addNew(dateItem())
+
+    assertFalse(logic.canAdd())
+  }
+}


### PR DESCRIPTION
BuilderItemsLogic.getAvailable() diffed the item pool against the used items via data-class equals(), which compares each BuilderItem's Formatter field by reference. Quick Start templates, builder presets, and recur presets each build their own Formatter instance for a given BiType (e.g. Date/Time), so a used item never equality-matched its pool counterpart and kept showing up in the "+" selection dialog. Tapping it added a second item with the same biType, which crashed the Compose LazyColumn on the duplicate key.

Filter by biType instead, since that's the actual identity used everywhere else (LazyColumn key, "used" list, etc.).