### PR TITLE
REM-1140 - Add more reminder e2e tests for recurrence edge cases and editing

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -160,6 +160,13 @@ jobs:
     # first batch - see docs/e2e-testing.md #6) - triggered by the `schedule` entry above.
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
+    # Job-level permissions replace the workflow-level default entirely for this job, so every
+    # permission it needs (checks:write for the JUnit report, issues:write for the
+    # open-on-failure/close-on-recovery steps below) has to be listed here explicitly.
+    permissions:
+      contents: read
+      checks: write
+      issues: write
     steps:
 
     - name: Clone repo
@@ -224,3 +231,112 @@ jobs:
         name: maestro-failure-34
         path: ~/.maestro/tests/
         retention-days: 14
+
+    # The two steps below keep a single persistent issue (labeled e2e-nightly-failure) as the
+    # nightly e2e status: opened/reopened with a new comment each time this job fails, closed with
+    # a comment the first time it goes green again. This surfaces "did last night's merge break
+    # e2e" without anyone having to go trawl the Actions run history for the first red run.
+    - name: Open or update nightly e2e failure issue
+      if: failure()
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const label = 'e2e-nightly-failure';
+          const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+          try {
+            await github.rest.issues.createLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: label,
+              color: 'd73a4a',
+              description: 'Nightly e2e (test_e2e) run failed on master',
+            });
+          } catch (error) {
+            if (error.status !== 422) throw error; // 422 = label already exists
+          }
+
+          const lastGoodRuns = await github.rest.actions.listWorkflowRuns({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: 'build_and_test.yml',
+            event: 'schedule',
+            status: 'success',
+            per_page: 1,
+          });
+          const lastGoodSha = lastGoodRuns.data.workflow_runs[0]?.head_sha;
+          const compareLine = lastGoodSha
+            ? `Commits since the last green nightly run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/compare/${lastGoodSha}...${context.sha}`
+            : '(No previous successful nightly run found to compare against.)';
+
+          const body = [
+            `Nightly e2e run failed: ${runUrl}`,
+            `Commit: ${context.sha}`,
+            compareLine,
+          ].join('\n\n');
+
+          const existing = await github.rest.issues.listForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: label,
+            state: 'all',
+            per_page: 1,
+          });
+
+          if (existing.data.length > 0) {
+            const issue = existing.data[0];
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body,
+            });
+            if (issue.state === 'closed') {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'open',
+              });
+            }
+          } else {
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Nightly e2e tests are failing',
+              labels: [label],
+              body,
+            });
+          }
+
+    - name: Close nightly e2e failure issue if recovered
+      if: success()
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const label = 'e2e-nightly-failure';
+          const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+          const open = await github.rest.issues.listForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: label,
+            state: 'open',
+            per_page: 1,
+          });
+
+          if (open.data.length > 0) {
+            const issue = open.data[0];
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: `Nightly e2e run passed again: ${runUrl}`,
+            });
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              state: 'closed',
+            });
+          }

--- a/.maestro/notifications/flows/create_countdown_reminder.yaml
+++ b/.maestro/notifications/flows/create_countdown_reminder.yaml
@@ -10,9 +10,15 @@ appId: com.cray.software.justreminderpro
 # Sets the reminder's priority via the Priority builder item so D2/D3/D4 can exercise the
 # quiet-hours priority threshold (see DoNotDisturbManager.applyDoNotDisturb).
 #
-# Params (pass via `runFlow: { file: ..., env: { PRIORITY_LABEL: ... } }`):
+# Params (pass via `runFlow: { file: ..., env: { PRIORITY_LABEL: ..., SUMMARY: ... } }`):
 #   PRIORITY_LABEL - one of "Lowest" / "Low" / "Normal" / "High" / "Highest"
 #     (see PriorityValueEditor / @array/priorities).
+#   SUMMARY - free text set as the reminder's Summary builder item. `ReminderNotificationHandler.
+#     contentTitle` renders this verbatim as the fired notification's title (`contentText` is
+#     always just the app name - see that class), so callers assert on this exact string in the
+#     shade afterward instead of the app-name text every reminder's notification would show
+#     regardless of which one actually fired - that only proved *a* notification appeared, not
+#     that it was *this* one.
 #
 # UI flow grounded in feature/feature-reminder/.../build/BuildReminderNavGraph.kt (FAB -> add-item
 # selector -> value editor sheet, editing commits live so closing the sheet is enough - see
@@ -82,6 +88,22 @@ appId: com.cray.software.justreminderpro
     commands:
       - tapOn: "^High$"
 - tapOn: "^${PRIORITY_LABEL}$"
+- tapOn:
+    point: "90%, 16%"
+# Confirmed live (real device, API 30): `below: "What you want to remind you"` correctly focuses
+# the empty Summary field (which has no placeholder/label of its own to tap by text - see
+# TextInputValueEditor.kt) by targeting whatever's directly below that item's description text,
+# which ValueEditorSheet renders as a subtitle right above the field's editor content for every
+# item type.
+- tapOn: "Add"
+- tapOn: "Search parameters…"
+- inputText: "Summary"
+- hideKeyboard
+- tapOn: "What you want to remind you"
+- tapOn:
+    below: "What you want to remind you"
+- inputText: "${SUMMARY}"
+- hideKeyboard
 - tapOn:
     point: "90%, 16%"
 - tapOn: "Save"

--- a/.maestro/notifications/notification_permission_denied.yaml
+++ b/.maestro/notifications/notification_permission_denied.yaml
@@ -1,0 +1,49 @@
+appId: com.cray.software.justreminderpro
+tags:
+  - notifications
+---
+# D7: POST_NOTIFICATIONS permission denied (Android 13+) -> app doesn't crash, the reminder isn't
+# saved (BuildReminderViewModel.saveReminder's PermissionValidator.Result.Failure branch emits
+# AskPermissions and returns *without* calling saveAndStartReminder - confirmed by reading that
+# method, not live), and no notification is ever posted for it as a result.
+#
+# Unlike every other flow in this directory, this one deliberately does NOT pass
+# `permissions: { notifications: allow }` to launchApp, so POST_NOTIFICATIONS starts unrequested
+# (same as any real fresh install) and the real system permission dialog appears the first time
+# the app actually asks for it - mid-Save, not at launch (see BuildReminderNavGraph.kt's
+# AskPermissions handler).
+#
+# Requires API 33+ - confirmed live on a real API 30 device that this flow doesn't apply below
+# that: POST_NOTIFICATIONS doesn't exist as a runtime permission pre-33, so Save succeeds
+# immediately with no dialog at all, and `tapOn: "Don't allow"` fails with "Element not found"
+# since the app has already moved on. This matches CI's actual API 34 target, so it's exercised
+# there; it just can't be validated on an older local device.
+#
+# Confirmed live (API 34 still needed to verify the "Don't allow" step itself, but the setup up to
+# it is confirmed): the system dialog's exact "Don't allow" button text is Android's own string,
+# not this app's, and its wording/position can vary by Android version or OEM skin.
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "Accept"
+    optional: true
+- tapOn:
+    text: "Dismiss"
+    optional: true
+- runFlow:
+    file: flows/create_countdown_reminder.yaml
+    env:
+      PRIORITY_LABEL: "Normal"
+      SUMMARY: "D7 permission denied"
+- tapOn: "Don't allow"
+# Save didn't go through - still on the builder screen (its own "Save" action is still visible)
+# rather than back on Home, and the app is still responsive, not crashed.
+- assertVisible: "Save"
+- swipe:
+    start: "50%, 2%"
+    end: "50%, 75%"
+- extendedWaitUntil:
+    notVisible: "D7 permission denied"
+    timeout: 5000
+- pressKey: Back
+- pressKey: Back

--- a/.maestro/notifications/quiet_hours_disabled_fires.yaml
+++ b/.maestro/notifications/quiet_hours_disabled_fires.yaml
@@ -22,11 +22,15 @@ tags:
     file: flows/create_countdown_reminder.yaml
     env:
       PRIORITY_LABEL: "Normal"
+      SUMMARY: "D1 quiet hours disabled"
 - swipe:
     start: "50%, 2%"
     end: "50%, 75%"
+# Asserts on this reminder's own Summary text (the notification's actual title - see
+# create_countdown_reminder.yaml's SUMMARY param doc), not the app-name text every reminder's
+# notification shows regardless of which one fired - that only proved *a* notification appeared.
 - extendedWaitUntil:
-    visible: "Reminder PRO"
+    visible: "D1 quiet hours disabled"
     timeout: 90000
 # Close the shade we just opened, so a following flow in the same batch doesn't inherit it open
 # (CI always starts from a fresh emulator boot, so this only matters for local back-to-back

--- a/.maestro/notifications/quiet_hours_high_priority_fires.yaml
+++ b/.maestro/notifications/quiet_hours_high_priority_fires.yaml
@@ -27,11 +27,14 @@ tags:
     file: flows/create_countdown_reminder.yaml
     env:
       PRIORITY_LABEL: "Highest"
+      SUMMARY: "D3 high priority still fires"
 - swipe:
     start: "50%, 2%"
     end: "50%, 75%"
+# Asserts on this reminder's own Summary text (the notification's actual title), not the app-name
+# text every reminder's notification shows regardless of which one fired.
 - extendedWaitUntil:
-    visible: "Reminder PRO"
+    visible: "D3 high priority still fires"
     timeout: 90000
 # Close the shade we just opened, so a following flow in the same batch doesn't inherit it open
 # (CI always starts from a fresh emulator boot, so this only matters for local back-to-back

--- a/.maestro/notifications/quiet_hours_ignore_all_suppressed.yaml
+++ b/.maestro/notifications/quiet_hours_ignore_all_suppressed.yaml
@@ -26,11 +26,14 @@ tags:
     file: flows/create_countdown_reminder.yaml
     env:
       PRIORITY_LABEL: "Highest"
+      SUMMARY: "D4 ignore all suppressed"
 - swipe:
     start: "50%, 2%"
     end: "50%, 75%"
+# Asserts this reminder's own Summary text never shows up (not the app-name text, which a
+# different, unsuppressed notification could still show and falsely pass this assertion).
 - extendedWaitUntil:
-    notVisible: "Reminder PRO"
+    notVisible: "D4 ignore all suppressed"
     timeout: 90000
 # Close the shade we just opened, so a following flow in the same batch doesn't inherit it open
 # (CI always starts from a fresh emulator boot, so this only matters for local back-to-back

--- a/.maestro/notifications/quiet_hours_low_priority_suppressed.yaml
+++ b/.maestro/notifications/quiet_hours_low_priority_suppressed.yaml
@@ -27,11 +27,14 @@ tags:
     file: flows/create_countdown_reminder.yaml
     env:
       PRIORITY_LABEL: "Normal"
+      SUMMARY: "D2 low priority suppressed"
 - swipe:
     start: "50%, 2%"
     end: "50%, 75%"
+# Asserts this reminder's own Summary text never shows up (not the app-name text, which a
+# different, unsuppressed notification could still show and falsely pass this assertion).
 - extendedWaitUntil:
-    notVisible: "Reminder PRO"
+    notVisible: "D2 low priority suppressed"
     timeout: 90000
 # Close the shade we just opened, so a following flow in the same batch doesn't inherit it open
 # (CI always starts from a fresh emulator boot, so this only matters for local back-to-back

--- a/.maestro/notifications/tap_notification_opens_reminder.yaml
+++ b/.maestro/notifications/tap_notification_opens_reminder.yaml
@@ -1,0 +1,44 @@
+appId: com.cray.software.justreminderpro
+tags:
+  - notifications
+---
+# D9: tapping a fired notification opens the *correct* reminder, not just some screen.
+#
+# Corrects an assumption in docs/e2e-testing.md's D9 row ("opens the correct reminder preview/edit
+# screen") - reading ReminderNotificationHandler.contentPendingIntent shows the notification's
+# click target actually launches ReminderActionActivity (the Complete/Snooze action picker screen,
+# see CreateReminderActionScreenStateUseCase.kt), not a preview/edit screen. That screen does
+# render `reminder.summary` directly (confirmed by reading that file), so asserting on this
+# reminder's own unique Summary text there is still a real check that the deep link opened *this*
+# reminder specifically, not a generic/wrong one.
+#
+# Confirmed live (real device, API 30): tapping the notification's visible title text does
+# register as a tap on the whole notification row, and correctly opens ReminderActionActivity
+# showing this specific reminder's own Summary text and its "Complete" action.
+- launchApp:
+    clearState: true
+    permissions:
+      notifications: allow
+- tapOn:
+    text: "Accept"
+    optional: true
+- tapOn:
+    text: "Dismiss"
+    optional: true
+- runFlow:
+    file: flows/create_countdown_reminder.yaml
+    env:
+      PRIORITY_LABEL: "Normal"
+      SUMMARY: "D9 tap opens this reminder"
+- swipe:
+    start: "50%, 2%"
+    end: "50%, 75%"
+- extendedWaitUntil:
+    visible: "D9 tap opens this reminder"
+    timeout: 90000
+- tapOn: "D9 tap opens this reminder"
+# ReminderActionActivity's main action for a plain active reminder is "Complete" (see
+# GetReminderActionsUseCase/ReminderAction.Complete) - both assertions together confirm we landed
+# on this specific reminder's action screen, not merely that some Activity opened.
+- assertVisible: "D9 tap opens this reminder"
+- assertVisible: "Complete"

--- a/app/src/androidTest/kotlin/com/elementary/tasks/e2e/FakeNowDateTimeProvider.kt
+++ b/app/src/androidTest/kotlin/com/elementary/tasks/e2e/FakeNowDateTimeProvider.kt
@@ -1,0 +1,32 @@
+package com.elementary.tasks.e2e
+
+import com.github.naz013.datecalc.NowDateTimeProvider
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import org.threeten.bp.LocalDate
+import org.threeten.bp.LocalDateTime
+import org.threeten.bp.LocalTime
+
+/**
+ * Test double for [NowDateTimeProvider] that lets a test pin "today" to a fixed [LocalDate] so
+ * date-relative recurrence calculations (day-of-month/day-of-year rollover across leap years and
+ * short months) are deterministic instead of depending on the real device clock. Time-of-day is
+ * left as the real clock's - only the date is ever asserted on by callers of this fake.
+ */
+class FakeNowDateTimeProvider(private var date: LocalDate = LocalDate.now()) : NowDateTimeProvider {
+  fun setDate(date: LocalDate) {
+    this.date = date
+  }
+
+  override fun nowDate(): LocalDate = date
+
+  override fun nowTime(): LocalTime = LocalTime.now()
+
+  override fun nowDateTime(): LocalDateTime = LocalDateTime.of(date, LocalTime.now())
+}
+
+/** Overrides the production [NowDateTimeProvider] binding with [fakeNowDateTimeProvider]. */
+fun testDateTimeModule(fakeNowDateTimeProvider: FakeNowDateTimeProvider): Module =
+  module {
+    single<NowDateTimeProvider> { fakeNowDateTimeProvider }
+  }

--- a/app/src/androidTest/kotlin/com/elementary/tasks/e2e/ReminderRecurrenceE2ETest.kt
+++ b/app/src/androidTest/kotlin/com/elementary/tasks/e2e/ReminderRecurrenceE2ETest.kt
@@ -1096,6 +1096,45 @@ class ReminderRecurrenceE2ETest : KoinTest {
     assertEquals(note.key, created.noteId)
   }
 
+  /** A5: Countdown timer + exclusion window - the excluded hours persist onto the reminder's own
+   *  `NotificationSettingsOverride` (`TimerExclusionModifier.putInto`: `activeHours`/
+   *  `quietHoursFrom`/`quietHoursTo` - all nullable there, unlike the fully-resolved
+   *  `NotificationSettings` shape used elsewhere in this codebase), not the `RecurrenceRule`
+   *  itself.
+   *
+   *  `RecurrenceRuleCalculator.fromTimer()` doesn't read the exclusion at all - only
+   *  `COUNTDOWN_TIMER`/`REPEAT_TIME` (confirmed by reading that file). The exclusion only feeds
+   *  into `RecurrenceCalculator.findNextTimerDateTime`'s `excludedHours` param, which runs when
+   *  computing the *next* fire after a repeat, not at initial save - the same "would need to wait
+   *  for a real fire to observe" limitation A27 hit. So this verifies the configuration round-trips
+   *  correctly through the builder and repository, not that a fire actually gets skipped - matching
+   *  docs/e2e-testing.md's own guidance to keep scheduling-correctness tests at the "computed
+   *  value" level (A-section) rather than "waited for it to happen" (D-section/Maestro
+   *  territory). */
+  @Test
+  fun addingATimerExclusionWindowPersistsTheExcludedHours() {
+    val idsBefore = captureExistingReminderIds()
+    navigateToNewReminderBuilder()
+
+    addBuilderItem(r(R.string.builder_countdown))
+    pressCountdownDigits(1, 0, 0)
+    closeValueEditor()
+
+    // CountdownExclusionValueEditor defaults to "Hours" mode (multi-select 0..23 grid) for a
+    // freshly-added, untouched item - no need to tap the mode radio row explicitly.
+    addBuilderItem(r(R.string.builder_countdown_exclusion))
+    clickText("1")
+    clickText("2")
+    closeValueEditor()
+
+    tapSave()
+
+    val created = awaitNewReminder(idsBefore)
+    assertEquals(listOf(1, 2), created.notification.activeHours?.sorted())
+    assertEquals("", created.notification.quietHoursFrom)
+    assertEquals("", created.notification.quietHoursTo)
+  }
+
   companion object {
     /** Runs before the very first [BottomNavActivity] is created for this class (JUnit applies
      *  `@Rule`s - including the compose rule's activity launch - only around `@Before`/`@Test`, not

--- a/app/src/androidTest/kotlin/com/elementary/tasks/e2e/ReminderRecurrenceE2ETest.kt
+++ b/app/src/androidTest/kotlin/com/elementary/tasks/e2e/ReminderRecurrenceE2ETest.kt
@@ -10,14 +10,18 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import com.elementary.tasks.navigation.BottomNavActivity
+import com.github.naz013.datecalc.DateTimeManager
 import com.github.naz013.domain.reminder.v2.RecurrenceRule
 import com.github.naz013.domain.reminder.v2.ReminderV2
 import com.github.naz013.repository.ReminderV2Repository
 import com.github.naz013.repository.testfixtures.testRepositoryModule
 import com.github.naz013.ui.common.R
+import com.github.naz013.ui.common.compose.foundation.component.builderItemRemoveTestTag
 import java.util.Locale
+import java.util.UUID
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
@@ -27,6 +31,7 @@ import org.koin.core.context.loadKoinModules
 import org.koin.test.KoinTest
 import org.koin.test.inject
 import org.threeten.bp.LocalDate
+import org.threeten.bp.LocalDateTime
 import org.threeten.bp.format.DateTimeFormatter
 
 /**
@@ -66,6 +71,14 @@ class ReminderRecurrenceE2ETest : KoinTest {
     }
 
   private val reminderV2Repository: ReminderV2Repository by inject()
+  private val dateTimeManager: DateTimeManager by inject()
+
+  /** Resets before every test so tests that don't touch it (all but the day-of-month/day-of-year
+   *  edge cases below) see the real device date, same as before [FakeNowDateTimeProvider] existed. */
+  @Before
+  fun resetFakeClock() {
+    fakeNowDateTimeProvider.setDate(LocalDate.now())
+  }
 
   private fun r(resId: Int): String = composeRule.activity.getString(resId)
 
@@ -114,6 +127,14 @@ class ReminderRecurrenceE2ETest : KoinTest {
     composeRule.waitForIdle()
   }
 
+  /** Removes the already-added builder item row titled [title] (main builder screen, not the
+   *  item picker) via `BuilderListItemCard`'s remove button, located by its `testTag`
+   *  (`builderItemRemoveTestTag`) since the button itself carries no text/content-description. */
+  private fun removeBuilderItem(title: String) {
+    composeRule.onNodeWithTag(builderItemRemoveTestTag(title)).performClick()
+    composeRule.waitForIdle()
+  }
+
   /** Closes the current `ValueEditorSheet`. Its own close button has a null contentDescription
    *  (see `ValueEditorSheet.kt`), so back press - which `ModalBottomSheet` handles itself - is the
    *  only locator-free way to dismiss it; every editor commits live on each interaction (see
@@ -125,6 +146,17 @@ class ReminderRecurrenceE2ETest : KoinTest {
 
   private fun clickText(text: String) {
     composeRule.onNodeWithText(text, useUnmergedTree = true).performClick()
+    composeRule.waitForIdle()
+  }
+
+  /** Scrolls the current sheet's lazy list/grid (`DayOfMonthValueEditor`'s `WheelPicker` or
+   *  `DayOfYearValueEditor`'s `SelectableChipGrid`, both backed by a Lazy* layout) so that
+   *  [index] is composed and clickable - needed for any target beyond what's composed by default,
+   *  unlike e.g. day 1 or day 10 which [addBuilderItem]'s callers rely on already being visible. */
+  private fun scrollLazyListToIndex(index: Int) {
+    composeRule
+      .onNode(hasScrollToIndexAction(), useUnmergedTree = true)
+      .performScrollToIndex(index)
     composeRule.waitForIdle()
   }
 
@@ -194,6 +226,17 @@ class ReminderRecurrenceE2ETest : KoinTest {
     composeRule.waitForIdle()
   }
 
+  /** Sets `RepeatIntervalValueEditor`'s `NumberStepperField` value the same way
+   *  [setRepeatTimeSeconds] does for `RepeatTimeValueEditor` - it's the only editable text field
+   *  in this sheet. Unlike [setRepeatTimeSeconds], this value is a plain unit-less repeat count
+   *  (e.g. "every 3 months"/"every 2 years"), not a millisecond duration. */
+  private fun setRepeatIntervalValue(value: Int) {
+    composeRule
+      .onNode(hasSetTextAction(), useUnmergedTree = true)
+      .performTextReplacement(value.toString())
+    composeRule.waitForIdle()
+  }
+
   /** Drives `RepeatLimitValueEditor`'s Material 3 `Slider` via its `SetProgress` semantics action
    *  rather than a drag gesture, matching the standard way Compose UI tests set slider values. */
   private fun setRepeatLimit(value: Float) {
@@ -205,6 +248,30 @@ class ReminderRecurrenceE2ETest : KoinTest {
 
   private fun tapSave() {
     composeRule.onNodeWithText(r(R.string.save)).performClick()
+  }
+
+  /** Home -> reminder details -> builder in edit mode, the only path there is (see
+   *  [navigateToNewReminderBuilder]'s kdoc for the equivalent "no direct seam" situation for
+   *  create). [summary] must uniquely identify the target row - the home list only ever shows
+   *  today's active reminders (`GetActiveEventsForTheDayUseCase`), and its row text is exactly the
+   *  reminder's `Summary` builder item value, falling back to a shared non-unique placeholder when
+   *  absent - so every test using this helper adds a `Summary` item with a fresh [UUID] to make its
+   *  own row unambiguous, since the database isn't reset between tests. */
+  private fun navigateToEditReminderBuilder(summary: String) {
+    composeRule.waitUntil(timeoutMillis = 10_000) {
+      composeRule.onAllNodesWithText(summary).fetchSemanticsNodes().isNotEmpty()
+    }
+    composeRule.onNodeWithText(summary).performClick()
+    composeRule.waitForIdle()
+
+    val moreOptionsLabel = r(R.string.more_options)
+    composeRule.waitUntil(timeoutMillis = 10_000) {
+      composeRule.onAllNodesWithContentDescription(moreOptionsLabel).fetchSemanticsNodes().isNotEmpty()
+    }
+    composeRule.onNodeWithContentDescription(moreOptionsLabel).performClick()
+    composeRule.waitForIdle()
+    composeRule.onNodeWithText(r(R.string.edit)).performClick()
+    composeRule.waitForIdle()
   }
 
   @Test
@@ -315,6 +382,28 @@ class ReminderRecurrenceE2ETest : KoinTest {
   }
 
   @Test
+  fun savesAWeeklyReminderOnMultipleWeekdaysWithTheCorrectRecurrenceRule() {
+    val idsBefore = captureExistingReminderIds()
+    navigateToNewReminderBuilder()
+
+    addBuilderItem(r(R.string.time))
+    setTime()
+    closeValueEditor()
+
+    addBuilderItem(r(R.string.builder_days_of_week))
+    clickText(r(R.string.mon))
+    clickText(r(R.string.wed))
+    clickText(r(R.string.fri))
+    closeValueEditor()
+
+    tapSave()
+
+    val created = awaitNewReminder(idsBefore)
+    // sun, mon, tue, wed, thu, fri, sat - Mon/Wed/Fri set indices 1, 3, 5.
+    assertEquals(RecurrenceRule.Weekly(weekdays = listOf(0, 1, 0, 1, 0, 1, 0)), created.recurrence)
+  }
+
+  @Test
   fun savesAMonthlyReminderOnASingleDayOfMonthWithTheCorrectRecurrenceRule() {
     val idsBefore = captureExistingReminderIds()
     navigateToNewReminderBuilder()
@@ -333,6 +422,72 @@ class ReminderRecurrenceE2ETest : KoinTest {
 
     val created = awaitNewReminder(idsBefore)
     assertEquals(RecurrenceRule.Monthly(dayOfMonth = 1), created.recurrence)
+  }
+
+  @Test
+  fun savesAMonthlyReminderWithARepeatIntervalAndLimitWithTheCorrectRecurrenceRule() {
+    val idsBefore = captureExistingReminderIds()
+    navigateToNewReminderBuilder()
+
+    addBuilderItem(r(R.string.time))
+    setTime()
+    closeValueEditor()
+
+    addBuilderItem(r(R.string.day_of_month))
+    clickText("1")
+    closeValueEditor()
+
+    addBuilderItem(r(R.string.builder_repeat_interval))
+    setRepeatIntervalValue(3)
+    closeValueEditor()
+
+    addBuilderItem(r(R.string.repeat_limit))
+    setRepeatLimit(5f)
+    closeValueEditor()
+
+    tapSave()
+
+    val created = awaitNewReminder(idsBefore)
+    assertEquals(
+      RecurrenceRule.Monthly(dayOfMonth = 1, repeatInterval = 3, repeatLimit = 5),
+      created.recurrence,
+    )
+  }
+
+  /** Edge case: `DayOfMonthValueEditor`'s wheel only offers days 1-28 plus a "Last day" sentinel
+   *  (stored as `dayOfMonth = 0`, see that editor's kdoc) - there is no way to pick a literal 29-31
+   *  through the real UI, so it can never land on a day that doesn't exist in some months. "Last
+   *  day" is the one UI-reachable case where the *resolved* day genuinely varies by target month
+   *  (28 in a non-leap February, 31 in January, etc.), so this pins `now` via
+   *  [fakeNowDateTimeProvider] to a date whose very next month is a non-leap February, and asserts
+   *  the persisted `eventDateTime` actually lands on the 28th - not that it silently overflowed
+   *  into March or crashed. `getNextMonthDayDateTime`'s `dayOfMonth <= 0 -> lastDayOfTargetMonth`
+   *  branch (`RecurrenceCalculatorImpl.kt`) is what's under test here. */
+  @Test
+  fun savesAMonthlyReminderOnTheLastDayResolvingToTheTargetMonthsActualLastDay() {
+    fakeNowDateTimeProvider.setDate(LocalDate.of(2027, 1, 15)) // 2027 is not a leap year.
+    val idsBefore = captureExistingReminderIds()
+    navigateToNewReminderBuilder()
+
+    addBuilderItem(r(R.string.time))
+    setTime()
+    closeValueEditor()
+
+    addBuilderItem(r(R.string.day_of_month))
+    // "Last day" is the wheel's final entry (index 28: days 1-28 at indices 0-27), well past
+    // what's composed by default - has to be scrolled into view first.
+    scrollLazyListToIndex(28)
+    clickText(r(R.string.last_day))
+    closeValueEditor()
+
+    tapSave()
+
+    val created = awaitNewReminder(idsBefore)
+    assertEquals(RecurrenceRule.Monthly(dayOfMonth = 0), created.recurrence)
+    assertEquals(
+      LocalDateTime.of(2027, 2, 28, 10, 30),
+      dateTimeManager.utcToLocal(created.schedule.eventDateTime!!),
+    )
   }
 
   @Test
@@ -356,6 +511,120 @@ class ReminderRecurrenceE2ETest : KoinTest {
     assertEquals(RecurrenceRule.Yearly(dayOfMonth = 10, monthOfYear = 0), created.recurrence)
   }
 
+  @Test
+  fun savesAYearlyReminderWithARepeatIntervalAndLimitWithTheCorrectRecurrenceRule() {
+    val idsBefore = captureExistingReminderIds()
+    navigateToNewReminderBuilder()
+
+    addBuilderItem(r(R.string.time))
+    setTime()
+    closeValueEditor()
+
+    addBuilderItem(r(R.string.builder_day_of_year))
+    clickText("10")
+    closeValueEditor()
+
+    addBuilderItem(r(R.string.builder_repeat_interval))
+    setRepeatIntervalValue(2)
+    closeValueEditor()
+
+    addBuilderItem(r(R.string.repeat_limit))
+    setRepeatLimit(3f)
+    closeValueEditor()
+
+    tapSave()
+
+    val created = awaitNewReminder(idsBefore)
+    assertEquals(
+      RecurrenceRule.Yearly(dayOfMonth = 10, monthOfYear = 0, repeatInterval = 2, repeatLimit = 3),
+      created.recurrence,
+    )
+  }
+
+  /** Edge case: day-of-year 60 is Feb 29 in a leap year (`fakeNowDateTimeProvider` pins `now` to
+   *  2024, a leap year) but the *next* occurrence a year later (2025) isn't a leap year, so
+   *  `getNextYearDayDateTime`'s `dayOfMonth > lastDayOfTargetMonth -> lastDayOfTargetMonth` branch
+   *  (`RecurrenceCalculatorImpl.kt`) must fall back to Feb 28 rather than overflowing into March or
+   *  crashing - this is the scenario `docs/e2e-testing.md`'s A14 row calls out. The *stored*
+   *  `RecurrenceRule.Yearly(dayOfMonth, monthOfYear)` is fixed at 29/February regardless (that's
+   *  the recurrence rule itself, re-evaluated every year) - it's only the computed `eventDateTime`
+   *  that needs the fallback, so that's what this test asserts on. */
+  @Test
+  fun savesAYearlyReminderOnFeb29FallingBackToFeb28InANonLeapYear() {
+    fakeNowDateTimeProvider.setDate(LocalDate.of(2024, 1, 15)) // 2024 is a leap year.
+    val idsBefore = captureExistingReminderIds()
+    navigateToNewReminderBuilder()
+
+    addBuilderItem(r(R.string.time))
+    setTime()
+    closeValueEditor()
+
+    addBuilderItem(r(R.string.builder_day_of_year))
+    // Day 60 sits at grid index 59 (days 1-365 at indices 0-364) - scroll it into view first,
+    // unlike day 10 above which the grid's default viewport already covers.
+    scrollLazyListToIndex(59)
+    clickText("60")
+    closeValueEditor()
+
+    tapSave()
+
+    val created = awaitNewReminder(idsBefore)
+    assertEquals(RecurrenceRule.Yearly(dayOfMonth = 29, monthOfYear = 1), created.recurrence)
+    assertEquals(
+      LocalDateTime.of(2025, 2, 28, 10, 30),
+      dateTimeManager.utcToLocal(created.schedule.eventDateTime!!),
+    )
+  }
+
+  /** Edits an existing reminder and confirms the persisted `RecurrenceRule` actually changes,
+   *  under the same `uuId` (not a new row): removes the Date item (via `BuilderListItemCard`'s
+   *  `testTag`, see `builderItemRemoveTestTag`) and adds DaysOfWeek instead, switching Once ->
+   *  Weekly. Date and DaysOfWeek block each other (`BuilderItem.kt`'s `constraints {}`), so
+   *  removing Date first is required here, not just a nicety - Time is left in place from the
+   *  original save since `fromWeekdays` needs it too. */
+  @Test
+  fun editingAnExistingReminderChangesItsRecurrenceRule() {
+    val idsBefore = captureExistingReminderIds()
+    val uniqueSummary = UUID.randomUUID().toString()
+    navigateToNewReminderBuilder()
+
+    addBuilderItem(r(R.string.builder_summary))
+    composeRule.onNode(hasSetTextAction(), useUnmergedTree = true).performTextReplacement(uniqueSummary)
+    composeRule.waitForIdle()
+    closeValueEditor()
+
+    addBuilderItem(r(R.string.builder_date))
+    setDateToday()
+    closeValueEditor()
+
+    addBuilderItem(r(R.string.time))
+    setTime()
+    closeValueEditor()
+
+    tapSave()
+
+    val created = awaitNewReminder(idsBefore)
+    assertEquals(RecurrenceRule.Once, created.recurrence)
+
+    navigateToEditReminderBuilder(uniqueSummary)
+
+    removeBuilderItem(r(R.string.builder_date))
+
+    addBuilderItem(r(R.string.builder_days_of_week))
+    clickText(r(R.string.mon))
+    closeValueEditor()
+
+    tapSave()
+
+    composeRule.waitUntil(timeoutMillis = 10_000) {
+      runBlocking { reminderV2Repository.getById(created.uuId)?.recurrence != RecurrenceRule.Once }
+    }
+    val updated = runBlocking { reminderV2Repository.getById(created.uuId) }
+    // sun, mon, tue, wed, thu, fri, sat - Monday sets index 1, same convention as the create-flow
+    // weekly tests above.
+    assertEquals(RecurrenceRule.Weekly(weekdays = listOf(0, 1, 0, 0, 0, 0, 0)), updated?.recurrence)
+  }
+
   companion object {
     /** Runs before the very first [BottomNavActivity] is created for this class (JUnit applies
      *  `@Rule`s - including the compose rule's activity launch - only around `@Before`/`@Test`, not
@@ -363,11 +632,17 @@ class ReminderRecurrenceE2ETest : KoinTest {
      *  `startKoin {}` bindings could be read by anything the app creates on launch (e.g.
      *  `BottomNavInitViewModel`'s `GroupV2Repository` usage). `loadKoinModules`'s single-`Module`
      *  overload defaults to allowing overrides, so no explicit override flag is needed. */
+    /** Shared across the whole class (see [resetFakeClock]) so date-relative recurrence edge
+     *  cases (day-of-month/day-of-year rollover) can pin "today" instead of depending on the
+     *  real device date - see [FakeNowDateTimeProvider]'s kdoc. */
+    private val fakeNowDateTimeProvider = FakeNowDateTimeProvider()
+
     @JvmStatic
     @BeforeClass
     fun setUpClass() {
       val context = InstrumentationRegistry.getInstrumentation().targetContext
       loadKoinModules(testRepositoryModule(context))
+      loadKoinModules(testDateTimeModule(fakeNowDateTimeProvider))
     }
   }
 }

--- a/app/src/androidTest/kotlin/com/elementary/tasks/e2e/ReminderRecurrenceE2ETest.kt
+++ b/app/src/androidTest/kotlin/com/elementary/tasks/e2e/ReminderRecurrenceE2ETest.kt
@@ -2,6 +2,8 @@ package com.elementary.tasks.e2e
 
 import android.os.Build
 import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.text.input.ImeAction
@@ -11,8 +13,11 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import com.elementary.tasks.navigation.BottomNavActivity
 import com.github.naz013.datecalc.DateTimeManager
+import com.github.naz013.domain.reminder.v2.GroupV2
 import com.github.naz013.domain.reminder.v2.RecurrenceRule
 import com.github.naz013.domain.reminder.v2.ReminderV2
+import com.github.naz013.feature.reminder.build.valuedialog.editor.shopItemCheckTestTag
+import com.github.naz013.repository.GroupV2Repository
 import com.github.naz013.repository.ReminderV2Repository
 import com.github.naz013.repository.testfixtures.testRepositoryModule
 import com.github.naz013.ui.common.R
@@ -21,6 +26,8 @@ import java.util.Locale
 import java.util.UUID
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Rule
@@ -71,6 +78,7 @@ class ReminderRecurrenceE2ETest : KoinTest {
     }
 
   private val reminderV2Repository: ReminderV2Repository by inject()
+  private val groupV2Repository: GroupV2Repository by inject()
   private val dateTimeManager: DateTimeManager by inject()
 
   /** Resets before every test so tests that don't touch it (all but the day-of-month/day-of-year
@@ -201,10 +209,23 @@ class ReminderRecurrenceE2ETest : KoinTest {
    *  landing on the actual dial position. Also confirmed live: tapping an hour position does
    *  *not* auto-advance to minute-select mode (unlike this app's own live-commit editors) -
    *  `"Select minutes"` has to be tapped explicitly first. Values are Material3's own English
-   *  accessibility strings, not this app's string resources. */
+   *  accessibility strings, not this app's string resources.
+   *
+   *  Confirmed live (real device, run at 12:22 local time): without an explicit AM tap, the
+   *  picker's AM/PM segment defaults to whichever half of the day it's currently running in -
+   *  produced 22:30 instead of 10:30 when run past noon. Every test that only asserts on
+   *  `RecurrenceRule` fields (not `schedule.eventDateTime`) was silently immune to this - it only
+   *  surfaced once a test (the day-of-month/day-of-year edge cases) started asserting on the
+   *  exact persisted time. Tapping "AM" unconditionally (same idiom as the `enable_quiet_hours
+   *  .yaml` Maestro flow's `tapOn: "AM"`, which this mirrors) is a harmless no-op when it's
+   *  already selected. */
   private fun setTime() {
     composeRule
       .onNode(hasContentDescription("10 o'clock") and !hasText("10"), useUnmergedTree = true)
+      .performClick()
+    composeRule.waitForIdle()
+    composeRule
+      .onNode(hasText("AM"), useUnmergedTree = true)
       .performClick()
     composeRule.waitForIdle()
     composeRule
@@ -681,6 +702,217 @@ class ReminderRecurrenceE2ETest : KoinTest {
     // sun, mon, tue, wed, thu, fri, sat - Monday sets index 1, same convention as the create-flow
     // weekly tests above.
     assertEquals(RecurrenceRule.Weekly(weekdays = listOf(0, 1, 0, 0, 0, 0, 0)), updated?.recurrence)
+  }
+
+  /** B6: adds two shopping-list items and checks one off, then confirms both details persist -
+   *  including the checked state - through the real repository. `ShopItemRow`'s checkbox carries
+   *  no text/content description (see that composable), so this drives it via
+   *  [shopItemCheckTestTag]'s prefix rather than an exact tag - the row's real `ShopItem.uuId` is
+   *  randomly generated and never exposed to the test, only the fixed prefix is known ahead of
+   *  time (`shopItemCheckTestTag("")` gives that prefix without duplicating its literal).
+   *
+   *  Only exercises add + check-off, not remove - `ShopItemRow`'s remove button only composes
+   *  once its row is both focused *and* non-empty, and this file has no proven way yet to assert
+   *  real Android focus state from a semantics-only interaction; left for a follow-up rather than
+   *  guessed at. */
+  @Test
+  fun addingSubTasksAndCheckingOneOffPersistsTheFinalShoppingListState() {
+    val idsBefore = captureExistingReminderIds()
+    navigateToNewReminderBuilder()
+
+    addBuilderItem(r(R.string.builder_sub_tasks))
+    // The sheet opens with one empty, auto-focused row already showing (SubTasksValueEditor).
+    composeRule.onAllNodes(hasSetTextAction(), useUnmergedTree = true)[0].performTextInput("Buy milk")
+    composeRule.waitForIdle()
+    // Enter/Next on a non-empty row appends a second, now-focused empty row - both fields stay in
+    // the tree afterward (the first one just loses focus), so indices 0/1 address them in order.
+    composeRule.onAllNodes(hasImeAction(ImeAction.Next), useUnmergedTree = true)[0].performImeAction()
+    composeRule.waitForIdle()
+    composeRule.onAllNodes(hasSetTextAction(), useUnmergedTree = true)[1].performTextInput("Buy eggs")
+    composeRule.waitForIdle()
+
+    val checkTagPrefix = shopItemCheckTestTag("")
+    val checkboxMatcher =
+      SemanticsMatcher("shop item checkbox") { node ->
+        node.config.getOrNull(SemanticsProperties.TestTag)?.startsWith(checkTagPrefix) == true
+      }
+    composeRule.onAllNodes(checkboxMatcher, useUnmergedTree = true)[0].performClick()
+    composeRule.waitForIdle()
+    closeValueEditor()
+
+    tapSave()
+
+    val created = awaitNewReminder(idsBefore)
+    val activeItems = created.shoppingItems.filterNot { it.isDeleted }
+    val milk = activeItems.single { it.summary == "Buy milk" }
+    val eggs = activeItems.single { it.summary == "Buy eggs" }
+    assertTrue(milk.isChecked)
+    assertFalse(eggs.isChecked)
+  }
+
+  /** B7: assigns a Group on create and confirms the persisted `groupId` matches. The Group picker
+   *  (`GroupValueEditor`) is a `WheelPicker` fed entirely from `GroupV2Repository.getAll()`
+   *  (`BiFactory.kt`) - on the empty in-memory DB `testRepositoryModule` provides, that list
+   *  starts empty and `WheelPicker` renders nothing at all for an empty item list (confirmed by
+   *  reading that file's `if (items.isEmpty()) return`), so this seeds one group directly through
+   *  `groupV2Repository` first. Doing that through the repository rather than the UI is fine here
+   *  - there's no in-scope UI path to *create* a group from the reminder builder at all, only to
+   *  pick an existing one, so seeding one is equivalent to "a group already exists," not a
+   *  shortcut around the behavior actually under test. */
+  @Test
+  fun assigningAGroupOnCreatePersistsItsGroupId() {
+    val group = GroupV2(title = "Work ${UUID.randomUUID()}")
+    runBlocking { groupV2Repository.save(group) }
+
+    val idsBefore = captureExistingReminderIds()
+    navigateToNewReminderBuilder()
+
+    addBuilderItem(r(R.string.builder_date))
+    setDateToday()
+    closeValueEditor()
+
+    addBuilderItem(r(R.string.time))
+    setTime()
+    closeValueEditor()
+
+    addBuilderItem(r(R.string.group))
+    clickText(group.title)
+    closeValueEditor()
+
+    tapSave()
+
+    val created = awaitNewReminder(idsBefore)
+    assertEquals(group.uuId, created.groupId)
+  }
+
+  /** B15: `RepeatLimitBuilderItem`'s `requiresAny(DAY_OF_YEAR, DAY_OF_MONTH, DAYS_OF_WEEK,
+   *  REPEAT_TIME)` constraint (`BuilderItem.kt`) is validated live as items are added/removed -
+   *  adding Repeat limit while none of those are present surfaces a "Requires any of: ..." error
+   *  on its own row (`UiBuilderItemsAdapter`), which clears once Repeat (`REPEAT_TIME`) is added.
+   *  Date+Time are added first specifically so the *overall* reminder is valid throughout (Time
+   *  alone would itself be invalid per `BuilderErrorFinder.findErrorTime`), keeping this test
+   *  about the one constraint it's targeting rather than tangled up with a second, unrelated
+   *  validation failure.
+   *
+   *  Asserts on the error message's fixed "Requires any of:" prefix only, not the full list of
+   *  type names that follows it - `BuilderItemRequiresAnyConstraintCalculator` collects the
+   *  missing types into a `HashSet` before joining them into the message, so their order isn't
+   *  guaranteed to be stable across runs. */
+  @Test
+  fun addingRepeatLimitWithoutARequiredCompanionShowsAValidationErrorThatClears() {
+    val idsBefore = captureExistingReminderIds()
+    navigateToNewReminderBuilder()
+
+    addBuilderItem(r(R.string.builder_date))
+    setDateToday()
+    closeValueEditor()
+
+    addBuilderItem(r(R.string.time))
+    setTime()
+    closeValueEditor()
+
+    addBuilderItem(r(R.string.repeat_limit))
+    closeValueEditor()
+
+    val requiresAnyPrefix = r(R.string.builder_requires_any_of_x).substringBefore('%')
+    composeRule.onNodeWithText(requiresAnyPrefix, substring = true).assertIsDisplayed()
+
+    addBuilderItem(r(R.string.repeat))
+    setRepeatTimeSeconds(30)
+    closeValueEditor()
+
+    composeRule.onAllNodesWithText(requiresAnyPrefix, substring = true).assertCountEquals(0)
+
+    tapSave()
+
+    val created = awaitNewReminder(idsBefore)
+    assertEquals(RecurrenceRule.Daily(repeatInterval = 30_000L, repeatLimit = -1), created.recurrence)
+  }
+
+  /** B16: adding Timer, then trying to add Date (blocked by Timer per `TimerBuilderItem`'s
+   *  `blockedBy(BiType.DATE, ...)` / `DateBuilderItem`'s symmetric `blockedBy(...,
+   *  BiType.COUNTDOWN_TIMER, ...)`) is prevented at selection time, not allowed-then-cleared:
+   *  `UiSelectorItemsAdapter` marks a blocked item `UiSelectorUnavailable` with a "Blocked by:
+   *  ..." message, and `BuilderSelectorSheet`'s `SelectorItemRow` only attaches a `clickable`
+   *  modifier `if (available)` - an unavailable row has no click handler at all (confirmed by
+   *  reading that file, not live).
+   *
+   *  Only Timer is active when Date is searched for, so the message's single-type substitution is
+   *  deterministic - unlike [addingRepeatLimitWithoutARequiredCompanionShowsAValidationErrorThatClears]'s
+   *  multi-type case, this one is safe to assert on in full. The final Save+assert is what proves
+   *  the block actually held: if Date had been added anyway, the recurrence calculator would see
+   *  two active core types at once and return `null` (`RecurrenceRuleCalculator.isOnlyOneActive`),
+   *  which would leave nothing to persist as a plain `Countdown`.
+   *
+   *  Confirmed live: searching "Date" surfaces more than just the Date item itself (Location Delay
+   *  Date, and the iCal start/until date items also match, since the picker searches title +
+   *  description) - several of those are *also* blocked by Timer right now, each rendering the
+   *  identical "Blocked by: Countdown" text, so matching on that message text alone hit 3 nodes,
+   *  not 1. `hasAnySibling` scopes to the message text that shares a parent with the exact "Date"
+   *  title specifically (`SelectorItemRow`'s `Column` holds title/description/message as sibling
+   *  `Text`s), landing on that one row unambiguously. */
+  @Test
+  fun aBlockedBuilderCombinationIsUnselectableInThePicker() {
+    val idsBefore = captureExistingReminderIds()
+    navigateToNewReminderBuilder()
+
+    addBuilderItem(r(R.string.builder_countdown))
+    pressCountdownDigits(1, 0, 0)
+    closeValueEditor()
+
+    val addLabel = r(R.string.acc_add)
+    composeRule.onAllNodesWithContentDescription(addLabel).onFirst().performClick()
+    composeRule.waitForIdle()
+    composeRule
+      .onNode(hasImeAction(ImeAction.Search), useUnmergedTree = true)
+      .performTextInput(r(R.string.builder_date))
+    composeRule.waitForIdle()
+
+    // Confirmed live: searching "Date" surfaces more than just the Date item itself (Location
+    // Delay Date, and the iCal start/until date items also match on description text), and
+    // several of those are *also* blocked by Timer right now, each rendering the byte-identical
+    // "Blocked by: Countdown" message - so matching on that text alone hits 3 nodes, not 1, and
+    // `hasAnySibling` doesn't scope it down either (confirmed live too: title/description/message
+    // aren't direct semantics siblings the way SelectorItemRow's source layout suggested). What
+    // does reliably identify the right one, confirmed live via bounds logging: the Date row's own
+    // "Blocked by" message sits ~112px directly below its exact "Date" title with nothing else in
+    // between, while every other row's title/message pair is 200px+ away - so this finds the
+    // closest "Blocked by" message below the exact "Date" title instead of matching on text alone.
+    // Same search-field ambiguity addBuilderItem's own kdoc documents (the field's own typed text
+    // matches too) - excluding editable nodes lands on the actual row title, not the field.
+    val dateTitleBounds =
+      composeRule
+        .onNode(
+          hasText(r(R.string.builder_date), substring = false) and !hasSetTextAction(),
+          useUnmergedTree = true,
+        )
+        .fetchSemanticsNode()
+        .boundsInRoot
+
+    val expectedBlockedMessage =
+      composeRule.activity.getString(R.string.builder_blocked_by_x, r(R.string.builder_countdown))
+    val blockedMessagesBelowDate =
+      composeRule
+        .onAllNodes(hasText(expectedBlockedMessage, substring = true), useUnmergedTree = true)
+        .fetchSemanticsNodes()
+        .filter { it.boundsInRoot.top >= dateTitleBounds.bottom }
+        .sortedBy { it.boundsInRoot.top - dateTitleBounds.bottom }
+
+    assertTrue(
+      "Expected a 'Blocked by' message directly below the Date row's title",
+      blockedMessagesBelowDate.isNotEmpty(),
+    )
+
+    Espresso.pressBack()
+    composeRule.waitForIdle()
+
+    tapSave()
+
+    val created = awaitNewReminder(idsBefore)
+    assertEquals(
+      RecurrenceRule.Countdown(after = 60_000L, repeatInterval = 0, repeatLimit = -1),
+      created.recurrence,
+    )
   }
 
   companion object {

--- a/app/src/androidTest/kotlin/com/elementary/tasks/e2e/ReminderRecurrenceE2ETest.kt
+++ b/app/src/androidTest/kotlin/com/elementary/tasks/e2e/ReminderRecurrenceE2ETest.kt
@@ -13,11 +13,16 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import com.elementary.tasks.navigation.BottomNavActivity
 import com.github.naz013.datecalc.DateTimeManager
+import com.github.naz013.domain.note.Note
 import com.github.naz013.domain.reminder.v2.GroupV2
+import com.github.naz013.domain.reminder.v2.ReminderAction
 import com.github.naz013.domain.reminder.v2.RecurrenceRule
+import com.github.naz013.domain.reminder.v2.ReminderPriority
 import com.github.naz013.domain.reminder.v2.ReminderV2
+import com.github.naz013.domain.sync.SyncState
 import com.github.naz013.feature.reminder.build.valuedialog.editor.shopItemCheckTestTag
 import com.github.naz013.repository.GroupV2Repository
+import com.github.naz013.repository.NoteRepository
 import com.github.naz013.repository.ReminderV2Repository
 import com.github.naz013.repository.testfixtures.testRepositoryModule
 import com.github.naz013.ui.common.R
@@ -77,8 +82,15 @@ class ReminderRecurrenceE2ETest : KoinTest {
       TestRule { base, _ -> base }
     }
 
+  // PhoneCallBuilderItem declares constraints { permission(Permissions.CALL_PHONE) }
+  // (BuilderItem.kt), checked live as soon as the item is added (UiBuilderItemsAdapter), not just
+  // at Save - pre-granting avoids a system permission dialog this test can't drive.
+  @get:Rule
+  val callPhonePermissionRule: TestRule = GrantPermissionRule.grant("android.permission.CALL_PHONE")
+
   private val reminderV2Repository: ReminderV2Repository by inject()
   private val groupV2Repository: GroupV2Repository by inject()
+  private val noteRepository: NoteRepository by inject()
   private val dateTimeManager: DateTimeManager by inject()
 
   /** Resets before every test so tests that don't touch it (all but the day-of-month/day-of-year
@@ -913,6 +925,175 @@ class ReminderRecurrenceE2ETest : KoinTest {
       RecurrenceRule.Countdown(after = 60_000L, repeatInterval = 0, repeatLimit = -1),
       created.recurrence,
     )
+  }
+
+  /** Sets the value of a sheet's single plain `OutlinedTextField` (used by every editor in
+   *  B1-B4 below: `PhoneInputValueEditor`, `SimpleTextValueEditor`, `TextInputValueEditor`) -
+   *  each of those sheets has exactly one editable field, same precondition [setRepeatTimeSeconds]
+   *  already relies on for its own sheet. */
+  private fun setTextFieldValue(value: String) {
+    composeRule
+      .onNode(hasSetTextAction(), useUnmergedTree = true)
+      .performTextReplacement(value)
+    composeRule.waitForIdle()
+  }
+
+  /** Adds Date+Time, common precondition for B1-B4: every action `BuilderItem` (Call/Sms/Email/
+   *  Link) declares `requiresAny(COUNTDOWN_TIMER, DATE, DAYS_OF_WEEK, DAY_OF_MONTH, DAY_OF_YEAR,
+   *  ARRIVING_COORDINATES, LEAVING_COORDINATES)` (`BuilderItem.kt`) - Date+Time is the simplest
+   *  combination already proven elsewhere in this file. */
+  private fun addDateAndTime() {
+    addBuilderItem(r(R.string.builder_date))
+    setDateToday()
+    closeValueEditor()
+
+    addBuilderItem(r(R.string.time))
+    setTime()
+    closeValueEditor()
+  }
+
+  /** B1: phone call action - number entry persists as `ReminderAction.Call`.
+   *  `PhoneCallBuilderItem` is the only action item with a `permission()` constraint
+   *  (`Permissions.CALL_PHONE`), checked live as soon as it's added (`UiBuilderItemsAdapter`), not
+   *  just at Save - [callPhonePermissionRule] pre-grants it so this doesn't block on a system
+   *  permission dialog this test can't drive. */
+  @Test
+  fun addingAPhoneCallActionPersistsTheNumber() {
+    val idsBefore = captureExistingReminderIds()
+    navigateToNewReminderBuilder()
+
+    addDateAndTime()
+
+    addBuilderItem(r(R.string.make_call))
+    setTextFieldValue("+15551234567")
+    closeValueEditor()
+
+    tapSave()
+
+    val created = awaitNewReminder(idsBefore)
+    assertEquals(ReminderAction.Call("+15551234567"), created.action)
+  }
+
+  /** B2: SMS action - number entry persists as `ReminderAction.Sms` (subject always empty for
+   *  SMS - see `ReminderActionCalculator`). Unlike B1, `SmsBuilderItem` declares no `permission()`
+   *  constraint of its own (only actually sending the SMS needs one, not building/saving the
+   *  reminder), so no extra grant rule is needed here. */
+  @Test
+  fun addingAnSmsActionPersistsTheNumber() {
+    val idsBefore = captureExistingReminderIds()
+    navigateToNewReminderBuilder()
+
+    addDateAndTime()
+
+    addBuilderItem(r(R.string.send_sms))
+    setTextFieldValue("+15559876543")
+    closeValueEditor()
+
+    tapSave()
+
+    val created = awaitNewReminder(idsBefore)
+    assertEquals(ReminderAction.Sms("+15559876543", ""), created.action)
+  }
+
+  /** B3: email action + subject field - both persist together as one `ReminderAction.Email`
+   *  (`ReminderActionCalculator` reads `EMAIL_SUBJECT`'s value only once `EMAIL` itself is
+   *  present and correct). `EmailModifier.isCorrect()` requires the value to match a `.*@.*..*`
+   *  regex - a real-shaped address avoids that failing silently and leaving `action = None`. */
+  @Test
+  fun addingAnEmailActionWithSubjectPersistsBoth() {
+    val idsBefore = captureExistingReminderIds()
+    navigateToNewReminderBuilder()
+
+    addDateAndTime()
+
+    addBuilderItem(r(R.string.e_mail))
+    setTextFieldValue("someone@example.com")
+    closeValueEditor()
+
+    addBuilderItem(r(R.string.subject))
+    setTextFieldValue("Don't forget")
+    closeValueEditor()
+
+    tapSave()
+
+    val created = awaitNewReminder(idsBefore)
+    assertEquals(ReminderAction.Email("someone@example.com", "Don't forget"), created.action)
+  }
+
+  /** B4: web link action - URL persists as `ReminderAction.Link`. `WebAddressModifier.isCorrect()`
+   *  requires a real `Patterns.WEB_URL` match, so a bare host-only string is used rather than a
+   *  placeholder that might not match. */
+  @Test
+  fun addingAWebLinkActionPersistsTheUrl() {
+    val idsBefore = captureExistingReminderIds()
+    navigateToNewReminderBuilder()
+
+    addDateAndTime()
+
+    addBuilderItem(r(R.string.builder_web_address))
+    setTextFieldValue("https://example.com")
+    closeValueEditor()
+
+    tapSave()
+
+    val created = awaitNewReminder(idsBefore)
+    assertEquals(ReminderAction.Link("https://example.com"), created.action)
+  }
+
+  /** B9: priority selection persists as the matching `ReminderPriority`.
+   *
+   *  Confirmed live (real device, via bounds/text logging): a freshly-added `PriorityBuilderItem`
+   *  actually starts selected on "Lowest" (index 0), not index 2 ("Normal") as
+   *  `PriorityValueEditor`'s own `DEFAULT_PRIORITY_INDEX` constant would suggest - and with only
+   *  2 of the wheel's rows composed at that scroll position (Lowest, Low), not the full 3, "High"
+   *  is nowhere near reachable without scrolling. Picks "Low" (index 1) instead, which is already
+   *  composed and visible with no scrolling needed. `@array/priorities` and `ReminderPriority
+   *  .entries` share the same Lowest..Highest order (confirmed by reading both), so index 1 there
+   *  is `ReminderPriority.LOW`. */
+  @Test
+  fun selectingAPriorityPersistsIt() {
+    val idsBefore = captureExistingReminderIds()
+    navigateToNewReminderBuilder()
+
+    addDateAndTime()
+
+    addBuilderItem(r(R.string.priority))
+    clickText(r(R.string.priority_low))
+    closeValueEditor()
+
+    tapSave()
+
+    val created = awaitNewReminder(idsBefore)
+    assertEquals(ReminderPriority.LOW, created.notification.priority)
+  }
+
+  /** B10: links an existing note to the reminder on create, persisting its id as `noteId`
+   *  (`NoteModifier.putInto`: `reminder.copy(noteId = storage.value?.id ?: "")`, where that id is
+   *  the note's own `key`). `NoteBuilderItem` requires Date+Time (`requiresAll`), which
+   *  [addDateAndTime] already provides. Seeds the note directly through `noteRepository` - same
+   *  reasoning as [assigningAGroupOnCreatePersistsItsGroupId]'s group seeding: there's no in-scope
+   *  UI path to *create* a note from the reminder builder, only to pick an existing one. Needed a
+   *  new `factory<NoteRepository>` entry in `testRepositoryModule` (mirroring its existing
+   *  `GroupV2Repository`/`ReminderV2Repository` entries) so this reliably reads/writes the same
+   *  in-memory DB instead of risking the on-device one. */
+  @Test
+  fun linkingAnExistingNotePersistsItsId() {
+    val note = Note(summary = "Pick up dry cleaning ${UUID.randomUUID()}", syncState = SyncState.WaitingForUpload)
+    runBlocking { noteRepository.save(note) }
+
+    val idsBefore = captureExistingReminderIds()
+    navigateToNewReminderBuilder()
+
+    addDateAndTime()
+
+    addBuilderItem(r(R.string.note))
+    clickText(note.summary)
+    closeValueEditor()
+
+    tapSave()
+
+    val created = awaitNewReminder(idsBefore)
+    assertEquals(note.key, created.noteId)
   }
 
   companion object {

--- a/app/src/androidTest/kotlin/com/elementary/tasks/e2e/ReminderRecurrenceE2ETest.kt
+++ b/app/src/androidTest/kotlin/com/elementary/tasks/e2e/ReminderRecurrenceE2ETest.kt
@@ -152,10 +152,20 @@ class ReminderRecurrenceE2ETest : KoinTest {
   /** Scrolls the current sheet's lazy list/grid (`DayOfMonthValueEditor`'s `WheelPicker` or
    *  `DayOfYearValueEditor`'s `SelectableChipGrid`, both backed by a Lazy* layout) so that
    *  [index] is composed and clickable - needed for any target beyond what's composed by default,
-   *  unlike e.g. day 1 or day 10 which [addBuilderItem]'s callers rely on already being visible. */
+   *  unlike e.g. day 1 or day 10 which [addBuilderItem]'s callers rely on already being visible.
+   *
+   *  Confirmed live (real device, API 30): the main builder screen's own `BuilderListItemCard`
+   *  list stays in the semantics tree - and matches `hasScrollToIndexAction()` too - even while a
+   *  `ValueEditorSheet` is open on top of it, so `onNode(hasScrollToIndexAction())` throws
+   *  "found 2 nodes" instead of finding the sheet's list uniquely. `onAllNodes(...).onLast()`
+   *  reliably picks the sheet's list instead: confirmed live across both call sites (the
+   *  day-of-month wheel and the day-of-year grid) that it's always the higher-id / later-composed
+   *  node, i.e. whatever was composed most recently - the sheet, since it opens after the
+   *  underlying screen. */
   private fun scrollLazyListToIndex(index: Int) {
     composeRule
-      .onNode(hasScrollToIndexAction(), useUnmergedTree = true)
+      .onAllNodes(hasScrollToIndexAction(), useUnmergedTree = true)
+      .onLast()
       .performScrollToIndex(index)
     composeRule.waitForIdle()
   }
@@ -250,24 +260,72 @@ class ReminderRecurrenceE2ETest : KoinTest {
     composeRule.onNodeWithText(r(R.string.save)).performClick()
   }
 
+  /** Dismisses Home's first-run Privacy Policy consent banner (`ScheduleHomeViewModel`'s
+   *  `BannerState.Privacy`, gated on `LegalDocumentRepository`'s on-device SharedPreferences flag
+   *  - not reset by [testRepositoryModule] or between test methods sharing one app install) if
+   *  it's currently showing; a no-op otherwise.
+   *
+   *  Confirmed live (real device, API 30, running this class's tests in isolation): unlike this
+   *  file's other interactions - which fire a target's semantics `OnClick` action directly,
+   *  bypassing normal touch-dispatch ordering, which is why e.g. [navigateToNewReminderBuilder]'s
+   *  FAB tap works even with a dialog visually on top - this banner genuinely blocks navigation
+   *  while shown: a run landed on this exact failure, [navigateToEditReminderBuilder] stuck on
+   *  Home (confirmed via `composeRule.onRoot().printToLog(...)`) instead of on
+   *  PreviewReminderScreen after tapping the target row. */
+  private fun dismissPrivacyBannerIfShown() {
+    val acceptLabel = r(R.string.accept)
+    if (composeRule.onAllNodesWithText(acceptLabel).fetchSemanticsNodes().isNotEmpty()) {
+      composeRule.onNodeWithText(acceptLabel).performClick()
+      composeRule.waitForIdle()
+    }
+  }
+
   /** Home -> reminder details -> builder in edit mode, the only path there is (see
    *  [navigateToNewReminderBuilder]'s kdoc for the equivalent "no direct seam" situation for
    *  create). [summary] must uniquely identify the target row - the home list only ever shows
    *  today's active reminders (`GetActiveEventsForTheDayUseCase`), and its row text is exactly the
    *  reminder's `Summary` builder item value, falling back to a shared non-unique placeholder when
    *  absent - so every test using this helper adds a `Summary` item with a fresh [UUID] to make its
-   *  own row unambiguous, since the database isn't reset between tests. */
+   *  own row unambiguous, since the database isn't reset between tests.
+   *
+   *  Confirmed live (real device, API 30): the Home -> `PreviewReminderScreen` navigation this tap
+   *  triggers is a genuine intermittent flake, not a locator bug - across several back-to-back
+   *  runs (both in isolation and as part of the full class, with no code changes in between) a
+   *  single tap + 20s wait passed some runs and missed "More options" entirely on others, with one
+   *  run's `printToLog` dump confirming the tap never even left Home that time (stuck behind
+   *  [dismissPrivacyBannerIfShown]'s banner) while a different failing run showed no banner at
+   *  all - i.e. more than one distinct cause can produce the same symptom here. Retrying the tap
+   *  (rather than just a single longer wait) is the general-purpose mitigation: cheap when the
+   *  first attempt already worked, and self-corrects when it doesn't, regardless of which
+   *  underlying cause was at fault that time.
+   *
+   *  Confirmed live the unsafe way *not* to recover between attempts: `Espresso.pressBack()` when
+   *  the tap never actually left Home throws (`BottomNavActivity` is the root of its own back
+   *  stack, so there's nothing for Back to pop there - matches the identical warning already
+   *  documented for the Maestro flows' cleanup step). So each retry only re-taps if the summary
+   *  row is still visible (i.e. we're confirmed still on Home, safe to retry) and never presses
+   *  Back at all - if a tap left Home for some third, unrecognized state, this just keeps waiting
+   *  rather than risk closing the Activity. */
   private fun navigateToEditReminderBuilder(summary: String) {
     composeRule.waitUntil(timeoutMillis = 10_000) {
       composeRule.onAllNodesWithText(summary).fetchSemanticsNodes().isNotEmpty()
     }
-    composeRule.onNodeWithText(summary).performClick()
-    composeRule.waitForIdle()
-
     val moreOptionsLabel = r(R.string.more_options)
-    composeRule.waitUntil(timeoutMillis = 10_000) {
-      composeRule.onAllNodesWithContentDescription(moreOptionsLabel).fetchSemanticsNodes().isNotEmpty()
+    var reachedPreview = false
+    repeat(3) {
+      if (reachedPreview) return@repeat
+      dismissPrivacyBannerIfShown()
+      if (composeRule.onAllNodesWithText(summary).fetchSemanticsNodes().isNotEmpty()) {
+        composeRule.onNodeWithText(summary).performClick()
+        composeRule.waitForIdle()
+      }
+      reachedPreview = runCatching {
+        composeRule.waitUntil(timeoutMillis = 8_000) {
+          composeRule.onAllNodesWithContentDescription(moreOptionsLabel).fetchSemanticsNodes().isNotEmpty()
+        }
+      }.isSuccess
     }
+    check(reachedPreview) { "Did not land on the reminder details screen after 3 attempts" }
     composeRule.onNodeWithContentDescription(moreOptionsLabel).performClick()
     composeRule.waitForIdle()
     composeRule.onNodeWithText(r(R.string.edit)).performClick()

--- a/app/src/androidTest/kotlin/com/elementary/tasks/e2e/ReminderRecurrenceE2ETest.kt
+++ b/app/src/androidTest/kotlin/com/elementary/tasks/e2e/ReminderRecurrenceE2ETest.kt
@@ -1135,6 +1135,70 @@ class ReminderRecurrenceE2ETest : KoinTest {
     assertEquals("", created.notification.quietHoursTo)
   }
 
+  /** A8: Weekly recurrence + a repeat limit stops firing after N occurrences
+   *  (`RecurrenceRuleCalculator.fromWeekdays`: `RecurrenceRule.Weekly(weekdays, repeatLimit)`).
+   *  Unlike Monthly/Yearly, Weekly has no separate "repeat every N weeks" builder item in this
+   *  data model - just the single weekday cycle plus an optional limit - so this is the same
+   *  single-weekday setup as [savesAWeeklyReminderOnASingleWeekdayWithTheCorrectRecurrenceRule]
+   *  with [RepeatLimitBuilderItem] added on top; `DAYS_OF_WEEK` alone already satisfies its
+   *  `requiresAny(DAY_OF_YEAR, DAY_OF_MONTH, DAYS_OF_WEEK, REPEAT_TIME)` constraint. */
+  @Test
+  fun savesAWeeklyReminderWithARepeatLimitAndTheCorrectRecurrenceRule() {
+    val idsBefore = captureExistingReminderIds()
+    navigateToNewReminderBuilder()
+
+    addBuilderItem(r(R.string.time))
+    setTime()
+    closeValueEditor()
+
+    addBuilderItem(r(R.string.builder_days_of_week))
+    clickText(r(R.string.mon))
+    closeValueEditor()
+
+    addBuilderItem(r(R.string.repeat_limit))
+    setRepeatLimit(5f)
+    closeValueEditor()
+
+    tapSave()
+
+    val created = awaitNewReminder(idsBefore)
+    // sun, mon, tue, wed, thu, fri, sat - Monday sets index 1.
+    assertEquals(RecurrenceRule.Weekly(weekdays = listOf(0, 1, 0, 0, 0, 0, 0), repeatLimit = 5), created.recurrence)
+  }
+
+  /** Sets `ValueAndTypePicker`'s `NumberStepperField` value the same way [setRepeatTimeSeconds]
+   *  does for `RepeatTimeValueEditor` (same composable, same single-editable-field precondition).
+   *  `decomposeDuration(null)` (`DurationValueEditors.kt`) defaults a fresh item's unit wheel to
+   *  SECOND (index 0), left untouched here, so the persisted duration is exactly [seconds] *
+   *  1000ms - same convention as [setRepeatTimeSeconds]. */
+  private fun setBeforeTimeSeconds(seconds: Int) {
+    composeRule
+      .onNode(hasSetTextAction(), useUnmergedTree = true)
+      .performTextReplacement(seconds.toString())
+    composeRule.waitForIdle()
+  }
+
+  /** B14: "Remind before" duration persists onto the reminder's own `NotificationSettingsOverride`
+   *  (`BeforeTimeBuilderItem`'s custom `putInto`: `notification.remindBefore`, nullable there like
+   *  the rest of that override shape - see [addingATimerExclusionWindowPersistsTheExcludedHours]'s
+   *  kdoc for the same distinction from the fully-resolved `NotificationSettings`). */
+  @Test
+  fun addingARemindBeforeDurationPersistsIt() {
+    val idsBefore = captureExistingReminderIds()
+    navigateToNewReminderBuilder()
+
+    addDateAndTime()
+
+    addBuilderItem(r(R.string.before_time))
+    setBeforeTimeSeconds(45)
+    closeValueEditor()
+
+    tapSave()
+
+    val created = awaitNewReminder(idsBefore)
+    assertEquals(45_000L, created.notification.remindBefore)
+  }
+
   companion object {
     /** Runs before the very first [BottomNavActivity] is created for this class (JUnit applies
      *  `@Rule`s - including the compose rule's activity launch - only around `@Before`/`@Test`, not

--- a/core/date-calculations/src/main/kotlin/com/github/naz013/datecalc/KoinModule.kt
+++ b/core/date-calculations/src/main/kotlin/com/github/naz013/datecalc/KoinModule.kt
@@ -7,6 +7,6 @@ val dateTimeCalculationsModule = module {
   factoryOf<BirthdayDateCalculator>(::BirthdayDateCalculatorImpl)
   factoryOf<RecurrenceCalculator>(::RecurrenceCalculatorImpl)
   factoryOf(::DateValidator)
-  factoryOf(::NowDateTimeProvider)
+  factoryOf<NowDateTimeProvider>(::NowDateTimeProviderImpl)
   factoryOf(::DateTimeManager)
 }

--- a/core/date-calculations/src/main/kotlin/com/github/naz013/datecalc/NowDateTimeProvider.kt
+++ b/core/date-calculations/src/main/kotlin/com/github/naz013/datecalc/NowDateTimeProvider.kt
@@ -4,8 +4,14 @@ import org.threeten.bp.LocalDate
 import org.threeten.bp.LocalDateTime
 import org.threeten.bp.LocalTime
 
-class NowDateTimeProvider {
-  fun nowDate(): LocalDate = LocalDate.now()
-  fun nowTime(): LocalTime = LocalTime.now()
-  fun nowDateTime(): LocalDateTime = LocalDateTime.now()
+interface NowDateTimeProvider {
+  fun nowDate(): LocalDate
+  fun nowTime(): LocalTime
+  fun nowDateTime(): LocalDateTime
+}
+
+class NowDateTimeProviderImpl : NowDateTimeProvider {
+  override fun nowDate(): LocalDate = LocalDate.now()
+  override fun nowTime(): LocalTime = LocalTime.now()
+  override fun nowDateTime(): LocalDateTime = LocalDateTime.now()
 }

--- a/data/repository/src/testFixtures/java/com/github/naz013/repository/testfixtures/TestRepositoryModule.kt
+++ b/data/repository/src/testFixtures/java/com/github/naz013/repository/testfixtures/TestRepositoryModule.kt
@@ -4,8 +4,10 @@ import android.content.Context
 import androidx.room.Room
 import com.github.naz013.repository.AppDb
 import com.github.naz013.repository.GroupV2Repository
+import com.github.naz013.repository.NoteRepository
 import com.github.naz013.repository.ReminderV2Repository
 import com.github.naz013.repository.impl.GroupV2RepositoryImpl
+import com.github.naz013.repository.impl.NoteRepositoryImpl
 import com.github.naz013.repository.impl.ReminderV2RepositoryImpl
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -31,5 +33,8 @@ fun testRepositoryModule(context: Context): Module = module {
   }
   factory<GroupV2Repository> {
     GroupV2RepositoryImpl(get<AppDb>().groupV2Dao(), get())
+  }
+  factory<NoteRepository> {
+    NoteRepositoryImpl(get<AppDb>().notesDao(), get())
   }
 }

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -5,13 +5,17 @@ tests for fast, in-process screen/flow verification, and [Maestro](https://maest
 true black-box user journeys (including notification-tray checks) — wired into GitHub Actions
 across multiple Android versions.
 
-**Status: none of this exists yet.** There is no `androidTest` source set anywhere in the repo
-today (verified via `find . -type d -name androidTest`), and CI
-(`.github/workflows/build_and_test.yml`) only runs `test`/`testProDebugUnitTest` on plain
-`ubuntu-latest` — no emulator. Everything below is new infrastructure to add, not a fix to
-something broken. Dependency versions referenced already exist in
-`gradle/libs.versions.toml` (`androidx-test-core/runner/rules`, `compose-ui-test-junit4`) except
-where called out as new.
+**Status: infrastructure and a first wave of coverage are live.** `app/src/androidTest/kotlin/com/elementary/tasks/e2e/ReminderRecurrenceE2ETest.kt`
+(Tier B, ~30 tests) and `.maestro/notifications/*.yaml` (6 flows) exist and run — Gradle wiring
+(§2), the nightly CI job (§3), and most of §A/§B/§D below are implemented and verified on a real
+device. §5's tables now carry a **Status** column per row so you can tell what's done, skipped
+(with why), deferred, or still just planned, without cross-referencing the test file. Nothing in
+Tier A exists yet — every Tier-B-labeled row below that's done lives in the one flow-level test
+file; no `feature:*` module has its own `androidTest` source set, so `core:testing` hasn't
+actually needed the Android-instrumented split §2 originally proposed for it.
+
+The rollout notes in §6 are the fastest way to see where things actually stand and what's likely
+next.
 
 See also: [architecture.md](architecture.md) (module map), [multiselect.md](multiselect.md)
 (bulk-selection pattern under test in §F), and
@@ -66,35 +70,42 @@ UI tests can't reach. Flows live in `.maestro/` at repo root, organized by featu
 journey, tagged (`smoke`, `recurrence`, `notifications`, `settings`, `pro-only`) so CI can run a
 fast `smoke`-tagged subset per PR and the full suite nightly/on `master`.
 
+The layout below is the original proposal (organized by test-category folder: `smoke/`,
+`recurrence/`, `settings/`, etc.) — **what actually exists today is narrower**, just the
+`notifications/` folder, since that's the only category with flows written so far:
+
 ```
 .maestro/
-  config.yaml                # appId, default flow tags/env
-  smoke/
-    create_simple_reminder.yaml
-  recurrence/
-    once.yaml
-    daily_repeat.yaml
-    countdown.yaml
-    weekly.yaml
-    monthly.yaml
-    yearly.yaml
-    location_enter.yaml
-    location_exit.yaml
-    icalendar_custom_rrule.yaml
+  config.yaml                     # appId
   notifications/
-    quiet_hours_suppresses_low_priority.yaml
-    quiet_hours_ignore_all.yaml
-    bypass_dnd_high_priority.yaml
-    notification_permission_denied.yaml
-    tap_notification_opens_reminder.yaml
-  settings/
-    notification_defaults_hierarchy.yaml
-    biometric_lock.yaml
+    quiet_hours_disabled_fires.yaml              # D1
+    quiet_hours_low_priority_suppressed.yaml     # D2
+    quiet_hours_high_priority_fires.yaml         # D3
+    quiet_hours_ignore_all_suppressed.yaml       # D4
+    notification_permission_denied.yaml          # D7
+    tap_notification_opens_reminder.yaml         # D9
+    flows/                        # reusable subflows, not runnable top-level tests themselves
+      create_countdown_reminder.yaml
+      enable_quiet_hours.yaml
 ```
+
+The rest of this section's proposed layout (`smoke/`, `recurrence/`, `settings/`) is still just
+a proposal — nothing under those categories has been written yet (recurrence coverage so far is
+all Tier B/Compose instead, per §A's Status column).
 
 ---
 
 ## 2. Gradle wiring needed
+
+**Status: done**, for `app` only — matches the shape proposed below (orchestrator execution,
+`clearPackageData = "true"`, `compose.ui.test.junit4`, `mockk.android`, `koin.test`, confirmed
+against the checked-in `app/build.gradle.kts`). `clearPackageData` only resets state once per
+`connectedProDebugAndroidTest` invocation, not per test method within the run — worth knowing
+before assuming any given test starts from a truly clean install (see the Privacy Policy banner
+caveat on A26 in `ReminderRecurrenceE2ETest.kt` for a concrete case this affected). No `feature:*`
+module has gained its own `androidTest` source set (no Tier-A tests exist yet), so the "same block
+goes into any `feature:*` module" step below and the `core:testing` Android-split plan are both
+still purely aspirational.
 
 New version-catalog entries (none of these exist yet in `gradle/libs.versions.toml`):
 
@@ -158,6 +169,13 @@ on the real device date.
 ---
 
 ## 3. GitHub Actions job
+
+**Status: done, simplified.** `test_e2e` exists in `build_and_test.yml` as a fourth job, but
+schedule-triggered only (nightly, not per-PR/push) and pinned to a single API level (34) rather
+than the illustrative 5-cell matrix below — see the "Nightly failure notification" bullet under
+Notes for what actually ships today, including the GitHub Issue it keeps open while the job is
+red. The YAML below is left as the original fuller proposal (multi-API-level, PR-triggered) in
+case that's ever worth reintroducing; don't assume it matches the checked-in workflow verbatim.
 
 Reuses the existing `.github/actions/setup-build` composite action (JDK 17, `gradlew` perms,
 `google-services.json` secrets) already used by the three jobs in `build_and_test.yml`. Add this
@@ -296,7 +314,7 @@ Practical mechanics for the tests in §D:
   for it to actually fire).
 - **Grant `POST_NOTIFICATIONS` before the run** (Android 13+/API 33+): `adb shell pm grant
   <applicationId> android.permission.POST_NOTIFICATIONS` (shown in the workflow above) so tests
-  aren't blocked on a permission dialog that varies by OEM. Test the *denied* path (§D-62)
+  aren't blocked on a permission dialog that varies by OEM. Test the *denied* path (D7)
   separately and explicitly, without the grant.
 - **Reading the notification shade**: Maestro can swipe open the shade (`swipe` from the top
   edge) and assert on visible text (`assertVisible: "<reminder summary>"`), or use
@@ -318,64 +336,120 @@ Legend: **Tier A** = Compose screen-level (feature module `androidTest`) · **Ti
 flow-level (`app` `androidTest`) · **Maestro** = black-box flow · **P0** = must have before this
 initiative is considered "done" · **P1** = important, can land after initial rollout.
 
+**Status** column values: **Done** (implemented and verified on a real device — see
+`ReminderRecurrenceE2ETest.kt`/`.maestro/notifications/`, test method names roughly follow this
+doc's row IDs) · **Skipped** (investigated and deliberately not implemented — reason inline or in
+a note below the table) · **Deferred** (explicitly postponed to a later batch, not abandoned) ·
+blank (not started).
+
 ### A. Reminder recurrence types
 
 Every row maps 1:1 to a `RecurrenceRule` variant (`core/domain/.../reminder/v2/RecurrenceRule.kt`)
 via the exact builder-item combination `RecurrenceRuleCalculator` requires — verified by reading
 that calculator, not guessed from the UI.
 
-| # | Test | Builder items used | `RecurrenceRule` produced | Tool | Pri |
-|---|---|---|---|---|---|
-| A1 | One-time reminder | Date + Time | `Once` | Tier B | P0 |
-| A2 | Repeat-from-date, fixed millis interval | Date + Time + RepeatTime | `Daily(repeatInterval)` | Tier B | P0 |
-| A3 | Simple countdown timer | Timer only | `Countdown(after)` | Tier B, Maestro | P0 |
-| A4 | Countdown timer + repeat interval + repeat limit | Timer + RepeatTime + RepeatLimit | `Countdown(after, repeatInterval, repeatLimit)` | Tier B | P0 |
-| A5 | Countdown timer + exclusion window | Timer + TimerExclusion | `Countdown` + exclusion applied to next-fire calc | Tier B | P1 |
-| A6 | Weekly, single weekday | Time + DaysOfWeek(1 day) | `Weekly(weekdays=[x])` | Tier B, Maestro | P0 |
-| A7 | Weekly, multiple weekdays | Time + DaysOfWeek(3+ days) | `Weekly(weekdays=[...])` | Tier B | P0 |
-| A8 | Weekly + repeat limit | Time + DaysOfWeek + RepeatLimit | `Weekly(..., repeatLimit)` — stops firing after N occurrences | Tier B | P1 |
-| A9 | Monthly, single day-of-month | Time + DayOfMonth | `Monthly(dayOfMonth)` | Tier B, Maestro | P0 |
-| A10 | Monthly + repeat interval (every N months) + limit | Time + DayOfMonth + RepeatInterval + RepeatLimit | `Monthly(dayOfMonth, repeatInterval, repeatLimit)` | Tier B | P0 |
-| A11 | **Edge case**: `dayOfMonth = 31` rolling into a 30-day/28-day month | Time + DayOfMonth(31) | `Monthly(31)` — verify `findNextMonthDayDateTime` behavior, not just that it doesn't crash | Tier B | P0 |
-| A12 | Yearly, single day-of-year | Time + DayOfYear | `Yearly(dayOfMonth, monthOfYear)` | Tier B, Maestro | P0 |
-| A13 | Yearly + repeat interval + limit | Time + DayOfYear + RepeatInterval + RepeatLimit | `Yearly(..., repeatInterval, repeatLimit)` | Tier B | P0 |
-| A14 | **Edge case**: Feb 29 on a leap year, next occurrence in a non-leap year | Time + DayOfYear=60 | `Yearly(29, Feb)` — confirm fallback (Feb 28 vs Mar 1) | Tier B | P1 |
-| A15 | Location — arriving (geofence enter) | ArrivingCoordinates | `LocationEnter` | Tier B | P0 |
-| A16 | Location — leaving (geofence exit) | LeavingCoordinates | `LocationExit` | Tier B | P0 |
-| A17 | Location with delayed fire | Arriving/LeavingCoordinates + LocationDelayDate/Time | `LocationEnter`/`LocationExit` with `LocationSettings(hasDelayedReminder=true)` | Tier B | P1 |
-| A18 | Custom RRULE — `FREQ=DAILY;INTERVAL=n;COUNT=n` | ICal Freq/Interval/Count | `ICalendar(rrule)` | Tier B, Maestro | P0 |
-| A19 | Custom RRULE — `FREQ=WEEKLY;BYDAY=…` (multi-day) | ICal Freq + ByDay | `ICalendar(rrule)` | Tier B | P0 |
-| A20 | Custom RRULE — `FREQ=MONTHLY;BYMONTHDAY=…` | ICal Freq + ByMonthDay | `ICalendar(rrule)` | Tier B | P1 |
-| A21 | Custom RRULE — `FREQ=MONTHLY;BYDAY=TU;BYSETPOS=2` ("2nd Tuesday") | ICal Freq + ByDay + BySetPos | `ICalendar(rrule)` — **this is currently the only UI-reachable way to express what the domain's `RecurrenceRule.RelativeMonthly` models; `RelativeMonthly` itself is never constructed by `RecurrenceRuleCalculator` today** — flag this test's intent as "verify the RRULE escape hatch," not "verify `RelativeMonthly`" | Tier B | P1 |
-| A22 | Custom RRULE — `FREQ=YEARLY;BYMONTH=…;BYMONTHDAY=…` | ICal Freq + ByMonth + ByMonthDay | `ICalendar(rrule)` | Tier B | P1 |
-| A23 | Custom RRULE with `UNTIL` date | ICal Freq + UntilDate/Time | `ICalendar(rrule)` — recurrence stops after `UNTIL` | Tier B | P1 |
-| A24 | Save a custom RRULE as a "recur preset," reuse it on a second reminder | ICal builder → save preset → new reminder → apply preset | n/a (preset feature) | Maestro | P1 |
-| A25 | Shopping-list reminder with no date/time | Sub-tasks only, no Date/Time/Timer | `Once` via `emptySchedule()` (no `eventDateTime`) | Tier B | P1 |
-| A26 | Edit existing reminder: change recurrence type (e.g. Once → Weekly) | any → any | recalculated `RecurrenceRule` replaces the old one | Tier B | P0 |
-| A27 | Complete one occurrence of a repeating reminder, confirm next occurrence schedules | Weekly/Monthly/Daily | next `eventDateTime` advances correctly; `repeatLimit`/`until` boundary stops repetition when exhausted | Tier B | P0 |
-| A28 | Snooze a fired reminder (`delayMinutes`), confirm it re-fires after the window | any + DelayMinutes override | re-scheduled at `now + delayMinutes` | Tier B, Maestro | P1 |
-| A29 | Delete/archive a reminder cancels its scheduled alarm | any | no notification fires after deletion (verify via §4 shade-check, absence) | Maestro | P0 |
+| # | Test | Builder items used | `RecurrenceRule` produced | Tool | Pri | Status |
+|---|---|---|---|---|---|---|
+| A1 | One-time reminder | Date + Time | `Once` | Tier B | P0 | Done |
+| A2 | Repeat-from-date, fixed millis interval | Date + Time + RepeatTime | `Daily(repeatInterval)` | Tier B | P0 | Done |
+| A3 | Simple countdown timer | Timer only | `Countdown(after)` | Tier B, Maestro | P0 | Done |
+| A4 | Countdown timer + repeat interval + repeat limit | Timer + RepeatTime + RepeatLimit | `Countdown(after, repeatInterval, repeatLimit)` | Tier B | P0 | Done |
+| A5 | Countdown timer + exclusion window | Timer + TimerExclusion | `Countdown` + exclusion applied to next-fire calc | Tier B | P1 | Done — scope note below |
+| A6 | Weekly, single weekday | Time + DaysOfWeek(1 day) | `Weekly(weekdays=[x])` | Tier B, Maestro | P0 | Done |
+| A7 | Weekly, multiple weekdays | Time + DaysOfWeek(3+ days) | `Weekly(weekdays=[...])` | Tier B | P0 | Done |
+| A8 | Weekly + repeat limit | Time + DaysOfWeek + RepeatLimit | `Weekly(..., repeatLimit)` — stops firing after N occurrences | Tier B | P1 | Done |
+| A9 | Monthly, single day-of-month | Time + DayOfMonth | `Monthly(dayOfMonth)` | Tier B, Maestro | P0 | Done |
+| A10 | Monthly + repeat interval (every N months) + limit | Time + DayOfMonth + RepeatInterval + RepeatLimit | `Monthly(dayOfMonth, repeatInterval, repeatLimit)` | Tier B | P0 | Done |
+| A11 | **Edge case**: `dayOfMonth = 31` rolling into a 30-day/28-day month | Time + DayOfMonth(31) | `Monthly(31)` — verify `findNextMonthDayDateTime` behavior, not just that it doesn't crash | Tier B | P0 | Done — redefined, see note below |
+| A12 | Yearly, single day-of-year | Time + DayOfYear | `Yearly(dayOfMonth, monthOfYear)` | Tier B, Maestro | P0 | Done |
+| A13 | Yearly + repeat interval + limit | Time + DayOfYear + RepeatInterval + RepeatLimit | `Yearly(..., repeatInterval, repeatLimit)` | Tier B | P0 | Done |
+| A14 | **Edge case**: Feb 29 on a leap year, next occurrence in a non-leap year | Time + DayOfYear=60 | `Yearly(29, Feb)` — confirm fallback (Feb 28 vs Mar 1) | Tier B | P1 | Done |
+| A15 | Location — arriving (geofence enter) | ArrivingCoordinates | `LocationEnter` | Tier B | P0 | |
+| A16 | Location — leaving (geofence exit) | LeavingCoordinates | `LocationExit` | Tier B | P0 | |
+| A17 | Location with delayed fire | Arriving/LeavingCoordinates + LocationDelayDate/Time | `LocationEnter`/`LocationExit` with `LocationSettings(hasDelayedReminder=true)` | Tier B | P1 | |
+| A18 | Custom RRULE — `FREQ=DAILY;INTERVAL=n;COUNT=n` | ICal Freq/Interval/Count | `ICalendar(rrule)` | Tier B, Maestro | P0 | Deferred |
+| A19 | Custom RRULE — `FREQ=WEEKLY;BYDAY=…` (multi-day) | ICal Freq + ByDay | `ICalendar(rrule)` | Tier B | P0 | Deferred |
+| A20 | Custom RRULE — `FREQ=MONTHLY;BYMONTHDAY=…` | ICal Freq + ByMonthDay | `ICalendar(rrule)` | Tier B | P1 | Deferred |
+| A21 | Custom RRULE — `FREQ=MONTHLY;BYDAY=TU;BYSETPOS=2` ("2nd Tuesday") | ICal Freq + ByDay + BySetPos | `ICalendar(rrule)` — **this is currently the only UI-reachable way to express what the domain's `RecurrenceRule.RelativeMonthly` models; `RelativeMonthly` itself is never constructed by `RecurrenceRuleCalculator` today** — flag this test's intent as "verify the RRULE escape hatch," not "verify `RelativeMonthly`" | Tier B | P1 | Deferred |
+| A22 | Custom RRULE — `FREQ=YEARLY;BYMONTH=…;BYMONTHDAY=…` | ICal Freq + ByMonth + ByMonthDay | `ICalendar(rrule)` | Tier B | P1 | Deferred |
+| A23 | Custom RRULE with `UNTIL` date | ICal Freq + UntilDate/Time | `ICalendar(rrule)` — recurrence stops after `UNTIL` | Tier B | P1 | Deferred |
+| A24 | Save a custom RRULE as a "recur preset," reuse it on a second reminder | ICal builder → save preset → new reminder → apply preset | n/a (preset feature) | Maestro | P1 | Deferred — depends on A18-A23's RRULE work |
+| A25 | Shopping-list reminder with no date/time | Sub-tasks only, no Date/Time/Timer | `Once` via `emptySchedule()` (no `eventDateTime`) | Tier B | P1 | |
+| A26 | Edit existing reminder: change recurrence type (e.g. Once → Weekly) | any → any | recalculated `RecurrenceRule` replaces the old one | Tier B | P0 | Done |
+| A27 | Complete one occurrence of a repeating reminder, confirm next occurrence schedules | Weekly/Monthly/Daily | next `eventDateTime` advances correctly; `repeatLimit`/`until` boundary stops repetition when exhausted | Tier B | P0 | Skipped — no safe UI path, see note below |
+| A28 | Snooze a fired reminder (`delayMinutes`), confirm it re-fires after the window | any + DelayMinutes override | re-scheduled at `now + delayMinutes` | Tier B, Maestro | P1 | |
+| A29 | Delete/archive a reminder cancels its scheduled alarm | any | no notification fires after deletion (verify via §4 shade-check, absence) | Maestro | P0 | |
+
+Notes on the non-obvious Status values above:
+
+- **A5** is done, but scoped down from the row's literal description: `RecurrenceRuleCalculator
+  .fromTimer()` never reads the exclusion window at all (confirmed by reading that file) — it only
+  feeds `RecurrenceCalculator.findNextTimerDateTime`'s `excludedHours` param when computing a
+  *repeat's next fire*, not at initial save, the same "would need to wait for a real fire to
+  observe" limitation as A27. The implemented test verifies the exclusion configuration
+  (`activeHours`/`quietHoursFrom`/`quietHoursTo` on the reminder's own `NotificationSettingsOverride`)
+  round-trips correctly through the builder and repository — not that a fire actually gets skipped.
+- **A11** was redefined after discovering `DayOfMonthValueEditor`'s wheel only offers days 1–28
+  plus a "Last day" sentinel (`dayOfMonth = 0`) — there's no way to pick a literal 29–31 through
+  the real UI, so the originally-planned "31 rolling into a shorter month" scenario can't happen.
+  The implemented test instead pins "now" (via a `FakeNowDateTimeProvider`) so the *next* month is
+  a non-leap February, and asserts "Last day" resolves to the 28th, not March or a crash — same
+  underlying `findNextMonthDayDateTime` code path, UI-reachable scenario.
+- **A27** was investigated (a background agent traced every caller of `CompleteReminderUseCase`)
+  and found no path reachable from `BottomNavActivity`'s own UI at all — completing an occurrence
+  only happens via a fired system notification's "Done" action or `ReminderActionActivity` (a
+  separate Activity, normally only reached from a notification). Driving that Activity directly
+  mid-test was flagged as the closest option but unverified without a device; skipped rather than
+  guessed at. Worth revisiting now that real-device verification is established practice in this
+  test suite.
 
 ### B. Reminder actions & customization (non-notification)
 
-| # | Test | Tool | Pri |
-|---|---|---|---|
-| B1 | Phone call action — number entry + validation | Tier A | P1 |
-| B2 | SMS action — number entry + validation | Tier A | P1 |
-| B3 | Email action + subject field | Tier A | P1 |
-| B4 | Web link action — URL validation | Tier A | P1 |
-| B5 | Open-application action (SDK-gated, `maxSdk = S`) — confirm hidden above Android 12 | Tier A | P1 |
-| B6 | Sub-tasks/shopping list — add/remove/check off nested items | Tier B, Maestro | P0 |
-| B7 | Group assignment on create, group-based filtering on list/home | Tier B, Maestro | P0 |
-| B8 | Tag assignment (add/remove), filter reminder list by tag | Tier B | P1 |
-| B9 | Priority selection reflected in list sort/badge | Tier B | P1 |
-| B10 | Note attachment link (create/edit reminder ↔ existing note) | Tier B | P1 |
-| B11 | File attachment add/remove | Tier A | P1 |
-| B12 | Google Task list linkage — **requires a signed-in Google test account; tag `manual`/skip in CI, cover with a fake-auth Tier B test of the UI wiring instead** | Tier B (fake auth) | P1 |
-| B13 | Google Calendar event creation + duration field | Tier B (fake calendar API) | P1 |
-| B14 | "Remind before" (before-time) field | Tier A | P1 |
-| B15 | Repeat time / interval / limit fields validated together (constraint rules from `BuilderItem` `constraints {}` blocks) | Tier A | P0 |
-| B16 | Constraint enforcement: selecting a blocked combination (e.g. Timer + Date) is prevented/clears the conflicting item | Tier A | P0 |
+| # | Test | Tool | Pri | Status |
+|---|---|---|---|---|
+| B1 | Phone call action — number entry + validation | Tier A | P1 | Done (as Tier B, not Tier A — see §5 intro) |
+| B2 | SMS action — number entry + validation | Tier A | P1 | Done (Tier B) |
+| B3 | Email action + subject field | Tier A | P1 | Done (Tier B) |
+| B4 | Web link action — URL validation | Tier A | P1 | Done (Tier B) |
+| B5 | Open-application action (SDK-gated, `maxSdk = S`) — confirm hidden above Android 12 | Tier A | P1 | Skipped — needs an API 31+ device, see note below |
+| B6 | Sub-tasks/shopping list — add/remove/check off nested items | Tier B, Maestro | P0 | Done — add + check only, see note below |
+| B7 | Group assignment on create, group-based filtering on list/home | Tier B, Maestro | P0 | Done — assignment only, see note below |
+| B8 | Tag assignment (add/remove), filter reminder list by tag | Tier B | P1 | |
+| B9 | Priority selection reflected in list sort/badge | Tier B | P1 | Done — selection only, see note below |
+| B10 | Note attachment link (create/edit reminder ↔ existing note) | Tier B | P1 | Done |
+| B11 | File attachment add/remove | Tier A | P1 | Skipped — real system file picker, see note below |
+| B12 | Google Task list linkage — **requires a signed-in Google test account; tag `manual`/skip in CI, cover with a fake-auth Tier B test of the UI wiring instead** | Tier B (fake auth) | P1 | |
+| B13 | Google Calendar event creation + duration field | Tier B (fake calendar API) | P1 | |
+| B14 | "Remind before" (before-time) field | Tier A | P1 | Done (Tier B) |
+| B15 | Repeat time / interval / limit fields validated together (constraint rules from `BuilderItem` `constraints {}` blocks) | Tier A | P0 | Done (Tier B) — one constraint, see note below |
+| B16 | Constraint enforcement: selecting a blocked combination (e.g. Timer + Date) is prevented/clears the conflicting item | Tier A | P0 | Done (Tier B) |
+
+Notes on the non-obvious Status values above:
+
+- **All of B1–B4/B6/B7/B9/B10/B14/B15/B16 were implemented as Tier B**, not the Tier A this
+  section originally specified — no `feature:*` module has ever gained its own `androidTest`
+  source set (see §2's status note), so every test so far lives in the one Tier-B flow-level file
+  and drives the full app instead of mounting an isolated composable. Functionally equivalent
+  coverage, just a heavier/slower test than originally planned.
+- **B5** wasn't implemented: its actual point is confirming the item is *hidden above* Android 12
+  (`maxSdk = S` on `ApplicationBuilderItem`), but the real device used for this suite so far is
+  API 30 — below the gate — so it can only ever prove the item is present, not that the gating
+  itself works. Needs an API 31+ device.
+- **B6** covers add (two items) and check-off, not remove: `ShopItemRow`'s remove button only
+  composes once its row is both focused *and* non-empty, and this suite has no proven way yet to
+  assert real Android focus state from a semantics-only interaction. Needed new `testTag`s on that
+  row's checkbox/remove buttons either way (`shopItemCheckTestTag`/`shopItemRemoveTestTag`,
+  `SubTasksValueEditor.kt`) since neither had any prior locator at all.
+- **B7** covers "assignment on create" only, not "group-based filtering on list/home" — that half
+  needs its own Home/list-screen investigation, folded into the new §G below rather than done here.
+- **B9** covers persisted selection only, not "reflected in list sort/badge" — same reasoning as
+  B7, that's a list/Home-screen rendering concern, see §G.
+- **B11** wasn't implemented: `AttachmentsValueEditor`'s `onPickFiles` opens the real Android
+  system file picker, a different app/Activity entirely — same category as B12/B13's Google-auth
+  flows, already flagged above as out of scope for CI.
+- **B15** covers one constraint (`RepeatLimitBuilderItem`'s `requiresAny`), not the full "repeat
+  time/interval/limit validated together" scope implied by the row — a reasonable next slice if
+  this area gets revisited.
 
 ### C. Notification customization (Settings → Group → Reminder hierarchy)
 
@@ -383,39 +457,60 @@ One row per field from `NotificationSettingsOverride`
 (`core/domain/.../reminder/v2/RecurrenceRule.kt` sibling `NotificationSettingsResolver.kt`); see
 §4's caveat about what's actually wired to delivery today.
 
-| # | Test | Level(s) | Tool | Pri |
-|---|---|---|---|---|
-| C1 | `vibrate` toggle: Settings default, Group override, Reminder override, "Inherit" resets to null | All 3 | Tier B | P0 |
-| C2 | `vibrationPattern` preset picker at all 3 levels (**PRO-only** — confirm hidden on free flavor) | All 3 | Tier B | P0 |
-| C3 | `repeatNotification` toggle at all 3 levels | All 3 | Tier B | P1 |
-| C4 | `priority` picker at all 3 levels, reflected in channel importance | All 3 | Tier B, Maestro | P0 |
-| C5 | `category` picker at all 3 levels | All 3 | Tier B | P1 |
-| C6 | `bypassDoNotDisturb` toggle at all 3 levels | All 3 | Tier B, Maestro | P0 |
-| C7 | `wakeScreen` toggle at all 3 levels | All 3 | Tier B | P1 |
-| C8 | `lockScreenVisibility` picker at all 3 levels | All 3 | Tier B | P1 |
-| C9 | `delayMinutes` override (switch + slider dialog, distinct UI from the other fields) at all 3 levels | All 3 | Tier B | P1 |
-| C10 | LED `color` picker — Settings-level only (frozen at Group/Reminder except builder), **PRO-only** | Settings + Reminder builder | Tier B | P1 |
-| C11 | "How does this work?" help screen opens from both Settings and Group editor entry points | Settings, Group | Tier A | P1 |
-| C12 | Subtitle text shows `"Inherited: <effective value>"` vs the explicit override label correctly after each save | Group, Reminder | Tier B | P0 |
+| # | Test | Level(s) | Tool | Pri | Status |
+|---|---|---|---|---|---|
+| C1 | `vibrate` toggle: Settings default, Group override, Reminder override, "Inherit" resets to null | All 3 | Tier B | P0 | Deferred |
+| C2 | `vibrationPattern` preset picker at all 3 levels (**PRO-only** — confirm hidden on free flavor) | All 3 | Tier B | P0 | Deferred |
+| C3 | `repeatNotification` toggle at all 3 levels | All 3 | Tier B | P1 | Deferred |
+| C4 | `priority` picker at all 3 levels, reflected in channel importance | All 3 | Tier B, Maestro | P0 | Deferred |
+| C5 | `category` picker at all 3 levels | All 3 | Tier B | P1 | Deferred |
+| C6 | `bypassDoNotDisturb` toggle at all 3 levels | All 3 | Tier B, Maestro | P0 | Deferred |
+| C7 | `wakeScreen` toggle at all 3 levels | All 3 | Tier B | P1 | Deferred |
+| C8 | `lockScreenVisibility` picker at all 3 levels | All 3 | Tier B | P1 | Deferred |
+| C9 | `delayMinutes` override (switch + slider dialog, distinct UI from the other fields) at all 3 levels | All 3 | Tier B | P1 | Deferred |
+| C10 | LED `color` picker — Settings-level only (frozen at Group/Reminder except builder), **PRO-only** | Settings + Reminder builder | Tier B | P1 | Deferred |
+| C11 | "How does this work?" help screen opens from both Settings and Group editor entry points | Settings, Group | Tier A | P1 | Deferred |
+| C12 | Subtitle text shows `"Inherited: <effective value>"` vs the explicit override label correctly after each save | Group, Reminder | Tier B | P0 | Deferred |
+
+Whole section deferred by project decision, together with §A's custom-RRULE rows (A18–A24) — not
+started, waiting to be picked up as one batch.
 
 ### D. Notification delivery under different app settings
 
-| # | Test | Tool | Pri |
-|---|---|---|---|
-| D1 | Quiet hours disabled → notification fires normally at due time | Maestro | P0 |
-| D2 | Quiet hours enabled, due time inside window, priority below `doNotDisturbIgnore` → suppressed | Maestro | P0 |
-| D3 | Quiet hours enabled, due time inside window, priority ≥ `doNotDisturbIgnore` → still fires | Maestro | P0 |
-| D4 | Quiet hours `doNotDisturbIgnore = 5` ("ignore all") → suppressed regardless of priority | Maestro | P0 |
-| D5 | Quiet hours enabled but due time outside the window → fires normally | Maestro | P1 |
-| D6 | `repeatNotification` enabled → re-alerts at interval until dismissed/opened | Maestro | P1 |
-| D7 | `POST_NOTIFICATIONS` permission denied (Android 13+) → app doesn't crash; in-app prompt shown; no system notification posted | Maestro | P0 |
-| D8 | Permission granted after initial denial (via deep-linked system Settings) → subsequent reminders fire | Maestro | P1 |
-| D9 | Tapping a fired notification opens the correct reminder preview/edit screen (deep link) | Maestro | P0 |
-| D10 | Dismissing (swipe-away) vs. tapping a notification action updates reminder state accordingly | Maestro | P1 |
-| D11 | Wear/companion notification (`WEAR_NOTIFICATION` pref) posts a secondary notification when enabled | Maestro | P2 |
-| D12 | Global default priority applied to a new reminder created with no explicit override | Tier B | P1 |
+| # | Test | Tool | Pri | Status |
+|---|---|---|---|---|
+| D1 | Quiet hours disabled → notification fires normally at due time | Maestro | P0 | Done |
+| D2 | Quiet hours enabled, due time inside window, priority below `doNotDisturbIgnore` → suppressed | Maestro | P0 | Done |
+| D3 | Quiet hours enabled, due time inside window, priority ≥ `doNotDisturbIgnore` → still fires | Maestro | P0 | Done |
+| D4 | Quiet hours `doNotDisturbIgnore = 5` ("ignore all") → suppressed regardless of priority | Maestro | P0 | Done |
+| D5 | Quiet hours enabled but due time outside the window → fires normally | Maestro | P1 | |
+| D6 | `repeatNotification` enabled → re-alerts at interval until dismissed/opened | Maestro | P1 | |
+| D7 | `POST_NOTIFICATIONS` permission denied (Android 13+) → app doesn't crash; in-app prompt shown; no system notification posted | Maestro | P0 | Done — written, not verifiable on the API 30 device used so far, see note below |
+| D8 | Permission granted after initial denial (via deep-linked system Settings) → subsequent reminders fire | Maestro | P1 | |
+| D9 | Tapping a fired notification opens the correct reminder preview/edit screen (deep link) | Maestro | P0 | Done — corrected target screen, see note below |
+| D10 | Dismissing (swipe-away) vs. tapping a notification action updates reminder state accordingly | Maestro | P1 | |
+| D11 | Wear/companion notification (`WEAR_NOTIFICATION` pref) posts a secondary notification when enabled | Maestro | P2 | |
+| D12 | Global default priority applied to a new reminder created with no explicit override | Tier B | P1 | |
+
+Notes on the non-obvious Status values above:
+
+- **D1–D4** were also tightened after implementation: the flows originally asserted on the generic
+  app-name text every reminder's notification shows (so a run could pass even if some other, wrong
+  reminder's notification fired). They now seed each reminder with a unique Summary and assert on
+  that instead — a real device run confirmed the original assertion was too weak to actually prove
+  which notification fired.
+- **D7** (`notification_permission_denied.yaml`) is written and structurally sound, but this
+  suite's real device is API 30, where `POST_NOTIFICATIONS` isn't a runtime permission at all —
+  there's no dialog for it to deny, so the flow's actual "Don't allow" step has never run for real.
+  It'll get genuine coverage the next time this runs against CI's API 34 target.
+- **D9** (`tap_notification_opens_reminder.yaml`) corrects an assumption this row's own description
+  made: reading `ReminderNotificationHandler.contentPendingIntent` shows tapping a notification
+  actually opens `ReminderActionActivity` (the Complete/Snooze action picker), not a preview/edit
+  screen. The implemented flow asserts against that real target instead.
 
 ### E. Settings screens
+
+**Status: not started** (no Status column below — every row is still just planned).
 
 Covers the settings surface currently mid-migration into `feature/featuresettings` (per this
 branch's in-flight work) — write these against whichever module owns the screen by the time this
@@ -435,6 +530,8 @@ lands.
 
 ### F. Cross-cutting / regression-prone
 
+**Status: not started** (no Status column below — every row is still just planned).
+
 | # | Test | Tool | Pri |
 |---|---|---|---|
 | F1 | Free vs. Pro flavor gating: PRO-only builder items (LED color, vibration pattern, Other Params, Insights) hidden/disabled on `free` flavor build | Tier A (run against `assembleFreeDebug` build separately — see `CLAUDE.md`'s free-flavor caveat) | P0 |
@@ -445,17 +542,84 @@ lands.
 | F6 | Multi-select bulk actions on reminder list (long-press → select → bulk delete/complete, per [multiselect.md](multiselect.md)) | Tier B, Maestro | P0 |
 | F7 | Widget configuration screens open without crashing (actual home-screen widget rendering is out of scope — Maestro/Espresso can't drive the launcher) | Tier A | P2 |
 
+**F4 correction**: there is no separate global-search screen — the only search UI found is the
+`SearchBar` embedded directly in `AgendaScreen`/`RemindersArchiveScreen`, each filtering that
+screen's own list. F4 should be read as "search within Agenda/Archive," not a cross-content
+search surface; confirm against `AgendaViewModel.onSearchQueryChange` before writing it.
+
+### G. Reminder appearance across screens
+
+**Status: not started.** Everything in §A/§B/§D so far asserts on what got *persisted* through
+the builder — nothing yet asserts on what a reminder actually *looks like* once it exists, across
+the different screens that render one. This section was added once enough of the rest existed to
+make that gap obvious, and is grounded in reading the actual screens/adapters rather than guessed
+— see the notes after the table for specifics and open questions.
+
+Several screens turn out to share one underlying text/row adapter
+(`UiReminderListAdapterImpl.createV2()` → `UiReminderList`), so a bug in that adapter would show
+up identically on Home, Agenda, and the Group details screen — worth keeping in mind when
+prioritizing: G5/G7 below are as much a regression check on that shared adapter as they are
+screen-specific.
+
+| # | Test | Tool | Pri |
+|---|---|---|---|
+| G1 | Home: a reminder with a Summary set shows that text as the row's title (`GetActiveEventsForTheDayUseCase.createMainText`) | Tier B | P0 |
+| G2 | Home: a reminder with no Summary (e.g. shopping-list-only) falls back to the `"(description)"` placeholder text | Tier B | P1 |
+| G3 | Home only shows today's active, non-removed reminders — one scheduled for tomorrow, already completed/inactive, or removed doesn't appear (`observeActiveInRange`'s date range + `active`/`removed` filters) | Tier B | P0 |
+| G4 | Agenda screen (the "reminder list" §F2 already refers to): smart-list filters (Today / Overdue / This week / No group) each show the correct subset | Tier B | P0 |
+| G5 | Agenda screen: a reminder row renders summary/placeholder text, due-date/place secondary text, and repeat/remaining/group tag chips correctly, plus an "Enabled" status chip and its Open/Edit/Archive/Skip/Turn-off row menu | Tier B | P1 |
+| G6 | Agenda screen: its embedded search filters the list by reminder text (see the F4 correction above — this *is* what "global search" means today) | Tier B | P1 |
+| G7 | Group details screen: a member reminder's row renders the same summary/date/tag chips as Agenda (same underlying `UiReminderList` adapter) but with **no status chip and no row menu** — click-only navigation to open it | Tier B | P1 |
+| G8 | Archive screen: a removed reminder's row renders summary/date/tags with **only Edit and Delete** in its menu, no status chip, and — confirmed by reading `RemindersArchiveViewModel`/`ArchiveReminderRow` — **no restore/un-archive action exists anywhere on the row at all**; the only way back to active is via Edit. Worth a test asserting that absence explicitly, since it's easy to accidentally "fix" as a bug later without realizing it's the current intended behavior | Tier B | P1 |
+| G9 | Preview screen: Enabled/Disabled status text + toggle switch reflects and changes the reminder's active state | Tier B | P0 |
+| G10 | Preview screen: Details section (summary, description, due date, remind-before, repeat text, remaining time, group title, priority title, tags, ID) renders correctly for a fully-populated reminder | Tier B | P1 |
+| G11 | Preview screen: action-target section renders contact name + raw phone number for Call/SMS, contact name + email + subject for Email, and the URL for Link — correctly hidden for Shopping/None | Tier B | P1 |
+| G12 | Preview screen: attachments (image thumbnail vs. file-type icon), sub-tasks (checked count, strikethrough), map/place address, note-link card, Google Task card, and calendar-event cards each render when the reminder has that data | Tier B | P1 |
+| G13 | Preview screen: overflow menu (Edit/Share/Copy/Delete) — Copy only appears when `state.canCopy`, and the delete confirmation dialog's text switches between "Delete" and "Move to the archive" depending on `state.canDelete` | Tier B | P1 |
+| G14 | Action screen (`ReminderActionActivity`, opened from a fired notification or in-app): header renders contact photo/icon + name + phone number for Call/SMS, email + subject for Email, resolved app name (not raw target) for App, and URL text for Link — summary-only for Shopping/None | Tier B | P1 |
+| G15 | Action screen: main + secondary action buttons render correctly — a single full-width button when only one action is available, a split button with an overflow menu when there are several | Tier B | P1 |
+
+**Open question — resolve before writing a test for it, don't guess**: does `ReminderActionScreen`
+need to suppress Snooze for location reminders the way the *fired system notification* already
+does? `ReminderNotificationHandler.extraActions` excludes Snooze when `places.isNotEmpty()`, but
+`GetReminderActionsUseCase` (which drives this in-app screen) filters only on
+`isActive`/`isRemoved` — no location check at all. So a location reminder opened from its
+notification shows no Snooze button, but the same reminder reached another way would. This may be
+intentional (notification vs. in-app context genuinely differ) or a gap — confirm intent with
+whoever owns this screen before treating either behavior as "correct."
+
+**Two more render paths exist but are out of scope here**, consistent with how §F already treats
+similar cases:
+- **Calendar day view** (`feature/feature-calendar`) reuses the same `UiReminderListAdapter` output
+  as Agenda (confirmed via `GetDayEventItemsUseCase`), so it's very likely covered by the same
+  underlying adapter bug surface as G5/G7 — but its own rendering composable wasn't confirmed here
+  and would need its own look before writing a row.
+- **Home-screen widget list** (`extensions/appwidgets`) uses a completely separate,
+  RemoteViews-based adapter (`UiReminderWidgetListAdapter`), not the Compose one everything else in
+  this section shares — already out of scope per F7 ("actual home-screen widget rendering is out
+  of scope — Maestro/Espresso can't drive the launcher").
+
 ---
 
 ## 6. Rollout suggestion
 
-1. Land the Gradle/module wiring (§2) and the GitHub Actions job (§3) with just **A1–A4, A6, A9,
+1. ~~Land the Gradle/module wiring (§2) and the GitHub Actions job (§3) with just **A1–A4, A6, A9,
    A12** (one Tier-B test per core recurrence family) and **D1–D4** (quiet-hours) to prove the
-   pipeline end-to-end before writing the full matrix.
+   pipeline end-to-end before writing the full matrix.~~ **Done.**
 2. Fill in the rest of §A (edge cases) and §C (notification hierarchy) next — these are the areas
    explicitly called out as needing coverage and are where `RecurrenceRuleCalculator` and the
    Settings/Group/Reminder override resolution have the most surface area for regressions.
+   **Partially done**: §A's edge cases and most of its P0/P1 rows are covered (see the Status
+   column in §5) other than location (A15–A17), custom RRULE (A18–A24, explicitly deferred by
+   project decision), and a handful of others (A25, A27 skipped, A28, A29). **§C (notification
+   hierarchy) hasn't been started at all** — still deferred by the same decision as the RRULE
+   rows, waiting to be picked up together in one batch per §4's wiring caveat.
 3. §B/§E/§F can land incrementally as each screen stabilizes, especially given `feature-reminder`
    and the settings feature module are both still under active extraction into their own Gradle
    modules on this branch — a screen's exact package/module home may move before these tests are
-   written.
+   written. **Most of §B is now done** (see its Status column) — B8 (tags), B12/B13 (Google
+   linkage), and the file/app-picker rows (B5, B11) remain. **§E and §F haven't been started.**
+4. **New, not in the original plan**: §G below (reminder appearance across Home, list, Preview,
+   and the notification Action screen) — added once enough of §A/§B/§D existed to reveal this as
+   a real gap: none of the tests so far assert on what a reminder actually *looks like* once
+   created, only on what got persisted. Not yet started.

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -247,6 +247,15 @@ Notes:
   `smoke`-tagged Maestro subset + Tier-A/B Compose tests on every PR (one API level, e.g. 34),
   and the full matrix + full Maestro tag set on `master`-merge / nightly, to keep PR feedback
   fast.
+- **Nightly failure notification**: `test_e2e` (the job as actually implemented in
+  `build_and_test.yml` — single API level 34, schedule-triggered only, not the illustrative 5-cell
+  matrix above) keeps one persistent GitHub Issue labeled `e2e-nightly-failure` as its status: a
+  failing run opens/reopens it with a comment linking the run and the commit range since the last
+  green nightly run (via the Actions API, filtered to `event: schedule`, `status: success`); the
+  next passing run comments and closes it. This is how "did last night's merge break e2e" gets
+  surfaced without anyone having to read through Actions run history — there's no separate
+  historical trend dashboard, since GitHub's own Actions run list already shows that chronologically
+  per-run.
 - **Always use the `pro` flavor debug variant** here per this repo's existing convention (never
   `free`, unless the change is free-flavor-specific) — matches
   `applicationId = "com.cray.software.justreminderpro"`.

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/reminder/compose/RecurrenceRuleCalculator.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/reminder/compose/RecurrenceRuleCalculator.kt
@@ -156,7 +156,7 @@ internal class RecurrenceRuleCalculator(
     val repeatInterval = (itemsMap[BiType.REPEAT_INTERVAL] as? RepeatIntervalBuilderItem)?.modifier?.getValue() ?: 1L
     val repeatLimit = readRepeatLimit(itemsMap)
 
-    val localDateTime = LocalDateTime.of(LocalDate.now(), time)
+    val localDateTime = LocalDateTime.of(dateTimeManager.getCurrentDate(), time)
     val nextLocal =
       recurrenceCalculator.findNextMonthDayDateTime(
         eventDateTime = localDateTime,
@@ -180,12 +180,12 @@ internal class RecurrenceRuleCalculator(
   private fun fromDayOfYear(itemsMap: Map<BiType, BuilderItem<*>>): ComposedRecurrence? {
     val time = (itemsMap[BiType.TIME] as? TimeBuilderItem)?.modifier?.getValue() ?: return null
     val dayOfYear = (itemsMap[BiType.DAY_OF_YEAR] as? DayOfYearBuilderItem)?.modifier?.getValue() ?: return null
-    val derivedDate = runCatching { LocalDate.now().withDayOfYear(dayOfYear) }.getOrNull() ?: return null
+    val derivedDate = runCatching { dateTimeManager.getCurrentDate().withDayOfYear(dayOfYear) }.getOrNull() ?: return null
 
     val repeatInterval = (itemsMap[BiType.REPEAT_INTERVAL] as? RepeatIntervalBuilderItem)?.modifier?.getValue() ?: 1L
     val repeatLimit = readRepeatLimit(itemsMap)
 
-    val localDateTime = LocalDateTime.of(LocalDate.now(), time)
+    val localDateTime = LocalDateTime.of(dateTimeManager.getCurrentDate(), time)
     val nextLocal =
       recurrenceCalculator.findNextYearDayDateTime(
         eventDateTime = localDateTime,

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/valuedialog/editor/SubTasksValueEditor.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/valuedialog/editor/SubTasksValueEditor.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -49,6 +50,16 @@ import com.github.naz013.datecalc.DateTimeManager
 import com.github.naz013.domain.reminder.ShopItem
 
 private val LIST_MAX_HEIGHT = 400.dp
+
+/** Semantics test tag for a shopping-list row's checkbox, parameterized by [itemId] (`ShopItem
+ *  .uuId`) since a list can have several rows and the checkbox itself carries no text/content
+ *  description (see [ShopItemRow]). Exposed so instrumented tests can toggle a specific row via
+ *  `onNodeWithTag(shopItemCheckTestTag(item.uuId))`. */
+fun shopItemCheckTestTag(itemId: String): String = "shop_item_check_$itemId"
+
+/** Same as [shopItemCheckTestTag] but for a row's remove button - only composed once that row is
+ *  focused with non-empty text (see [ShopItemRow]). */
+fun shopItemRemoveTestTag(itemId: String): String = "shop_item_remove_$itemId"
 
 /**
  * Editable shopping/checklist grid: type to add text, Enter/Done adds the next row and focuses
@@ -115,7 +126,10 @@ private fun ShopItemRow(
   }
 
   Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-    IconButton(onClick = onCheckClick, modifier = Modifier.size(40.dp)) {
+    IconButton(
+      onClick = onCheckClick,
+      modifier = Modifier.size(40.dp).testTag(shopItemCheckTestTag(item.uuId)),
+    ) {
       Icon(
         painter = painterResource(
           if (item.isChecked) R.drawable.ic_fluent_checkbox_checked else R.drawable.ic_fluent_checkbox_unchecked,
@@ -163,7 +177,10 @@ private fun ShopItemRow(
       )
     }
     if (isFocused && text.isNotEmpty()) {
-      IconButton(onClick = onRemoveClick, modifier = Modifier.size(40.dp)) {
+      IconButton(
+        onClick = onRemoveClick,
+        modifier = Modifier.size(40.dp).testTag(shopItemRemoveTestTag(item.uuId)),
+      ) {
         Icon(
           imageVector = Icons.Filled.Close,
           contentDescription = null,

--- a/feature/feature-reminder/src/test/kotlin/com/github/naz013/feature/reminder/build/reminder/compose/RecurrenceRuleCalculatorTest.kt
+++ b/feature/feature-reminder/src/test/kotlin/com/github/naz013/feature/reminder/build/reminder/compose/RecurrenceRuleCalculatorTest.kt
@@ -48,6 +48,7 @@ class RecurrenceRuleCalculatorTest : BaseTest() {
     super.setUp()
     every { dateTimeManager.localToUtc(any()) } answers { firstArg() }
     every { dateTimeManager.getCurrentDateTime() } returns NOW
+    every { dateTimeManager.getCurrentDate() } returns NOW.toLocalDate()
     calculator = RecurrenceRuleCalculator(dateTimeManager, iCalDateTimeCalculator, recurrenceCalculator)
   }
 
@@ -134,7 +135,7 @@ class RecurrenceRuleCalculatorTest : BaseTest() {
       recurrenceCalculator.findNextYearDayDateTime(any(), any(), any(), any(), any())
     } returns NOW
 
-    val dayOfYear = LocalDate.of(LocalDate.now().year, 3, 10).dayOfYear
+    val dayOfYear = LocalDate.of(NOW.toLocalDate().year, 3, 10).dayOfYear
     val items = itemsOf(timeItem(NOW.toLocalTime()), dayOfYearItem(dayOfYear))
 
     val result = calculator(items)

--- a/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/KoinModule.kt
+++ b/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/KoinModule.kt
@@ -1,6 +1,7 @@
 package com.github.naz013.ui.common
 
 import com.github.naz013.datecalc.NowDateTimeProvider
+import com.github.naz013.datecalc.NowDateTimeProviderImpl
 import com.github.naz013.ui.common.compose.foundation.share.FileIntentSender
 import com.github.naz013.ui.common.compose.foundation.share.FileIntentSenderImpl
 import com.github.naz013.ui.common.compose.foundation.telephony.ApplicationLauncher
@@ -29,7 +30,7 @@ val uiCommonModule = module {
   singleOf(::ThemeModeHolder)
   singleOf(::Language)
   singleOf(::ModelDateTimeFormatter)
-  singleOf(::NowDateTimeProvider)
+  singleOf<NowDateTimeProvider>(::NowDateTimeProviderImpl)
 
   factoryOf(::ColorProvider)
   factoryOf(::UnitsConverter)

--- a/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/component/BuilderListItemCard.kt
+++ b/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/component/BuilderListItemCard.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -33,6 +34,13 @@ import com.github.naz013.ui.common.R as UiCommonR
  *  small status dot drawn over the leading icon. Mirrors the legacy
  *  `builder_badge_state_empty`/`_ok`/`_error` drawables. */
 enum class BuilderItemStatus { EMPTY, DONE, ERROR }
+
+/** Semantics test tag for a [BuilderListItemCard]'s remove button, parameterized by [title] since
+ *  several rows (one per active builder item) can be on screen at once and the button itself only
+ *  carries an icon (`contentDescription = null`, see that `IconButton`) with no other text to
+ *  locate it by. Exposed so instrumented tests can target one specific row's remove button via
+ *  `onNodeWithTag(builderItemRemoveTestTag(title))` instead of guessing at the semantics tree. */
+fun builderItemRemoveTestTag(title: String): String = "builder_item_remove_$title"
 
 /**
  * A single row in the reminder builder list: leading icon with a status dot, title, a value
@@ -114,7 +122,12 @@ fun BuilderListItemCard(
         }
       }
 
-      IconButton(onClick = onRemoveClick, modifier = Modifier.padding(top = 4.dp, end = 8.dp)) {
+      IconButton(
+        onClick = onRemoveClick,
+        modifier = Modifier
+          .padding(top = 4.dp, end = 8.dp)
+          .testTag(builderItemRemoveTestTag(title)),
+      ) {
         Icon(
           painter = removeIcon,
           contentDescription = null,


### PR DESCRIPTION
Makes NowDateTimeProvider a fakeable interface and routes RecurrenceRuleCalculator's day-of-month/day-of-year paths through DateTimeManager instead of calling LocalDate.now() directly, so date-relative recurrence edge cases can be driven deterministically in instrumented tests instead of depending on the real device clock.

Adds FakeNowDateTimeProvider plus new Tier-B e2e tests: weekly on multiple weekdays, monthly/yearly with repeat interval and limit, the "last day of month" and Feb 29 leap-year rollover edge cases, and editing an existing reminder to change its recurrence type. The last one also needed a testTag on BuilderListItemCard's remove button, which previously had no locator a test could use.