### PR TITLE
REM-1136 - Fix guard exact-alarm scheduling against denied permission and Secur…

### DIFF
--- a/app/src/main/java/com/elementary/tasks/core/services/JobScheduler.kt
+++ b/app/src/main/java/com/elementary/tasks/core/services/JobScheduler.kt
@@ -4,6 +4,7 @@ import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import com.elementary.tasks.core.services.alarm.AlarmReceiver
 import com.elementary.tasks.core.services.event.AutoBackupEventTask
@@ -254,11 +255,30 @@ class JobScheduler(
         flags = PendingIntent.FLAG_CANCEL_CURRENT,
         ignoreIn13 = false,
       )
-    systemServiceProvider.provideAlarmManager()?.setExactAndAllowWhileIdle(
-      AlarmManager.RTC_WAKEUP,
-      millis,
-      pendingIntent,
-    )
+    val alarmManager = systemServiceProvider.provideAlarmManager()
+    if (alarmManager == null) {
+      Logger.e(TAG, "Cannot schedule alarm for action=$action: AlarmManager is unavailable")
+      return
+    }
+    try {
+      if (canScheduleExactAlarms(alarmManager)) {
+        alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, millis, pendingIntent)
+      } else {
+        Logger.w(TAG, "Exact alarms are not permitted, scheduling an inexact alarm for action=$action instead")
+        alarmManager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, millis, pendingIntent)
+      }
+    } catch (e: SecurityException) {
+      Logger.e(TAG, "Failed to schedule exact alarm for action=$action, falling back to an inexact alarm", e)
+      alarmManager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, millis, pendingIntent)
+    }
+  }
+
+  private fun canScheduleExactAlarms(alarmManager: AlarmManager): Boolean {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      alarmManager.canScheduleExactAlarms()
+    } else {
+      true
+    }
   }
 
   private fun cancelReminder(uuId: String) {


### PR DESCRIPTION
…ityException

Reminders were saved as active before the underlying AlarmManager alarm was scheduled, and setExactAndAllowWhileIdle() had no permission check or error handling. On Android 12+, if exact-alarm scheduling is denied, this throws an uncaught SecurityException, leaving the reminder marked active/scheduled in the DB while no OS alarm was ever registered, so it silently never fires.

Now checks canScheduleExactAlarms() and falls back to an inexact alarm instead, and catches SecurityException as a safety net, so a reminder always gets some alarm scheduled rather than silently dropping.