### PR TITLE
REM-1155 - Complete reminder when notification is dismissed

### DIFF
--- a/app/src/main/java/com/elementary/tasks/core/services/action/NotificationAlertActionHandler.kt
+++ b/app/src/main/java/com/elementary/tasks/core/services/action/NotificationAlertActionHandler.kt
@@ -46,11 +46,13 @@ abstract class NotificationAlertActionHandler<T>(
     builder.setContentIntent(contentPendingIntent(data))
     style.decorate(builder, contextProvider)
 
+    val dismissPendingIntent = actionPendingIntent(data, dismissActionKey())
     builder.addAction(
       R.drawable.ic_fluent_checkmark,
       textProvider.getText(R.string.ok),
-      actionPendingIntent(data, dismissActionKey()),
+      dismissPendingIntent,
     )
+    builder.setDeleteIntent(dismissPendingIntent)
     extraActions(data).forEach { action ->
       builder.addAction(action.icon, action.label, actionPendingIntent(data, action.actionKey))
     }

--- a/app/src/main/java/com/elementary/tasks/core/services/action/NotificationAlertActionHandler.kt
+++ b/app/src/main/java/com/elementary/tasks/core/services/action/NotificationAlertActionHandler.kt
@@ -36,7 +36,7 @@ abstract class NotificationAlertActionHandler<T>(
 
     val builder = NotificationCompat.Builder(contextProvider.context, channelId(data))
     builder.setAutoCancel(false)
-    builder.setOngoing(true)
+    builder.setOngoing(isOngoing(data))
     builder.setContentTitle(contentTitle(data))
     contentText(data)?.also { builder.setContentText(it) }
     vibrationPattern(data)?.also { builder.setVibrate(it) }
@@ -99,6 +99,11 @@ abstract class NotificationAlertActionHandler<T>(
    *  [Notifier.reminderChannelId]) when a field needs to vary per notification on Android 8+,
    *  where a channel's importance/vibration/DND-bypass are locked at creation. */
   protected open fun channelId(data: T): String = Notifier.CHANNEL_REMINDER
+
+  /** Whether this notification blocks swipe-dismissal. Defaults to true (current behavior for
+   *  every domain); override to let a domain's own settings opt out and allow swipe, which - via
+   *  the shared [setDeleteIntent] wiring above - completes the item exactly like tapping OK. */
+  protected open fun isOngoing(data: T): Boolean = true
 
   protected abstract fun receiverClass(): Class<out BroadcastReceiver>
 

--- a/app/src/main/java/com/elementary/tasks/core/services/action/reminder/process/ReminderNotificationHandler.kt
+++ b/app/src/main/java/com/elementary/tasks/core/services/action/reminder/process/ReminderNotificationHandler.kt
@@ -24,7 +24,7 @@ class ReminderNotificationHandler(
   contextProvider: ContextProvider,
   textProvider: TextProvider,
   private val notifier: Notifier,
-  prefs: Prefs,
+  private val prefs: Prefs,
   wearNotification: WearNotification,
   style: NotificationStyle,
 ) : NotificationAlertActionHandler<ReminderV2>(
@@ -42,6 +42,8 @@ class ReminderNotificationHandler(
   override fun receiverClass(): Class<out BroadcastReceiver> = ReminderActionReceiver::class.java
 
   override fun dismissActionKey(): String = ReminderActionReceiver.ACTION_HIDE
+
+  public override fun isOngoing(data: ReminderV2): Boolean = !prefs.isDefaultSwipeToDismissEnabled
 
   override fun extraActions(data: ReminderV2): List<NotificationAction> =
     if (data.places.isEmpty()) {

--- a/app/src/main/java/com/elementary/tasks/core/utils/params/Prefs.kt
+++ b/app/src/main/java/com/elementary/tasks/core/utils/params/Prefs.kt
@@ -361,6 +361,10 @@ class Prefs(
     get() = getBoolean(PrefsConstants.DEFAULT_WAKE_SCREEN, def = false)
     set(value) = putBoolean(PrefsConstants.DEFAULT_WAKE_SCREEN, value)
 
+  var isDefaultSwipeToDismissEnabled: Boolean
+    get() = getBoolean(PrefsConstants.DEFAULT_SWIPE_TO_DISMISS, def = false)
+    set(value) = putBoolean(PrefsConstants.DEFAULT_SWIPE_TO_DISMISS, value)
+
   var defaultLockScreenVisibility: String
     get() = getString(PrefsConstants.DEFAULT_LOCK_SCREEN_VISIBILITY, def = "PRIVATE")
     set(value) = putString(PrefsConstants.DEFAULT_LOCK_SCREEN_VISIBILITY, value)

--- a/app/src/main/java/com/elementary/tasks/core/utils/params/Prefs.kt
+++ b/app/src/main/java/com/elementary/tasks/core/utils/params/Prefs.kt
@@ -362,7 +362,7 @@ class Prefs(
     set(value) = putBoolean(PrefsConstants.DEFAULT_WAKE_SCREEN, value)
 
   var isDefaultSwipeToDismissEnabled: Boolean
-    get() = getBoolean(PrefsConstants.DEFAULT_SWIPE_TO_DISMISS, def = false)
+    get() = getBoolean(PrefsConstants.DEFAULT_SWIPE_TO_DISMISS, def = true)
     set(value) = putBoolean(PrefsConstants.DEFAULT_SWIPE_TO_DISMISS, value)
 
   var defaultLockScreenVisibility: String

--- a/app/src/main/java/com/elementary/tasks/core/utils/params/PrefsConstants.kt
+++ b/app/src/main/java/com/elementary/tasks/core/utils/params/PrefsConstants.kt
@@ -111,6 +111,7 @@ object PrefsConstants {
   const val DEFAULT_NOTIFICATION_CATEGORY = "default_notification_category"
   const val DEFAULT_BYPASS_DO_NOT_DISTURB = "default_bypass_do_not_disturb"
   const val DEFAULT_WAKE_SCREEN = "default_wake_screen"
+  const val DEFAULT_SWIPE_TO_DISMISS = "default_swipe_to_dismiss"
   const val DEFAULT_LOCK_SCREEN_VISIBILITY = "default_lock_screen_visibility"
 
   const val REMINDER_V2_BACKFILL_DONE = "reminder_v2_backfill_done"

--- a/app/src/main/java/com/elementary/tasks/module/logicreminder/ReminderPreferencesImpl.kt
+++ b/app/src/main/java/com/elementary/tasks/module/logicreminder/ReminderPreferencesImpl.kt
@@ -116,6 +116,10 @@ class ReminderPreferencesImpl(
     get() = prefs.isDefaultWakeScreenEnabled
     set(value) { prefs.isDefaultWakeScreenEnabled = value }
 
+  override var isDefaultSwipeToDismissEnabled: Boolean
+    get() = prefs.isDefaultSwipeToDismissEnabled
+    set(value) { prefs.isDefaultSwipeToDismissEnabled = value }
+
   override var defaultLockScreenVisibility: String
     get() = prefs.defaultLockScreenVisibility
     set(value) { prefs.defaultLockScreenVisibility = value }

--- a/app/src/main/java/com/elementary/tasks/settings/SettingsCrossFeatureEntries.kt
+++ b/app/src/main/java/com/elementary/tasks/settings/SettingsCrossFeatureEntries.kt
@@ -122,6 +122,7 @@ fun RemindersCrossFeatureEntry(
       onDefaultVibrateToggle = viewModel::onDefaultVibrateToggle,
       onDefaultBypassDoNotDisturbToggle = viewModel::onDefaultBypassDoNotDisturbToggle,
       onDefaultWakeScreenToggle = viewModel::onDefaultWakeScreenToggle,
+      onDefaultSwipeToDismissToggle = viewModel::onDefaultSwipeToDismissToggle,
       onDefaultCategoryClick = viewModel::onDefaultCategoryClick,
       onDefaultLockScreenVisibilityClick = viewModel::onDefaultLockScreenVisibilityClick,
       onDefaultVibrationPatternClick = viewModel::onDefaultVibrationPatternClick,

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/settings/RemindersSettingsScreen.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/settings/RemindersSettingsScreen.kt
@@ -49,6 +49,7 @@ fun RemindersSettingsScreen(
   onDefaultVibrateToggle: () -> Unit,
   onDefaultBypassDoNotDisturbToggle: () -> Unit,
   onDefaultWakeScreenToggle: () -> Unit,
+  onDefaultSwipeToDismissToggle: () -> Unit,
   onDefaultCategoryClick: () -> Unit,
   onDefaultLockScreenVisibilityClick: () -> Unit,
   onDefaultVibrationPatternClick: () -> Unit,
@@ -164,6 +165,7 @@ fun RemindersSettingsScreen(
         onClick = onLedColorClick,
       )
     }
+    
 
     SettingsSectionHeader(stringResource(R.string.status_bar))
 
@@ -288,6 +290,14 @@ fun RemindersSettingsScreen(
       onCheckedChange = { onDefaultWakeScreenToggle() },
       subtitleOn = stringResource(R.string.wake_screen_enabled),
       subtitleOff = stringResource(R.string.wake_screen_disabled),
+      dividerBottom = true,
+    )
+    SettingsSwitchItem(
+      title = stringResource(R.string.allow_swipe_to_dismiss),
+      checked = state.isDefaultSwipeToDismissChecked,
+      onCheckedChange = { onDefaultSwipeToDismissToggle() },
+      subtitleOn = stringResource(R.string.allow_swipe_to_dismiss_enabled),
+      subtitleOff = stringResource(R.string.allow_swipe_to_dismiss_disabled),
       dividerBottom = true,
     )
     SettingsItem(

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/settings/RemindersSettingsScreen.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/settings/RemindersSettingsScreen.kt
@@ -165,7 +165,6 @@ fun RemindersSettingsScreen(
         onClick = onLedColorClick,
       )
     }
-    
 
     SettingsSectionHeader(stringResource(R.string.status_bar))
 

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/settings/RemindersSettingsScreen.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/settings/RemindersSettingsScreen.kt
@@ -166,6 +166,15 @@ fun RemindersSettingsScreen(
       )
     }
 
+    SettingsSwitchItem(
+      title = stringResource(R.string.allow_swipe_to_dismiss),
+      checked = state.isDefaultSwipeToDismissChecked,
+      onCheckedChange = { onDefaultSwipeToDismissToggle() },
+      subtitleOn = stringResource(R.string.allow_swipe_to_dismiss_enabled),
+      subtitleOff = stringResource(R.string.allow_swipe_to_dismiss_disabled),
+      dividerBottom = true,
+    )
+
     SettingsSectionHeader(stringResource(R.string.status_bar))
 
     SettingsSwitchItem(
@@ -289,14 +298,6 @@ fun RemindersSettingsScreen(
       onCheckedChange = { onDefaultWakeScreenToggle() },
       subtitleOn = stringResource(R.string.wake_screen_enabled),
       subtitleOff = stringResource(R.string.wake_screen_disabled),
-      dividerBottom = true,
-    )
-    SettingsSwitchItem(
-      title = stringResource(R.string.allow_swipe_to_dismiss),
-      checked = state.isDefaultSwipeToDismissChecked,
-      onCheckedChange = { onDefaultSwipeToDismissToggle() },
-      subtitleOn = stringResource(R.string.allow_swipe_to_dismiss_enabled),
-      subtitleOff = stringResource(R.string.allow_swipe_to_dismiss_disabled),
       dividerBottom = true,
     )
     SettingsItem(

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/settings/RemindersSettingsState.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/settings/RemindersSettingsState.kt
@@ -27,6 +27,7 @@ data class RemindersSettingsState(
   val isDefaultVibrateChecked: Boolean = false,
   val isDefaultBypassDoNotDisturbChecked: Boolean = false,
   val isDefaultWakeScreenChecked: Boolean = false,
+  val isDefaultSwipeToDismissChecked: Boolean = false,
   val defaultCategoryName: String = "",
   val defaultLockScreenVisibilityName: String = "",
   val defaultVibrationPatternName: String = "",

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/settings/RemindersSettingsViewModel.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/settings/RemindersSettingsViewModel.kt
@@ -243,6 +243,11 @@ class RemindersSettingsViewModel(
     refreshState()
   }
 
+  fun onDefaultSwipeToDismissToggle() {
+    reminderPreferences.isDefaultSwipeToDismissEnabled = !reminderPreferences.isDefaultSwipeToDismissEnabled
+    refreshState()
+  }
+
   fun onDefaultCategoryClick() {
     showChoiceDialog(
       kind = ChoiceDialogKind.CATEGORY,
@@ -355,6 +360,7 @@ class RemindersSettingsViewModel(
       isDefaultVibrateChecked = reminderPreferences.isDefaultVibrateEnabled,
       isDefaultBypassDoNotDisturbChecked = reminderPreferences.isDefaultBypassDoNotDisturbEnabled,
       isDefaultWakeScreenChecked = reminderPreferences.isDefaultWakeScreenEnabled,
+      isDefaultSwipeToDismissChecked = reminderPreferences.isDefaultSwipeToDismissEnabled,
       defaultCategoryName = categoryOptions()[
         categoryValues().indexOf(reminderPreferences.defaultNotificationCategory).coerceAtLeast(0)
       ],

--- a/logic/logic-reminder/src/main/kotlin/com/github/naz013/logic/reminder/ReminderPreferences.kt
+++ b/logic/logic-reminder/src/main/kotlin/com/github/naz013/logic/reminder/ReminderPreferences.kt
@@ -30,6 +30,7 @@ interface ReminderPreferences {
   var defaultNotificationCategory: String
   var isDefaultBypassDoNotDisturbEnabled: Boolean
   var isDefaultWakeScreenEnabled: Boolean
+  var isDefaultSwipeToDismissEnabled: Boolean
   var defaultLockScreenVisibility: String
   var initPresets: Boolean
   var initDefaultPresets: Boolean

--- a/ui/ui-common/src/main/res/values-ar/strings.xml
+++ b/ui/ui-common/src/main/res/values-ar/strings.xml
@@ -1133,4 +1133,7 @@
     <string name="select_reminder_or_birthday_to_see_details">اختر تذكيرًا أو عيد ميلاد لعرض التفاصيل</string>
     <string name="acc_close">إغلاق</string>
     <string name="turn_on">تشغيل</string>
+    <string name="allow_swipe_to_dismiss">السماح بالتمرير للإغلاق</string>
+    <string name="allow_swipe_to_dismiss_enabled">يؤدي تمرير الإشعار بعيدًا إلى إكمال التذكير</string>
+    <string name="allow_swipe_to_dismiss_disabled">يجب إغلاق الإشعار بزر موافق</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-bg/strings.xml
+++ b/ui/ui-common/src/main/res/values-bg/strings.xml
@@ -1136,4 +1136,7 @@
     <string name="select_reminder_or_birthday_to_see_details">Изберете напомняне или рожден ден, за да видите подробности</string>
     <string name="acc_close">Затвори</string>
     <string name="turn_on">Включване</string>
+    <string name="allow_swipe_to_dismiss">Разрешаване на превъртане за отхвърляне</string>
+    <string name="allow_swipe_to_dismiss_enabled">Прекарването на известието настрани завършва напомнянето</string>
+    <string name="allow_swipe_to_dismiss_disabled">Известието трябва да бъде затворено с бутона OK</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-cs/strings.xml
+++ b/ui/ui-common/src/main/res/values-cs/strings.xml
@@ -1135,4 +1135,7 @@
     <string name="select_reminder_or_birthday_to_see_details">Vyberte připomenutí nebo narozeniny a zobrazte podrobnosti</string>
     <string name="acc_close">Zavřít</string>
     <string name="turn_on">Zapnout</string>
+    <string name="allow_swipe_to_dismiss">Povolit odstranění přejetím</string>
+    <string name="allow_swipe_to_dismiss_enabled">Přejetím oznámení se připomenutí dokončí</string>
+    <string name="allow_swipe_to_dismiss_disabled">Oznámení musí být zavřeno tlačítkem OK</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-da/strings.xml
+++ b/ui/ui-common/src/main/res/values-da/strings.xml
@@ -1133,4 +1133,7 @@
     <string name="select_reminder_or_birthday_to_see_details">Vælg en påmindelse eller fødselsdag for at se detaljer</string>
     <string name="acc_close">Luk</string>
     <string name="turn_on">Tænd</string>
+    <string name="allow_swipe_to_dismiss">Tillad swipe for at afvise</string>
+    <string name="allow_swipe_to_dismiss_enabled">At swipe notifikationen væk fuldfører påmindelsen</string>
+    <string name="allow_swipe_to_dismiss_disabled">Notifikationen skal lukkes med OK-knappen</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-de/strings.xml
+++ b/ui/ui-common/src/main/res/values-de/strings.xml
@@ -1135,4 +1135,7 @@
     <string name="select_reminder_or_birthday_to_see_details">Wählen Sie eine Erinnerung oder einen Geburtstag aus, um Details anzuzeigen</string>
     <string name="acc_close">Schließen</string>
     <string name="turn_on">Einschalten</string>
+    <string name="allow_swipe_to_dismiss">Wischen zum Schließen zulassen</string>
+    <string name="allow_swipe_to_dismiss_enabled">Das Wegwischen der Benachrichtigung schließt die Erinnerung ab</string>
+    <string name="allow_swipe_to_dismiss_disabled">Die Benachrichtigung muss mit der OK-Schaltfläche geschlossen werden</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-es/strings.xml
+++ b/ui/ui-common/src/main/res/values-es/strings.xml
@@ -1135,4 +1135,7 @@
     <string name="select_reminder_or_birthday_to_see_details">Selecciona un recordatorio o cumpleaños para ver los detalles</string>
     <string name="acc_close">Cerrar</string>
     <string name="turn_on">Encender</string>
+    <string name="allow_swipe_to_dismiss">Permitir deslizar para descartar</string>
+    <string name="allow_swipe_to_dismiss_enabled">Deslizar la notificación completa el recordatorio</string>
+    <string name="allow_swipe_to_dismiss_disabled">La notificación debe cerrarse con el botón Aceptar</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-fr/strings.xml
+++ b/ui/ui-common/src/main/res/values-fr/strings.xml
@@ -1135,4 +1135,7 @@
     <string name="select_reminder_or_birthday_to_see_details">Sélectionnez un rappel ou un anniversaire pour voir les détails</string>
     <string name="acc_close">Fermer</string>
     <string name="turn_on">Allumer</string>
+    <string name="allow_swipe_to_dismiss">Autoriser le balayage pour ignorer</string>
+    <string name="allow_swipe_to_dismiss_enabled">Balayer la notification termine le rappel</string>
+    <string name="allow_swipe_to_dismiss_disabled">La notification doit être fermée avec le bouton OK</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-hi/strings.xml
+++ b/ui/ui-common/src/main/res/values-hi/strings.xml
@@ -1137,4 +1137,7 @@
     <string name="select_reminder_or_birthday_to_see_details">विवरण देखने के लिए एक रिमाइंडर या जन्मदिन चुनें</string>
     <string name="acc_close">बंद करें</string>
     <string name="turn_on">चालू करें</string>
+    <string name="allow_swipe_to_dismiss">स्वाइप करके हटाने की अनुमति दें</string>
+    <string name="allow_swipe_to_dismiss_enabled">सूचना को स्वाइप करके हटाने से रिमाइंडर पूरा हो जाता है</string>
+    <string name="allow_swipe_to_dismiss_disabled">सूचना को OK बटन से बंद करना आवश्यक है</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-id/strings.xml
+++ b/ui/ui-common/src/main/res/values-id/strings.xml
@@ -1133,4 +1133,7 @@
     <string name="select_reminder_or_birthday_to_see_details">Pilih pengingat atau ulang tahun untuk melihat detailnya</string>
     <string name="acc_close">Tutup</string>
     <string name="turn_on">Nyalakan</string>
+    <string name="allow_swipe_to_dismiss">Izinkan geser untuk menutup</string>
+    <string name="allow_swipe_to_dismiss_enabled">Menggeser notifikasi akan menyelesaikan pengingat</string>
+    <string name="allow_swipe_to_dismiss_disabled">Notifikasi harus ditutup dengan tombol OK</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-it/strings.xml
+++ b/ui/ui-common/src/main/res/values-it/strings.xml
@@ -1135,4 +1135,7 @@
     <string name="select_reminder_or_birthday_to_see_details">Seleziona un promemoria o un compleanno per vedere i dettagli</string>
     <string name="acc_close">Chiudi</string>
     <string name="turn_on">Accendi</string>
+    <string name="allow_swipe_to_dismiss">Consenti lo scorrimento per rimuovere</string>
+    <string name="allow_swipe_to_dismiss_enabled">Scorrere la notifica per rimuoverla completa il promemoria</string>
+    <string name="allow_swipe_to_dismiss_disabled">La notifica deve essere chiusa con il pulsante OK</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-ja/strings.xml
+++ b/ui/ui-common/src/main/res/values-ja/strings.xml
@@ -1135,4 +1135,7 @@
     <string name="select_reminder_or_birthday_to_see_details">詳細を表示するには、リマインダーまたは誕生日を選択してください</string>
     <string name="acc_close">閉じる</string>
     <string name="turn_on">オンにする</string>
+    <string name="allow_swipe_to_dismiss">スワイプして閉じることを許可</string>
+    <string name="allow_swipe_to_dismiss_enabled">通知をスワイプして閉じるとリマインダーが完了します</string>
+    <string name="allow_swipe_to_dismiss_disabled">通知はOKボタンで閉じる必要があります</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-ko/strings.xml
+++ b/ui/ui-common/src/main/res/values-ko/strings.xml
@@ -1135,4 +1135,7 @@
     <string name="select_reminder_or_birthday_to_see_details">세부정보를 보려면 알림 또는 생일을 선택하세요</string>
     <string name="acc_close">닫기</string>
     <string name="turn_on">켜기</string>
+    <string name="allow_swipe_to_dismiss">스와이프하여 닫기 허용</string>
+    <string name="allow_swipe_to_dismiss_enabled">알림을 스와이프하여 닫으면 미리 알림이 완료됩니다</string>
+    <string name="allow_swipe_to_dismiss_disabled">알림은 확인 버튼으로 닫아야 합니다</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-nb/strings.xml
+++ b/ui/ui-common/src/main/res/values-nb/strings.xml
@@ -1133,4 +1133,7 @@
     <string name="select_reminder_or_birthday_to_see_details">Velg en påminnelse eller bursdag for å se detaljer</string>
     <string name="acc_close">Lukk</string>
     <string name="turn_on">Slå på</string>
+    <string name="allow_swipe_to_dismiss">Tillat sveiping for å avvise</string>
+    <string name="allow_swipe_to_dismiss_enabled">Å sveipe bort varselet fullfører påminnelsen</string>
+    <string name="allow_swipe_to_dismiss_disabled">Varselet må lukkes med OK-knappen</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-nl/strings.xml
+++ b/ui/ui-common/src/main/res/values-nl/strings.xml
@@ -1133,4 +1133,7 @@
     <string name="select_reminder_or_birthday_to_see_details">Selecteer een herinnering of verjaardag om de details te bekijken</string>
     <string name="acc_close">Sluiten</string>
     <string name="turn_on">Inschakelen</string>
+    <string name="allow_swipe_to_dismiss">Vegen om te sluiten toestaan</string>
+    <string name="allow_swipe_to_dismiss_enabled">De melding wegvegen voltooit de herinnering</string>
+    <string name="allow_swipe_to_dismiss_disabled">De melding moet worden gesloten met de OK-knop</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-pl/strings.xml
+++ b/ui/ui-common/src/main/res/values-pl/strings.xml
@@ -1135,4 +1135,7 @@
     <string name="select_reminder_or_birthday_to_see_details">Wybierz przypomnienie lub urodziny, aby zobaczyć szczegóły</string>
     <string name="acc_close">Zamknij</string>
     <string name="turn_on">Włącz</string>
+    <string name="allow_swipe_to_dismiss">Zezwól na przesunięcie, aby odrzucić</string>
+    <string name="allow_swipe_to_dismiss_enabled">Przesunięcie powiadomienia powoduje ukończenie przypomnienia</string>
+    <string name="allow_swipe_to_dismiss_disabled">Powiadomienie musi zostać zamknięte przyciskiem OK</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-pt/strings.xml
+++ b/ui/ui-common/src/main/res/values-pt/strings.xml
@@ -1135,4 +1135,7 @@
     <string name="select_reminder_or_birthday_to_see_details">Selecione um lembrete ou aniversário para ver os detalhes</string>
     <string name="acc_close">Fechar</string>
     <string name="turn_on">Ligar</string>
+    <string name="allow_swipe_to_dismiss">Permitir deslizar para dispensar</string>
+    <string name="allow_swipe_to_dismiss_enabled">Deslizar a notificação conclui o lembrete</string>
+    <string name="allow_swipe_to_dismiss_disabled">A notificação deve ser fechada com o botão OK</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-ro/strings.xml
+++ b/ui/ui-common/src/main/res/values-ro/strings.xml
@@ -1135,4 +1135,7 @@
     <string name="select_reminder_or_birthday_to_see_details">Selectați un memento sau o zi de naștere pentru a vedea detaliile</string>
     <string name="acc_close">Închide</string>
     <string name="turn_on">Pornire</string>
+    <string name="allow_swipe_to_dismiss">Permite glisarea pentru a închide</string>
+    <string name="allow_swipe_to_dismiss_enabled">Glisarea notificării finalizează memento-ul</string>
+    <string name="allow_swipe_to_dismiss_disabled">Notificarea trebuie închisă cu butonul OK</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-ru/strings.xml
+++ b/ui/ui-common/src/main/res/values-ru/strings.xml
@@ -1134,4 +1134,7 @@
     <string name="select_reminder_or_birthday_to_see_details">Выберите напоминание или день рождения, чтобы увидеть подробности</string>
     <string name="acc_close">Закрыть</string>
     <string name="turn_on">Включить</string>
+    <string name="allow_swipe_to_dismiss">Разрешить смахивание для закрытия</string>
+    <string name="allow_swipe_to_dismiss_enabled">Смахивание уведомления завершает напоминание</string>
+    <string name="allow_swipe_to_dismiss_disabled">Уведомление нужно закрыть кнопкой ОК</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-sv/strings.xml
+++ b/ui/ui-common/src/main/res/values-sv/strings.xml
@@ -1133,4 +1133,7 @@
     <string name="select_reminder_or_birthday_to_see_details">Välj en påminnelse eller födelsedag för att se detaljer</string>
     <string name="acc_close">Stäng</string>
     <string name="turn_on">Slå på</string>
+    <string name="allow_swipe_to_dismiss">Tillåt svep för att avvisa</string>
+    <string name="allow_swipe_to_dismiss_enabled">Att svepa bort aviseringen slutför påminnelsen</string>
+    <string name="allow_swipe_to_dismiss_disabled">Aviseringen måste stängas med OK-knappen</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-th/strings.xml
+++ b/ui/ui-common/src/main/res/values-th/strings.xml
@@ -1133,4 +1133,7 @@
     <string name="select_reminder_or_birthday_to_see_details">เลือกการแจ้งเตือนหรือวันเกิดเพื่อดูรายละเอียด</string>
     <string name="acc_close">ปิด</string>
     <string name="turn_on">เปิด</string>
+    <string name="allow_swipe_to_dismiss">อนุญาตให้ปัดเพื่อปิด</string>
+    <string name="allow_swipe_to_dismiss_enabled">การปัดการแจ้งเตือนออกจะทำให้การแจ้งเตือนเสร็จสมบูรณ์</string>
+    <string name="allow_swipe_to_dismiss_disabled">ต้องปิดการแจ้งเตือนด้วยปุ่มตกลง</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-tr/strings.xml
+++ b/ui/ui-common/src/main/res/values-tr/strings.xml
@@ -1136,4 +1136,7 @@
     <string name="select_reminder_or_birthday_to_see_details">Ayrıntıları görmek için bir hatırlatıcı veya doğum günü seçin</string>
     <string name="acc_close">Kapat</string>
     <string name="turn_on">Aç</string>
+    <string name="allow_swipe_to_dismiss">Kapatmak için kaydırmaya izin ver</string>
+    <string name="allow_swipe_to_dismiss_enabled">Bildirimi kaydırarak kapatmak hatırlatıcıyı tamamlar</string>
+    <string name="allow_swipe_to_dismiss_disabled">Bildirim, Tamam düğmesiyle kapatılmalıdır</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-uk/strings.xml
+++ b/ui/ui-common/src/main/res/values-uk/strings.xml
@@ -1136,4 +1136,7 @@
     <string name="select_reminder_or_birthday_to_see_details">Виберіть нагадування або день народження, щоб побачити деталі</string>
     <string name="acc_close">Закрити</string>
     <string name="turn_on">Увімкнути</string>
+    <string name="allow_swipe_to_dismiss">Дозволити змахування для закриття</string>
+    <string name="allow_swipe_to_dismiss_enabled">Змахування сповіщення завершує нагадування</string>
+    <string name="allow_swipe_to_dismiss_disabled">Сповіщення потрібно закрити кнопкою ОК</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-vi/strings.xml
+++ b/ui/ui-common/src/main/res/values-vi/strings.xml
@@ -1133,4 +1133,7 @@
     <string name="select_reminder_or_birthday_to_see_details">Chọn lời nhắc hoặc sinh nhật để xem chi tiết</string>
     <string name="acc_close">Đóng</string>
     <string name="turn_on">Bật</string>
+    <string name="allow_swipe_to_dismiss">Cho phép vuốt để bỏ qua</string>
+    <string name="allow_swipe_to_dismiss_enabled">Vuốt để tắt thông báo sẽ hoàn thành lời nhắc</string>
+    <string name="allow_swipe_to_dismiss_disabled">Thông báo phải được đóng bằng nút OK</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-zh/strings.xml
+++ b/ui/ui-common/src/main/res/values-zh/strings.xml
@@ -1136,4 +1136,7 @@
     <string name="select_reminder_or_birthday_to_see_details">选择提醒事项或生日以查看详细信息</string>
     <string name="acc_close">关闭</string>
     <string name="turn_on">开启</string>
+    <string name="allow_swipe_to_dismiss">允许滑动关闭</string>
+    <string name="allow_swipe_to_dismiss_enabled">滑动关闭通知即完成提醒</string>
+    <string name="allow_swipe_to_dismiss_disabled">必须使用确定按钮关闭通知</string>
 </resources>

--- a/ui/ui-common/src/main/res/values/strings.xml
+++ b/ui/ui-common/src/main/res/values/strings.xml
@@ -1141,4 +1141,7 @@
     <string name="calendar_view_3_days">3 days</string>
     <string name="calendar_view_7_days">7 days</string>
     <string name="calendar_switch_view_mode">Switch calendar view</string>
+    <string name="allow_swipe_to_dismiss">Allow swipe to dismiss</string>
+    <string name="allow_swipe_to_dismiss_enabled">Swiping the notification away completes the reminder</string>
+    <string name="allow_swipe_to_dismiss_disabled">Notification must be dismissed with the OK button</string>
 </resources>


### PR DESCRIPTION
## Summary
- Swiping away a reminder or birthday alert notification now completes it, exactly like tapping OK (`setDeleteIntent` reuses the OK action's `PendingIntent`).
- New setting: **Settings > Reminders > Notification defaults > Allow swipe to dismiss** (off by default). When enabled, reminder notifications are built without `setOngoing`, so the notification actually becomes swipeable and the delete-intent wiring above can fire. Birthday notifications are unaffected and keep their current non-swipeable behavior.

## Test plan
- [x] `./gradlew :app:compileProDebugKotlin`
- [x] `./gradlew :app:assembleProDebug`
- [ ] Manual on-device: toggle "Allow swipe to dismiss" on, trigger a reminder alert, swipe it away, confirm it completes like tapping OK
- [ ] Manual on-device: toggle off (default), confirm behavior is unchanged from before this PR
- [ ] Confirm birthday notifications remain unaffected either way