### PR TITLE
REM-1089 - keep RecurrenceRule constructors from R8 to prevent Gson crash

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,7 +43,7 @@ The project uses a **multi-module Clean Architecture** layout. Key rules:
 - Wrap external API calls (cloud, Room) in `try/catch` and log errors via the `Logger` interface from `logging-api`.
 - Never swallow exceptions silently; always log or propagate.
 - **Persistence**: Room (SQLite). Mappings between Entity (repository) and Domain (domain) are mandatory.
-- **JSON serialization**: Never call `Gson().toJson(...)` / `fromJson(...)` on a domain (or any non-`*Json`) data class directly. Define a corresponding `*Json` data class with `@SerializedName` on every field, in the module performing the conversion, and map explicitly between it and the domain model. Unannotated Gson field reflection is not safe under R8/ProGuard shrinking — see the `@SerializedName` keep rule in `app/proguard-rules.pro` and the `RecurrenceRule$Weekly` production crash it caused.
+- **JSON serialization**: Every field Gson touches (`Gson().toJson(...)` / `fromJson(...)`) needs `@SerializedName` — unannotated Gson field reflection is not safe under R8/ProGuard shrinking (see the `@SerializedName` keep rule in `app/proguard-rules.pro`) and caused the `RecurrenceRule$Weekly` production crash. Annotate the class directly when the wire shape matches the model 1:1 (e.g. `Place`, `ShopItem`, `RecurrenceRule`'s variants); define a separate `*Json` data class in the converting module only when the wire format genuinely diverges (a sealed class flattened to `type`+`payload` columns, `LocalDateTime` as an epoch-millis string). Either way, wrap the `fromJson` call in `runCatching` with a safe fallback — a Gson parse failure must never propagate uncaught into a `List.map { it.toDomain() }` and take down an entire list load.
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,6 +43,7 @@ The project uses a **multi-module Clean Architecture** layout. Key rules:
 - Wrap external API calls (cloud, Room) in `try/catch` and log errors via the `Logger` interface from `logging-api`.
 - Never swallow exceptions silently; always log or propagate.
 - **Persistence**: Room (SQLite). Mappings between Entity (repository) and Domain (domain) are mandatory.
+- **JSON serialization**: Never call `Gson().toJson(...)` / `fromJson(...)` on a domain (or any non-`*Json`) data class directly. Define a corresponding `*Json` data class with `@SerializedName` on every field, in the module performing the conversion, and map explicitly between it and the domain model. Unannotated Gson field reflection is not safe under R8/ProGuard shrinking — see the `@SerializedName` keep rule in `app/proguard-rules.pro` and the `RecurrenceRule$Weekly` production crash it caused.
 
 ---
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -135,6 +135,13 @@
   @com.google.gson.annotations.SerializedName <fields>;
 }
 
+# RecurrenceRule's variants are (de)serialized via raw field-reflection Gson in
+# ReminderV2Mapper (no @SerializedName), so without a keep rule R8 can rewrite their
+# constructors and crash with "Failed to invoke constructor '...$Weekly()' with no args"
+# when Gson reflectively reconstructs a persisted reminder.
+-keep class com.github.naz013.domain.reminder.v2.RecurrenceRule { *; }
+-keep class com.github.naz013.domain.reminder.v2.RecurrenceRule$* { *; }
+
 -dontwarn com.oracle.svm.core.annotate.AutomaticFeature
 -dontwarn com.oracle.svm.core.annotate.Delete
 -dontwarn com.oracle.svm.core.annotate.TargetClass

--- a/app/src/main/java/com/elementary/tasks/core/os/compose/PermissionRequester.kt
+++ b/app/src/main/java/com/elementary/tasks/core/os/compose/PermissionRequester.kt
@@ -144,6 +144,9 @@ fun rememberPermissionRequesterRationale(): PermissionRequester {
   val requester = remember(activity) { PermissionRequester(activity) }
   val launcher =
     rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { results ->
+      if (results.entries.isEmpty()) {
+        return@rememberLauncherForActivityResult
+      }
       val (permission, isGranted) = results.entries.first()
       requester.onSystemResult(permission, isGranted)
     }

--- a/app/src/main/java/com/elementary/tasks/notes/preview/PreviewNoteViewModel.kt
+++ b/app/src/main/java/com/elementary/tasks/notes/preview/PreviewNoteViewModel.kt
@@ -99,7 +99,9 @@ class PreviewNoteViewModel(
       reminderV2Repository.getByNoteId(key).map {
         reminderToUiNoteAttachedReminder(it)
       }
-    _state.update { it.copy(reminders = reminders) }
+    withContext(dispatcherProvider.main()) {
+      _state.update { it.copy(reminders = reminders) }
+    }
   }
 
   fun onStatusClick() {
@@ -116,7 +118,9 @@ class PreviewNoteViewModel(
       val noteWithImages = noteRepository.getById(key)
       val note = noteWithImages?.note
       if (note == null) {
-        event.emit(ViewModelEvent.Message(textProvider.getText(R.string.notes_failed_to_update)))
+        withContext(dispatcherProvider.main()) {
+          event.emit(ViewModelEvent.Message(textProvider.getText(R.string.notes_failed_to_update)))
+        }
         return@launch
       }
 
@@ -142,7 +146,9 @@ class PreviewNoteViewModel(
   fun onDeleteConfirmed() {
     viewModelScope.launch(dispatcherProvider.default()) {
       deleteNoteUseCase(key)
-      event.emit(ViewModelEvent.MoveBack)
+      withContext(dispatcherProvider.main()) {
+        event.emit(ViewModelEvent.MoveBack)
+      }
     }
   }
 
@@ -150,11 +156,15 @@ class PreviewNoteViewModel(
     viewModelScope.launch(dispatcherProvider.default()) {
       val noteWithImages = noteRepository.getById(key) ?: return@launch
       val file = createSharedNoteFileUseCase(noteWithImages)
+
       Logger.i(TAG, "Share note file created: ${file?.absolutePath}")
-      if (file != null && file.exists() && file.canRead()) {
-        event.emit(ViewModelEvent.ShareNote(noteWithImages.getTitle(), file))
-      } else {
-        event.emit(ViewModelEvent.Message(textProvider.getText(R.string.failed_to_send_note)))
+
+      withContext(dispatcherProvider.main()) {
+        if (file != null && file.exists() && file.canRead()) {
+          event.emit(ViewModelEvent.ShareNote(noteWithImages.getTitle(), file))
+        } else {
+          event.emit(ViewModelEvent.Message(textProvider.getText(R.string.failed_to_send_note)))
+        }
       }
     }
   }

--- a/domain/src/main/kotlin/com/github/naz013/domain/reminder/v2/BuilderSchemeItemV2.kt
+++ b/domain/src/main/kotlin/com/github/naz013/domain/reminder/v2/BuilderSchemeItemV2.kt
@@ -1,6 +1,13 @@
 package com.github.naz013.domain.reminder.v2
 
+import com.google.gson.annotations.SerializedName
+
+/** Gson round-tripped directly as a Room column (see `ReminderV2BuilderSchemeConverter`), so
+ * every field needs [SerializedName] - see [RecurrenceRule] for why an unannotated field is a
+ * production-crash risk under R8. */
 data class BuilderSchemeItemV2(
+  @SerializedName("type")
   val type: Int,
+  @SerializedName("position")
   val position: Int
 )

--- a/domain/src/main/kotlin/com/github/naz013/domain/reminder/v2/NotificationSettingsResolver.kt
+++ b/domain/src/main/kotlin/com/github/naz013/domain/reminder/v2/NotificationSettingsResolver.kt
@@ -1,25 +1,48 @@
 package com.github.naz013.domain.reminder.v2
 
+import com.google.gson.annotations.SerializedName
+
 /**
  * The override shape held by [GroupV2] and [ReminderV2]: every field is nullable, where
  * `null` means "inherit from the next level down" (Reminder -> Group -> Settings).
+ *
+ * Also embedded directly in [com.github.naz013.domain.workflow.WorkflowAction.ApplyNotificationOverride]
+ * and Gson round-tripped there (see `WorkflowTriggerActionCodec`), so every field needs
+ * [SerializedName] - see [RecurrenceRule] for why an unannotated field is a production-crash risk
+ * under R8.
  */
 data class NotificationSettingsOverride(
+  @SerializedName("color")
   val color: Int? = null,
+  @SerializedName("vibrate")
   val vibrate: Boolean? = null,
+  @SerializedName("vibrationPattern")
   val vibrationPattern: List<Long>? = null,
+  @SerializedName("repeatNotification")
   val repeatNotification: Boolean? = null,
+  @SerializedName("volume")
   val volume: Int? = null,
+  @SerializedName("soundUri")
   val soundUri: String? = null,
+  @SerializedName("quietHoursFrom")
   val quietHoursFrom: String? = null,
+  @SerializedName("quietHoursTo")
   val quietHoursTo: String? = null,
+  @SerializedName("activeHours")
   val activeHours: List<Int>? = null,
+  @SerializedName("delayMinutes")
   val delayMinutes: Int? = null,
+  @SerializedName("priority")
   val priority: ReminderPriority? = null,
+  @SerializedName("category")
   val category: ReminderNotificationCategory? = null,
+  @SerializedName("bypassDoNotDisturb")
   val bypassDoNotDisturb: Boolean? = null,
+  @SerializedName("wakeScreen")
   val wakeScreen: Boolean? = null,
+  @SerializedName("lockScreenVisibility")
   val lockScreenVisibility: LockScreenVisibility? = null,
+  @SerializedName("remindBefore")
   val remindBefore: Long? = null
 )
 

--- a/domain/src/main/kotlin/com/github/naz013/domain/reminder/v2/RecurrenceRule.kt
+++ b/domain/src/main/kotlin/com/github/naz013/domain/reminder/v2/RecurrenceRule.kt
@@ -1,15 +1,22 @@
 package com.github.naz013.domain.reminder.v2
 
+import com.google.gson.annotations.SerializedName
 import org.threeten.bp.LocalDateTime
 
+/** Variants are Gson round-tripped directly (see `ReminderV2Mapper`/`files/DataConverterImpl`),
+ * so every field needs [SerializedName] - without it R8 is free to strip/rename the constructor
+ * and fields, which crashed in production (see the "Failed to invoke constructor" incident). */
 sealed class RecurrenceRule {
   data object Once : RecurrenceRule()
 
   /** Fires once after [after] millis. [repeatInterval] (raw millis, same convention as [Daily])
    * optionally repeats the timer after that; 0 (the default) means fire once and stop. */
   data class Countdown(
+    @SerializedName("after")
     val after: Long,
+    @SerializedName("repeatInterval")
     val repeatInterval: Long = 0,
+    @SerializedName("repeatLimit")
     val repeatLimit: Int = -1
   ) : RecurrenceRule()
 
@@ -18,39 +25,60 @@ sealed class RecurrenceRule {
    * raw millisecond duration - it can express sub-day granularity (seconds/minutes/hours), not
    * just whole days, matching how V1's plain by-date repeat picker stores its value. */
   data class Daily(
+    @SerializedName("repeatInterval")
     val repeatInterval: Long = 1,
+    @SerializedName("repeatLimit")
     val repeatLimit: Int = -1,
+    @SerializedName("until")
     val until: LocalDateTime? = null
   ) : RecurrenceRule()
 
   data class Weekly(
+    @SerializedName("weekdays")
     val weekdays: List<Int>,
+    @SerializedName("repeatInterval")
     val repeatInterval: Long = 1,
+    @SerializedName("repeatLimit")
     val repeatLimit: Int = -1,
+    @SerializedName("until")
     val until: LocalDateTime? = null
   ) : RecurrenceRule()
 
   data class Monthly(
+    @SerializedName("dayOfMonth")
     val dayOfMonth: Int,
+    @SerializedName("repeatInterval")
     val repeatInterval: Long = 1,
+    @SerializedName("repeatLimit")
     val repeatLimit: Int = -1,
+    @SerializedName("until")
     val until: LocalDateTime? = null
   ) : RecurrenceRule()
 
   /** e.g. "every 2nd Tuesday of the month". [weekday] follows the app's 0=Sunday..6=Saturday convention. */
   data class RelativeMonthly(
+    @SerializedName("weekday")
     val weekday: Int,
+    @SerializedName("ordinal")
     val ordinal: Int,
+    @SerializedName("repeatInterval")
     val repeatInterval: Long = 1,
+    @SerializedName("repeatLimit")
     val repeatLimit: Int = -1,
+    @SerializedName("until")
     val until: LocalDateTime? = null
   ) : RecurrenceRule()
 
   data class Yearly(
+    @SerializedName("dayOfMonth")
     val dayOfMonth: Int,
+    @SerializedName("monthOfYear")
     val monthOfYear: Int,
+    @SerializedName("repeatInterval")
     val repeatInterval: Long = 1,
+    @SerializedName("repeatLimit")
     val repeatLimit: Int = -1,
+    @SerializedName("until")
     val until: LocalDateTime? = null
   ) : RecurrenceRule()
 
@@ -60,6 +88,7 @@ sealed class RecurrenceRule {
 
   /** Escape hatch for anything the structured cases above don't model, e.g. BYSETPOS/BYWEEKNO combinations. */
   data class ICalendar(
+    @SerializedName("rrule")
     val rrule: String
   ) : RecurrenceRule()
 }

--- a/domain/src/main/kotlin/com/github/naz013/domain/reminder/v2/ShopItemV2.kt
+++ b/domain/src/main/kotlin/com/github/naz013/domain/reminder/v2/ShopItemV2.kt
@@ -1,12 +1,21 @@
 package com.github.naz013.domain.reminder.v2
 
+import com.google.gson.annotations.SerializedName
 import org.threeten.bp.LocalDateTime
 import java.util.UUID
 
+/** Gson round-tripped directly as a Room column (see `ReminderV2ShopItemsConverter`), so every
+ * field needs [SerializedName] - see [RecurrenceRule] for why an unannotated field is a
+ * production-crash risk under R8. */
 data class ShopItemV2(
+  @SerializedName("uuId")
   val uuId: String = UUID.randomUUID().toString(),
+  @SerializedName("summary")
   val summary: String = "",
+  @SerializedName("isChecked")
   val isChecked: Boolean = false,
+  @SerializedName("isDeleted")
   val isDeleted: Boolean = false,
+  @SerializedName("createdAt")
   val createdAt: LocalDateTime
 )

--- a/domain/src/main/kotlin/com/github/naz013/domain/workflow/WorkflowAction.kt
+++ b/domain/src/main/kotlin/com/github/naz013/domain/workflow/WorkflowAction.kt
@@ -1,7 +1,11 @@
 package com.github.naz013.domain.workflow
 
 import com.github.naz013.domain.reminder.v2.NotificationSettingsOverride
+import com.google.gson.annotations.SerializedName
 
+/** Variants with a payload are Gson round-tripped directly (see `WorkflowTriggerActionCodec`), so
+ * every field needs [SerializedName] - see [com.github.naz013.domain.reminder.v2.RecurrenceRule]
+ * for why an unannotated field is a production-crash risk under R8. */
 sealed class WorkflowAction {
   /** Powers the auto-archive workflow. */
   data object ArchiveReminder : WorkflowAction()
@@ -9,16 +13,19 @@ sealed class WorkflowAction {
   data object CompleteReminder : WorkflowAction()
 
   data class ApplyNotificationOverride(
+    @SerializedName("override")
     val override: NotificationSettingsOverride
   ) : WorkflowAction()
 
   /** Chained/dependent reminders: activates another reminder by id. */
   data class ActivateReminder(
+    @SerializedName("reminderId")
     val reminderId: String
   ) : WorkflowAction()
 
   /** Escape hatch mirroring ResolvedEventAction's open-endedness: runs an existing BackgroundTask. */
   data class RunBackgroundTask(
+    @SerializedName("taskKey")
     val taskKey: String
   ) : WorkflowAction()
 }

--- a/domain/src/main/kotlin/com/github/naz013/domain/workflow/WorkflowCondition.kt
+++ b/domain/src/main/kotlin/com/github/naz013/domain/workflow/WorkflowCondition.kt
@@ -1,20 +1,28 @@
 package com.github.naz013.domain.workflow
 
 import com.github.naz013.domain.reminder.v2.ReminderPriority
+import com.google.gson.annotations.SerializedName
 
 /** An extra, optional filter narrowing when a [WorkflowRule]'s trigger actually fires its action.
  * All of a rule's conditions must hold (AND-chain) - a minimal, extensible v1 vocabulary, not a
- * full boolean-expression system. */
+ * full boolean-expression system.
+ *
+ * Variants are Gson round-tripped directly (see `WorkflowTriggerActionCodec`), so every field
+ * needs [SerializedName] - see [com.github.naz013.domain.reminder.v2.RecurrenceRule] for why an
+ * unannotated field is a production-crash risk under R8. */
 sealed class WorkflowCondition {
   /** Matches when the reminder's resolved priority is [priority] or higher. */
   data class PriorityAtLeast(
+    @SerializedName("priority")
     val priority: ReminderPriority
   ) : WorkflowCondition()
 
   /** Matches when the current time of day falls in `[fromMinuteOfDay, toMinuteOfDay)`
    * (0..1439 each), wrapping past midnight if `fromMinuteOfDay > toMinuteOfDay`. */
   data class WithinTimeWindow(
+    @SerializedName("fromMinuteOfDay")
     val fromMinuteOfDay: Int,
+    @SerializedName("toMinuteOfDay")
     val toMinuteOfDay: Int
   ) : WorkflowCondition()
 
@@ -23,6 +31,7 @@ sealed class WorkflowCondition {
    * filter on a rule managed elsewhere (e.g. a Global rule that should only ever fire for one
    * particular group). */
   data class GroupIs(
+    @SerializedName("groupId")
     val groupId: String
   ) : WorkflowCondition()
 }

--- a/domain/src/main/kotlin/com/github/naz013/domain/workflow/WorkflowTrigger.kt
+++ b/domain/src/main/kotlin/com/github/naz013/domain/workflow/WorkflowTrigger.kt
@@ -1,9 +1,15 @@
 package com.github.naz013.domain.workflow
 
+import com.google.gson.annotations.SerializedName
+
+/** Variants with a payload are Gson round-tripped directly (see `WorkflowTriggerActionCodec`), so
+ * every field needs [SerializedName] - see [com.github.naz013.domain.reminder.v2.RecurrenceRule]
+ * for why an unannotated field is a production-crash risk under R8. */
 sealed class WorkflowTrigger {
   data object ReminderCompleted : WorkflowTrigger()
 
   data class ReminderSnoozedNTimes(
+    @SerializedName("count")
     val count: Int
   ) : WorkflowTrigger()
 
@@ -15,10 +21,12 @@ sealed class WorkflowTrigger {
 
   /** Powers the auto-archive workflow: fires for completed reminders older than [days]. */
   data class ReminderAgeExceeded(
+    @SerializedName("days")
     val days: Int
   ) : WorkflowTrigger()
 
   data class ReminderUnacknowledgedFor(
+    @SerializedName("minutes")
     val minutes: Int
   ) : WorkflowTrigger()
 }

--- a/files/src/main/kotlin/com/github/naz013/files/DataConverterImpl.kt
+++ b/files/src/main/kotlin/com/github/naz013/files/DataConverterImpl.kt
@@ -253,18 +253,31 @@ private fun ShopItemV2Json.toDomain(): ShopItemV2 = ShopItemV2(
   createdAt = LocalDateTime.parse(createdAt, jsonDateTimeFormatter)
 )
 
-private fun toRecurrenceRule(type: String, payload: String): RecurrenceRule = when (type) {
-  "ONCE" -> RecurrenceRule.Once
-  "COUNTDOWN" -> recurrenceGson.fromJson(payload, RecurrenceRule.Countdown::class.java)
-  "DAILY" -> recurrenceGson.fromJson(payload, RecurrenceRule.Daily::class.java)
-  "WEEKLY" -> recurrenceGson.fromJson(payload, RecurrenceRule.Weekly::class.java)
-  "MONTHLY" -> recurrenceGson.fromJson(payload, RecurrenceRule.Monthly::class.java)
-  "RELATIVE_MONTHLY" -> recurrenceGson.fromJson(payload, RecurrenceRule.RelativeMonthly::class.java)
-  "YEARLY" -> recurrenceGson.fromJson(payload, RecurrenceRule.Yearly::class.java)
-  "LOCATION_ENTER" -> RecurrenceRule.LocationEnter
-  "LOCATION_EXIT" -> RecurrenceRule.LocationExit
-  "ICALENDAR" -> recurrenceGson.fromJson(payload, RecurrenceRule.ICalendar::class.java)
-  else -> RecurrenceRule.Once
+/** Falls back to [RecurrenceRule.Once] (and logs) instead of throwing on a payload it can't
+ * parse — e.g. a backup file written before [RecurrenceRule]'s fields were `@SerializedName`
+ * protected — so one unreadable reminder doesn't fail the whole backup restore. Mirrors
+ * `ReminderV2Mapper.toRecurrenceRule` in the `repository` module. */
+private fun toRecurrenceRule(type: String, payload: String): RecurrenceRule = runCatching {
+  when (type) {
+    "ONCE" -> RecurrenceRule.Once
+    "COUNTDOWN" -> recurrenceGson.fromJson(payload, RecurrenceRule.Countdown::class.java)
+    "DAILY" -> recurrenceGson.fromJson(payload, RecurrenceRule.Daily::class.java)
+    "WEEKLY" -> recurrenceGson.fromJson(payload, RecurrenceRule.Weekly::class.java).also {
+      requireNotNull(it.weekdays) { "weekdays is null" }
+    }
+    "MONTHLY" -> recurrenceGson.fromJson(payload, RecurrenceRule.Monthly::class.java)
+    "RELATIVE_MONTHLY" -> recurrenceGson.fromJson(payload, RecurrenceRule.RelativeMonthly::class.java)
+    "YEARLY" -> recurrenceGson.fromJson(payload, RecurrenceRule.Yearly::class.java)
+    "LOCATION_ENTER" -> RecurrenceRule.LocationEnter
+    "LOCATION_EXIT" -> RecurrenceRule.LocationExit
+    "ICALENDAR" -> recurrenceGson.fromJson(payload, RecurrenceRule.ICalendar::class.java).also {
+      requireNotNull(it.rrule) { "rrule is null" }
+    }
+    else -> RecurrenceRule.Once
+  }
+}.getOrElse { e ->
+  Logger.e(FILES_TAG, "Failed to parse recurrence rule, type=$type, payload=$payload", e)
+  RecurrenceRule.Once
 }
 
 private fun toReminderAction(type: String, target: String, subject: String): ReminderAction =
@@ -281,6 +294,7 @@ private fun toReminderAction(type: String, target: String, subject: String): Rem
 
 private val jsonDateTimeFormatter: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
 private val recurrenceGson = Gson()
+private const val FILES_TAG = "DataConverter"
 
 private fun GroupV2.toJson(): GroupV2Json {
   return GroupV2Json(

--- a/repository/src/main/java/com/github/naz013/repository/entity/ReminderV2Mapper.kt
+++ b/repository/src/main/java/com/github/naz013/repository/entity/ReminderV2Mapper.kt
@@ -13,10 +13,13 @@ import com.github.naz013.domain.reminder.v2.RecurrenceRule
 import com.github.naz013.domain.reminder.v2.SyncMetadata
 import com.github.naz013.domain.reminder.v2.TaskExportSettings
 import com.github.naz013.domain.sync.SyncState
+import com.github.naz013.logging.Logger
 import com.google.gson.Gson
 import org.threeten.bp.Instant
 import org.threeten.bp.LocalDateTime
 import org.threeten.bp.ZoneOffset
+
+private const val TAG = "ReminderV2Mapper"
 
 private val gson = Gson()
 
@@ -183,18 +186,30 @@ private fun RecurrenceRule.toColumns(): Pair<String, String> = when (this) {
   is RecurrenceRule.ICalendar -> "ICALENDAR" to gson.toJson(this)
 }
 
-private fun toRecurrenceRule(type: String, payload: String): RecurrenceRule = when (type) {
-  "ONCE" -> RecurrenceRule.Once
-  "COUNTDOWN" -> gson.fromJson(payload, RecurrenceRule.Countdown::class.java)
-  "DAILY" -> gson.fromJson(payload, RecurrenceRule.Daily::class.java)
-  "WEEKLY" -> gson.fromJson(payload, RecurrenceRule.Weekly::class.java)
-  "MONTHLY" -> gson.fromJson(payload, RecurrenceRule.Monthly::class.java)
-  "RELATIVE_MONTHLY" -> gson.fromJson(payload, RecurrenceRule.RelativeMonthly::class.java)
-  "YEARLY" -> gson.fromJson(payload, RecurrenceRule.Yearly::class.java)
-  "LOCATION_ENTER" -> RecurrenceRule.LocationEnter
-  "LOCATION_EXIT" -> RecurrenceRule.LocationExit
-  "ICALENDAR" -> gson.fromJson(payload, RecurrenceRule.ICalendar::class.java)
-  else -> RecurrenceRule.Once
+/** Falls back to [RecurrenceRule.Once] (and logs) instead of throwing on a payload it can't parse,
+ * e.g. a row written before a fix to `app/proguard-rules.pro` kept Gson-reflected field names -
+ * one unreadable row must not take down the whole reminder list. */
+private fun toRecurrenceRule(type: String, payload: String): RecurrenceRule = runCatching {
+  when (type) {
+    "ONCE" -> RecurrenceRule.Once
+    "COUNTDOWN" -> gson.fromJson(payload, RecurrenceRule.Countdown::class.java)
+    "DAILY" -> gson.fromJson(payload, RecurrenceRule.Daily::class.java)
+    "WEEKLY" -> gson.fromJson(payload, RecurrenceRule.Weekly::class.java).also {
+      requireNotNull(it.weekdays) { "weekdays is null" }
+    }
+    "MONTHLY" -> gson.fromJson(payload, RecurrenceRule.Monthly::class.java)
+    "RELATIVE_MONTHLY" -> gson.fromJson(payload, RecurrenceRule.RelativeMonthly::class.java)
+    "YEARLY" -> gson.fromJson(payload, RecurrenceRule.Yearly::class.java)
+    "LOCATION_ENTER" -> RecurrenceRule.LocationEnter
+    "LOCATION_EXIT" -> RecurrenceRule.LocationExit
+    "ICALENDAR" -> gson.fromJson(payload, RecurrenceRule.ICalendar::class.java).also {
+      requireNotNull(it.rrule) { "rrule is null" }
+    }
+    else -> RecurrenceRule.Once
+  }
+}.getOrElse { e ->
+  Logger.e(TAG, "Failed to parse recurrence rule, type=$type, payload=$payload", e)
+  RecurrenceRule.Once
 }
 
 private fun ReminderAction.toColumns(): Triple<String, String, String> = when (this) {

--- a/repository/src/main/java/com/github/naz013/repository/entity/WorkflowTriggerActionCodec.kt
+++ b/repository/src/main/java/com/github/naz013/repository/entity/WorkflowTriggerActionCodec.kt
@@ -3,6 +3,7 @@ package com.github.naz013.repository.entity
 import com.github.naz013.domain.workflow.WorkflowAction
 import com.github.naz013.domain.workflow.WorkflowCondition
 import com.github.naz013.domain.workflow.WorkflowTrigger
+import com.github.naz013.logging.Logger
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 
@@ -11,6 +12,8 @@ import com.google.gson.reflect.TypeToken
  * [WorkflowTemplateMapper] — a rule and a template store the exact same trigger/action shapes.
  */
 internal val workflowGson = Gson()
+
+private const val TAG = "WorkflowTriggerActionCodec"
 
 internal fun WorkflowTrigger.toColumns(): Pair<String, String> = when (this) {
   is WorkflowTrigger.ReminderCompleted -> "REMINDER_COMPLETED" to ""
@@ -22,15 +25,22 @@ internal fun WorkflowTrigger.toColumns(): Pair<String, String> = when (this) {
   is WorkflowTrigger.ReminderUnacknowledgedFor -> "REMINDER_UNACKNOWLEDGED_FOR" to workflowGson.toJson(this)
 }
 
-internal fun toWorkflowTrigger(type: String, payload: String): WorkflowTrigger = when (type) {
-  "REMINDER_COMPLETED" -> WorkflowTrigger.ReminderCompleted
-  "REMINDER_SNOOZED_N_TIMES" -> workflowGson.fromJson(payload, WorkflowTrigger.ReminderSnoozedNTimes::class.java)
-  "GROUP_ALL_COMPLETED" -> WorkflowTrigger.GroupAllCompleted
-  "LOCATION_ENTERED" -> WorkflowTrigger.LocationEntered
-  "LOCATION_EXITED" -> WorkflowTrigger.LocationExited
-  "REMINDER_AGE_EXCEEDED" -> workflowGson.fromJson(payload, WorkflowTrigger.ReminderAgeExceeded::class.java)
-  "REMINDER_UNACKNOWLEDGED_FOR" -> workflowGson.fromJson(payload, WorkflowTrigger.ReminderUnacknowledgedFor::class.java)
-  else -> WorkflowTrigger.ReminderCompleted
+/** Falls back to [WorkflowTrigger.ReminderCompleted] (and logs) instead of throwing on a payload
+ * it can't parse — one unreadable row must not take down the whole workflow-rule list. */
+internal fun toWorkflowTrigger(type: String, payload: String): WorkflowTrigger = runCatching {
+  when (type) {
+    "REMINDER_COMPLETED" -> WorkflowTrigger.ReminderCompleted
+    "REMINDER_SNOOZED_N_TIMES" -> workflowGson.fromJson(payload, WorkflowTrigger.ReminderSnoozedNTimes::class.java)
+    "GROUP_ALL_COMPLETED" -> WorkflowTrigger.GroupAllCompleted
+    "LOCATION_ENTERED" -> WorkflowTrigger.LocationEntered
+    "LOCATION_EXITED" -> WorkflowTrigger.LocationExited
+    "REMINDER_AGE_EXCEEDED" -> workflowGson.fromJson(payload, WorkflowTrigger.ReminderAgeExceeded::class.java)
+    "REMINDER_UNACKNOWLEDGED_FOR" -> workflowGson.fromJson(payload, WorkflowTrigger.ReminderUnacknowledgedFor::class.java)
+    else -> WorkflowTrigger.ReminderCompleted
+  }
+}.getOrElse { e ->
+  Logger.e(TAG, "Failed to parse workflow trigger, type=$type, payload=$payload", e)
+  WorkflowTrigger.ReminderCompleted
 }
 
 internal fun WorkflowAction.toColumns(): Pair<String, String> = when (this) {
@@ -41,13 +51,20 @@ internal fun WorkflowAction.toColumns(): Pair<String, String> = when (this) {
   is WorkflowAction.RunBackgroundTask -> "RUN_BACKGROUND_TASK" to workflowGson.toJson(this)
 }
 
-internal fun toWorkflowAction(type: String, payload: String): WorkflowAction = when (type) {
-  "ARCHIVE_REMINDER" -> WorkflowAction.ArchiveReminder
-  "COMPLETE_REMINDER" -> WorkflowAction.CompleteReminder
-  "APPLY_NOTIFICATION_OVERRIDE" -> workflowGson.fromJson(payload, WorkflowAction.ApplyNotificationOverride::class.java)
-  "ACTIVATE_REMINDER" -> workflowGson.fromJson(payload, WorkflowAction.ActivateReminder::class.java)
-  "RUN_BACKGROUND_TASK" -> workflowGson.fromJson(payload, WorkflowAction.RunBackgroundTask::class.java)
-  else -> WorkflowAction.ArchiveReminder
+/** Falls back to [WorkflowAction.ArchiveReminder] (and logs) instead of throwing on a payload it
+ * can't parse — one unreadable row must not take down the whole workflow-rule list. */
+internal fun toWorkflowAction(type: String, payload: String): WorkflowAction = runCatching {
+  when (type) {
+    "ARCHIVE_REMINDER" -> WorkflowAction.ArchiveReminder
+    "COMPLETE_REMINDER" -> WorkflowAction.CompleteReminder
+    "APPLY_NOTIFICATION_OVERRIDE" -> workflowGson.fromJson(payload, WorkflowAction.ApplyNotificationOverride::class.java)
+    "ACTIVATE_REMINDER" -> workflowGson.fromJson(payload, WorkflowAction.ActivateReminder::class.java)
+    "RUN_BACKGROUND_TASK" -> workflowGson.fromJson(payload, WorkflowAction.RunBackgroundTask::class.java)
+    else -> WorkflowAction.ArchiveReminder
+  }
+}.getOrElse { e ->
+  Logger.e(TAG, "Failed to parse workflow action, type=$type, payload=$payload", e)
+  WorkflowAction.ArchiveReminder
 }
 
 private data class ConditionColumns(val type: String, val payload: String)
@@ -58,11 +75,18 @@ private fun WorkflowCondition.toColumns(): ConditionColumns = when (this) {
   is WorkflowCondition.GroupIs -> ConditionColumns("GROUP_IS", workflowGson.toJson(this))
 }
 
-private fun toWorkflowCondition(columns: ConditionColumns): WorkflowCondition? = when (columns.type) {
-  "PRIORITY_AT_LEAST" -> workflowGson.fromJson(columns.payload, WorkflowCondition.PriorityAtLeast::class.java)
-  "WITHIN_TIME_WINDOW" -> workflowGson.fromJson(columns.payload, WorkflowCondition.WithinTimeWindow::class.java)
-  "GROUP_IS" -> workflowGson.fromJson(columns.payload, WorkflowCondition.GroupIs::class.java)
-  else -> null
+/** Drops (and logs) a condition it can't parse, rather than throwing - one bad condition must not
+ * take down the whole rule/conditions list; [toWorkflowConditions] already filters out nulls. */
+private fun toWorkflowCondition(columns: ConditionColumns): WorkflowCondition? = runCatching {
+  when (columns.type) {
+    "PRIORITY_AT_LEAST" -> workflowGson.fromJson(columns.payload, WorkflowCondition.PriorityAtLeast::class.java)
+    "WITHIN_TIME_WINDOW" -> workflowGson.fromJson(columns.payload, WorkflowCondition.WithinTimeWindow::class.java)
+    "GROUP_IS" -> workflowGson.fromJson(columns.payload, WorkflowCondition.GroupIs::class.java)
+    else -> null
+  }
+}.getOrElse { e ->
+  Logger.e(TAG, "Failed to parse workflow condition, columns=$columns", e)
+  null
 }
 
 private val conditionColumnsListType = object : TypeToken<List<ConditionColumns>>() {}.type

--- a/repository/src/test/java/com/github/naz013/repository/entity/ReminderV2MapperTest.kt
+++ b/repository/src/test/java/com/github/naz013/repository/entity/ReminderV2MapperTest.kt
@@ -166,4 +166,52 @@ class ReminderV2MapperTest {
     assertEquals(0L, roundTripped.snoozeCount)
     assertEquals(null, roundTripped.lastShownAt)
   }
+
+  @Test
+  fun `toEntity then toDomain round trips a weekly recurrence`() {
+    val reminder = ReminderV2(
+      uuId = "id-9",
+      summary = "Standup",
+      recurrence = RecurrenceRule.Weekly(weekdays = listOf(1, 3, 5)),
+      schedule = ReminderSchedule(startDateTime = LocalDateTime.of(2026, 7, 20, 9, 0)),
+      action = ReminderAction.None
+    )
+
+    val roundTripped = reminder.toEntity().toDomain()
+
+    assertEquals(reminder, roundTripped)
+  }
+
+  @Test
+  fun `toDomain falls back to Once when a WEEKLY payload has no weekdays field`() {
+    // Simulates a row written before app-proguard-rules kept RecurrenceRule's real field
+    // names, so the persisted JSON keys ("a", "b", "c") no longer match "weekdays" etc.
+    val entity = legacyEntity(recurrenceType = "WEEKLY", recurrencePayload = """{"a":[1,3,5],"b":1,"c":-1}""")
+
+    val domain = entity.toDomain()
+
+    assertEquals(RecurrenceRule.Once, domain.recurrence)
+  }
+
+  @Test
+  fun `toDomain falls back to Once when the recurrence payload is malformed JSON`() {
+    val entity = legacyEntity(recurrenceType = "MONTHLY", recurrencePayload = "not-json")
+
+    val domain = entity.toDomain()
+
+    assertEquals(RecurrenceRule.Once, domain.recurrence)
+  }
+
+  private fun legacyEntity(recurrenceType: String, recurrencePayload: String) = ReminderV2Entity(
+    uuId = "id-legacy",
+    recurrenceType = recurrenceType,
+    recurrencePayload = recurrencePayload,
+    schedule = ReminderScheduleColumns(startDateTime = 0L),
+    notification = NotificationSettingsOverrideColumns(),
+    calendarExport = null,
+    taskExport = null,
+    location = null,
+    actionType = "NONE",
+    syncState = SyncState.Synced.name
+  )
 }

--- a/repository/src/test/java/com/github/naz013/repository/entity/WorkflowRuleMapperTest.kt
+++ b/repository/src/test/java/com/github/naz013/repository/entity/WorkflowRuleMapperTest.kt
@@ -104,4 +104,52 @@ class WorkflowRuleMapperTest {
     assertEquals(rule, roundTripped)
     assertEquals(emptyList<WorkflowCondition>(), roundTripped.conditions)
   }
+
+  @Test
+  fun `toDomain falls back to ReminderCompleted when the trigger payload is malformed`() {
+    val entity = legacyEntity(triggerType = "REMINDER_AGE_EXCEEDED", triggerPayload = "not-json")
+
+    val trigger = entity.toDomain().trigger
+
+    assertEquals(WorkflowTrigger.ReminderCompleted, trigger)
+  }
+
+  @Test
+  fun `toDomain falls back to ArchiveReminder when the action payload is malformed`() {
+    val entity = legacyEntity(actionType = "ACTIVATE_REMINDER", actionPayload = "not-json")
+
+    val action = entity.toDomain().action
+
+    assertEquals(WorkflowAction.ArchiveReminder, action)
+  }
+
+  @Test
+  fun `toDomain drops a condition it can't parse instead of failing the whole list`() {
+    val entity = legacyEntity(
+      conditionsPayload = """[{"type":"WITHIN_TIME_WINDOW","payload":"not-json"},""" +
+        """{"type":"GROUP_IS","payload":"{\"groupId\":\"group-1\"}"}]"""
+    )
+
+    val conditions = entity.toDomain().conditions
+
+    assertEquals(listOf(WorkflowCondition.GroupIs(groupId = "group-1")), conditions)
+  }
+
+  private fun legacyEntity(
+    triggerType: String = "REMINDER_COMPLETED",
+    triggerPayload: String = "",
+    actionType: String = "ARCHIVE_REMINDER",
+    actionPayload: String = "",
+    conditionsPayload: String = "[]"
+  ) = WorkflowRuleEntity(
+    uuId = "rule-legacy",
+    scopeType = "GLOBAL",
+    triggerType = triggerType,
+    triggerPayload = triggerPayload,
+    conditionsPayload = conditionsPayload,
+    actionType = actionType,
+    actionPayload = actionPayload,
+    createdAt = 0L,
+    syncState = SyncState.Synced.name
+  )
 }

--- a/rules and agents.md
+++ b/rules and agents.md
@@ -18,12 +18,22 @@
 - **State**: MVVM with `StateFlow` / `LiveData`.
 - **Log**: Use `logging-api` (`Logger` interface) to avoid concrete coupling.
 - **Persistence**: Room (SQLite). Mappings between Entity and Domain are mandatory.
-- **JSON**: Never `Gson().toJson(...)` / `fromJson(...)` a domain (or any non-`*Json`) data class
-  directly. Define a corresponding `*Json` data class, with `@SerializedName` on every field, in the
-  module doing the conversion, and map explicitly between it and the domain model. Gson field
-  reflection without `@SerializedName` is not safe under R8/ProGuard shrinking (see the
-  `@SerializedName` keep rule in `app/proguard-rules.pro`) - it caused a production crash
-  (`RecurrenceRule$Weekly` constructor stripped by R8).
+- **JSON**: Every field Gson touches (`Gson().toJson(...)` / `fromJson(...)`, directly or via
+  `TypeToken`) needs `@SerializedName` - unannotated Gson field reflection is not safe under
+  R8/ProGuard shrinking (see the `@SerializedName` keep rule in `app/proguard-rules.pro`) - it
+  caused a production crash (`RecurrenceRule$Weekly` constructor stripped by R8). Two ways to get
+  there, pick based on whether the wire shape matches the model:
+  - **Annotate the class directly** when the JSON shape is just the model's own fields (e.g.
+    `Place`, `ShopItem`, `BuilderSchemeItem`, `GoogleTaskList`, `RecurrenceRule`'s variants,
+    `WorkflowTrigger`/`WorkflowAction`/`WorkflowCondition`). Simplest; no translation layer needed.
+  - **Define a `*Json` data class** in the module doing the conversion when the wire format
+    genuinely diverges from the domain shape (e.g. a sealed class flattened to `type`+`payload`
+    columns, `LocalDateTime` written as an epoch-millis string) - see `files/model/*Json.kt` and
+    `repository/entity/*Columns` for the pattern.
+  - Whichever you pick, a Gson-reflected type getting `fromJson`'d is never allowed to throw
+    uncaught into a `List.map { it.toDomain() }` - wrap the parse in `runCatching` with a safe
+    fallback (see `ReminderV2Mapper.toRecurrenceRule`), so one bad row can't take down an entire
+    list load.
 
 ## Dependency Rules
 - Arrows: `A -> B` (A depends on B).

--- a/rules and agents.md
+++ b/rules and agents.md
@@ -18,6 +18,12 @@
 - **State**: MVVM with `StateFlow` / `LiveData`.
 - **Log**: Use `logging-api` (`Logger` interface) to avoid concrete coupling.
 - **Persistence**: Room (SQLite). Mappings between Entity and Domain are mandatory.
+- **JSON**: Never `Gson().toJson(...)` / `fromJson(...)` a domain (or any non-`*Json`) data class
+  directly. Define a corresponding `*Json` data class, with `@SerializedName` on every field, in the
+  module doing the conversion, and map explicitly between it and the domain model. Gson field
+  reflection without `@SerializedName` is not safe under R8/ProGuard shrinking (see the
+  `@SerializedName` keep rule in `app/proguard-rules.pro`) - it caused a production crash
+  (`RecurrenceRule$Weekly` constructor stripped by R8).
 
 ## Dependency Rules
 - Arrows: `A -> B` (A depends on B).


### PR DESCRIPTION
ReminderV2Mapper serializes RecurrenceRule's variants (Weekly, Daily, Monthly, ...) via raw field-reflection Gson with no @SerializedName, so R8 had no reason to preserve their real constructors. In release builds this let R8 synthesize a bogus no-arg constructor, which Gson found and invoked instead of the real one, crashing with "Failed to invoke constructor '...\$Weekly()' with no args" when reconstructing a persisted reminder's recurrence rule.