### PR TITLE
REM-1162 - Update home screen init state on the main thread

### DIFF
--- a/app/src/main/java/com/elementary/tasks/navigation/BottomNavInitViewModel.kt
+++ b/app/src/main/java/com/elementary/tasks/navigation/BottomNavInitViewModel.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 sealed interface BottomNavInitState {
   data object Loading : BottomNavInitState
@@ -68,7 +69,10 @@ class BottomNavInitViewModel(
       if (prefs.isSbNotificationEnabled) {
         notifier.sendShowReminderPermanent()
       }
-      _state.value = BottomNavInitState.Ready(requiresLogin = prefs.hasPinCode)
+      val requiresLogin = prefs.hasPinCode
+      withContext(dispatcherProvider.main()) {
+        _state.value = BottomNavInitState.Ready(requiresLogin = requiresLogin)
+      }
     }
   }
 


### PR DESCRIPTION
BottomNavInitViewModel set its Ready StateFlow value from the default dispatcher while it's observed by Compose via
collectAsStateWithLifecycle(). In the nightly e2e run this occasionally made the resulting recomposition run on that background thread instead of main, crashing LazyColumn's prefetch scheduler with "The current thread must have a looper!" and cascading into several other ReminderRecurrenceE2ETest failures in the same run.