### PR TITLE
REM-1152 - Add option to pin the note in lists

### DIFF
--- a/core/domain/src/main/kotlin/com/github/naz013/domain/note/Note.kt
+++ b/core/domain/src/main/kotlin/com/github/naz013/domain/note/Note.kt
@@ -35,6 +35,8 @@ data class Note(
   var fontSize: Int = -1,
   @SerializedName("archived")
   var archived: Boolean = false,
+  @SerializedName("isPinned")
+  var isPinned: Boolean = false,
   @SerializedName("versionId")
   var version: Long = 0L,
   @Transient

--- a/core/domain/src/main/kotlin/com/github/naz013/domain/note/NoteWithImages.kt
+++ b/core/domain/src/main/kotlin/com/github/naz013/domain/note/NoteWithImages.kt
@@ -51,4 +51,8 @@ data class NoteWithImages(
   fun getFontSize(): Int {
     return note?.fontSize ?: FontParams.DEFAULT_FONT_SIZE
   }
+
+  fun isPinned(): Boolean {
+    return note?.isPinned ?: false
+  }
 }

--- a/data/files-api/src/main/kotlin/com/github/naz013/files/model/NoteV3Json.kt
+++ b/data/files-api/src/main/kotlin/com/github/naz013/files/model/NoteV3Json.kt
@@ -31,6 +31,8 @@ data class NoteV3Json(
   val fontSize: Int = -1,
   @SerializedName("archived")
   val archived: Boolean = false,
+  @SerializedName("isPinned")
+  val isPinned: Boolean = false,
   @SerializedName("versionId")
   var version: Long = 0L,
 )

--- a/data/repository-api/src/main/java/com/github/naz013/repository/NoteRepository.kt
+++ b/data/repository-api/src/main/java/com/github/naz013/repository/NoteRepository.kt
@@ -17,7 +17,8 @@ interface NoteRepository {
   /**
    * Filters by archive state and (optional) lowercase search text, and sorts in SQL (sortOrder
    * is one of "date_az", "date_za", "text_az", "text_za" — anything else behaves like
-   * "date_za"), all as a single query.
+   * "date_za"), all as a single query. Pinned notes are always sorted first, ahead of the
+   * requested sortOrder.
    */
   suspend fun getNotes(isArchived: Boolean, query: String, sortOrder: String): List<NoteWithImages>
   suspend fun getImagesIds(): List<Int>

--- a/data/repository/src/main/java/com/github/naz013/repository/AppDb.kt
+++ b/data/repository/src/main/java/com/github/naz013/repository/AppDb.kt
@@ -71,6 +71,7 @@ import com.github.naz013.repository.migrations.MIGRATION_29_30
 import com.github.naz013.repository.migrations.MIGRATION_2_3
 import com.github.naz013.repository.migrations.MIGRATION_30_31
 import com.github.naz013.repository.migrations.MIGRATION_31_32
+import com.github.naz013.repository.migrations.MIGRATION_32_33
 import com.github.naz013.repository.migrations.MIGRATION_3_4
 import com.github.naz013.repository.migrations.MIGRATION_4_5
 import com.github.naz013.repository.migrations.MIGRATION_5_6
@@ -104,7 +105,7 @@ import com.github.naz013.repository.migrations.MIGRATION_9_10
     TagAssignmentEntity::class,
     HolidayEntity::class
   ],
-  version = 32,
+  version = 33,
   exportSchema = false
 )
 @Suppress("TooManyFunctions") // one DAO accessor per entity - inherent to this class, not a smell
@@ -171,7 +172,8 @@ internal abstract class AppDb : RoomDatabase() {
             MIGRATION_28_29,
             MIGRATION_29_30,
             MIGRATION_30_31,
-            MIGRATION_31_32
+            MIGRATION_31_32,
+            MIGRATION_32_33
           )
           .allowMainThreadQueries()
           .build()

--- a/data/repository/src/main/java/com/github/naz013/repository/dao/NotesDao.kt
+++ b/data/repository/src/main/java/com/github/naz013/repository/dao/NotesDao.kt
@@ -24,6 +24,7 @@ internal interface NotesDao {
         WHERE archived = :isArchived
         AND (:query = '' OR LOWER(summary) LIKE '%' || :query || '%')
         ORDER BY
+          isPinned DESC,
           CASE WHEN :sortOrder = 'date_az' THEN date END ASC,
           CASE WHEN :sortOrder = 'text_az' THEN summary END ASC,
           CASE WHEN :sortOrder = 'text_za' THEN summary END DESC,

--- a/data/repository/src/main/java/com/github/naz013/repository/entity/NoteEntity.kt
+++ b/data/repository/src/main/java/com/github/naz013/repository/entity/NoteEntity.kt
@@ -39,6 +39,8 @@ internal data class NoteEntity(
   val fontSize: Int = -1,
   @SerializedName("archived")
   val archived: Boolean = false,
+  @SerializedName("isPinned")
+  val isPinned: Boolean = false,
   @SerializedName("version")
   val version: Long = 0L,
   @SerializedName("syncState")
@@ -60,6 +62,7 @@ internal data class NoteEntity(
     opacity = note.opacity,
     fontSize = note.fontSize,
     archived = note.archived,
+    isPinned = note.isPinned,
     version = note.version,
     syncState = note.syncState.name
   )
@@ -80,6 +83,7 @@ internal data class NoteEntity(
       opacity = opacity,
       fontSize = fontSize,
       archived = archived,
+      isPinned = isPinned,
       version = version,
       syncState = SyncState.valueOf(syncState)
     )

--- a/data/repository/src/main/java/com/github/naz013/repository/migrations/Migration32To33.kt
+++ b/data/repository/src/main/java/com/github/naz013/repository/migrations/Migration32To33.kt
@@ -1,0 +1,12 @@
+package com.github.naz013.repository.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+internal val MIGRATION_32_33: Migration = object : Migration(32, 33) {
+  override fun migrate(db: SupportSQLiteDatabase) {
+    runCatching {
+      db.execSQL("ALTER TABLE Note ADD COLUMN isPinned INTEGER NOT NULL DEFAULT 0")
+    }
+  }
+}

--- a/data/sync/src/main/kotlin/com/github/naz013/sync/images/PostProcessNoteV3UseCase.kt
+++ b/data/sync/src/main/kotlin/com/github/naz013/sync/images/PostProcessNoteV3UseCase.kt
@@ -45,6 +45,7 @@ internal class PostProcessNoteV3UseCase(
       updatedAt = noteV3Json.updatedAt,
       fontSize = noteV3Json.fontSize,
       archived = noteV3Json.archived,
+      isPinned = noteV3Json.isPinned,
       syncState = SyncState.Synced,
     )
   }

--- a/data/sync/src/main/kotlin/com/github/naz013/sync/usecase/upload/PreProcessUploadingFileUseCase.kt
+++ b/data/sync/src/main/kotlin/com/github/naz013/sync/usecase/upload/PreProcessUploadingFileUseCase.kt
@@ -59,6 +59,7 @@ internal class PreProcessUploadingFileUseCase(
       titleFontStyle = note.titleFontStyle,
       color = note.color,
       archived = note.archived,
+      isPinned = note.isPinned,
       date = note.date,
       fontSize = note.fontSize,
       palette = note.palette,

--- a/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/KoinModule.kt
+++ b/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/KoinModule.kt
@@ -15,6 +15,7 @@ import com.github.naz013.feature.note.usecase.ChangeNoteArchiveStateUseCase
 import com.github.naz013.feature.note.usecase.CreateSharedNoteFileUseCase
 import com.github.naz013.feature.note.usecase.DeleteNoteUseCase
 import com.github.naz013.feature.note.usecase.SaveNoteUseCase
+import com.github.naz013.feature.note.usecase.TogglePinnedNoteUseCase
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.singleOf
 import org.koin.core.module.dsl.viewModel
@@ -24,6 +25,7 @@ val featureNoteModule = module {
   factoryOf(::DeleteNoteUseCase)
   factoryOf(::SaveNoteUseCase)
   factoryOf(::ChangeNoteArchiveStateUseCase)
+  factoryOf(::TogglePinnedNoteUseCase)
 
   factoryOf(::CreateSharedNoteFileUseCase)
 
@@ -98,11 +100,13 @@ val featureNoteModule = module {
       get(),
       get(),
       get(),
+      get(),
     )
   }
   viewModel { (id: String) ->
     PreviewNoteViewModel(
       id,
+      get(),
       get(),
       get(),
       get(),

--- a/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/NotesNavGraph.kt
+++ b/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/NotesNavGraph.kt
@@ -314,6 +314,7 @@ private fun NotePreviewEntry(
       },
       onShareClick = viewModel::onShareClick,
       onArchiveClick = viewModel::onArchiveClick,
+      onPinClick = viewModel::onPinClick,
       onDeleteClick = viewModel::onDeleteClick,
       onImageOpen = viewModel::onImageOpen,
       onReminderEditClick = viewModel::onReminderEditClick,

--- a/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/UiNotePreview.kt
+++ b/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/UiNotePreview.kt
@@ -14,4 +14,5 @@ internal data class UiNotePreview(
   val titleTypeface: Typeface?,
   val titleTextSize: Float,
   val isArchived: Boolean,
+  val isPinned: Boolean,
 )

--- a/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/UiNotePreviewAdapter.kt
+++ b/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/UiNotePreviewAdapter.kt
@@ -40,6 +40,7 @@ internal class UiNotePreviewAdapter(
       ),
       titleTextSize = titleTextSize.toFloat(),
       isArchived = noteWithImages.note?.archived ?: false,
+      isPinned = noteWithImages.isPinned(),
     )
   }
 }

--- a/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/list/NotesScreen.kt
+++ b/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/list/NotesScreen.kt
@@ -49,6 +49,7 @@ import com.github.naz013.ui.common.compose.foundation.SelectionTopBar
 import com.github.naz013.ui.common.compose.foundation.component.AppDropdownMenu
 import com.github.naz013.ui.common.compose.foundation.component.PopupMenuItem
 import com.github.naz013.ui.common.compose.foundation.component.SearchBar
+import com.github.naz013.ui.common.icon.DrawableCatalog
 import com.github.naz013.ui.note.NoteCard
 import com.github.naz013.ui.note.UiNoteListItem
 import com.github.naz013.ui.tag.TagFilterRow
@@ -223,6 +224,7 @@ private fun NotesList(
             ) {
               NoteOverflowMenu(
                 isArchived = isArchived,
+                isPinned = note.isPinned,
                 textColor = note.textColor,
                 onMenuAction = { action -> onNoteMenuAction(note, action) },
               )
@@ -260,6 +262,7 @@ private fun NotesList(
             ) {
               NoteOverflowMenu(
                 isArchived = isArchived,
+                isPinned = note.isPinned,
                 textColor = note.textColor,
                 onMenuAction = { action -> onNoteMenuAction(note, action) },
               )
@@ -274,6 +277,7 @@ private fun NotesList(
 @Composable
 private fun BoxScope.NoteOverflowMenu(
   isArchived: Boolean,
+  isPinned: Boolean,
   textColor: androidx.compose.ui.graphics.Color,
   onMenuAction: (NoteMenuAction) -> Unit,
 ) {
@@ -287,13 +291,14 @@ private fun BoxScope.NoteOverflowMenu(
   AppDropdownMenu(
     expanded = menuExpanded,
     onDismissRequest = { menuExpanded = false },
-    items = noteMenuItems(isArchived),
+    items = noteMenuItems(isArchived, isPinned),
     onItemClick = { id -> onMenuAction(NoteMenuAction.entries[id]) },
   )
 }
 
 @Composable
-private fun noteMenuItems(isArchived: Boolean): List<PopupMenuItem> {
+private fun noteMenuItems(isArchived: Boolean, isPinned: Boolean): List<PopupMenuItem> {
+  val pinAction = if (isPinned) NoteMenuAction.UNPIN to R.string.unpin else NoteMenuAction.PIN to R.string.pin
   val actions =
     if (isArchived) {
       listOf(
@@ -308,6 +313,7 @@ private fun noteMenuItems(isArchived: Boolean): List<PopupMenuItem> {
         NoteMenuAction.SHARE to R.string.share,
         NoteMenuAction.SHOW_IN_STATUS_BAR to R.string.show_note_in_notifications,
         NoteMenuAction.EDIT to R.string.edit,
+        pinAction,
         NoteMenuAction.ARCHIVE to R.string.notes_move_to_archive,
         NoteMenuAction.DELETE to R.string.delete,
       )
@@ -324,6 +330,8 @@ private fun NoteMenuAction.iconRes(): Int =
     NoteMenuAction.SHARE -> R.drawable.ic_fluent_share
     NoteMenuAction.SHOW_IN_STATUS_BAR -> R.drawable.ic_fluent_alert
     NoteMenuAction.ARCHIVE, NoteMenuAction.UNARCHIVE -> R.drawable.ic_fluent_archive
+    NoteMenuAction.PIN -> DrawableCatalog.Fluent.Pin
+    NoteMenuAction.UNPIN -> DrawableCatalog.Fluent.PinOff
     NoteMenuAction.DELETE -> R.drawable.ic_fluent_delete
   }
 

--- a/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/list/NotesScreenState.kt
+++ b/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/list/NotesScreenState.kt
@@ -31,5 +31,7 @@ enum class NoteMenuAction {
   SHOW_IN_STATUS_BAR,
   ARCHIVE,
   UNARCHIVE,
+  PIN,
+  UNPIN,
   DELETE,
 }

--- a/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/list/NotesViewModel.kt
+++ b/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/list/NotesViewModel.kt
@@ -23,6 +23,7 @@ import com.github.naz013.feature.note.usecase.ChangeNoteArchiveStateUseCase
 import com.github.naz013.feature.note.usecase.CreateSharedNoteFileUseCase
 import com.github.naz013.feature.note.usecase.DeleteNoteUseCase
 import com.github.naz013.feature.note.usecase.SaveNoteUseCase
+import com.github.naz013.feature.note.usecase.TogglePinnedNoteUseCase
 import com.github.naz013.repository.NoteRepository
 import com.github.naz013.repository.TagAssignmentRepository
 import com.github.naz013.repository.TagRepository
@@ -64,6 +65,7 @@ internal class NotesViewModel(
   private val appWidgetUpdater: AppWidgetUpdater,
   private val deleteNoteUseCase: DeleteNoteUseCase,
   private val changeNoteArchiveStateUseCase: ChangeNoteArchiveStateUseCase,
+  private val togglePinnedNoteUseCase: TogglePinnedNoteUseCase,
   private val saveNoteUseCase: SaveNoteUseCase,
   private val createSharedNoteFileUseCase: CreateSharedNoteFileUseCase,
   private val imagesSingleton: ImagesSingleton,
@@ -305,7 +307,15 @@ internal class NotesViewModel(
 
       NoteMenuAction.ARCHIVE -> moveToArchive(note.id)
       NoteMenuAction.UNARCHIVE -> unarchive(note.id)
+      NoteMenuAction.PIN, NoteMenuAction.UNPIN -> togglePinned(note.id)
       NoteMenuAction.DELETE -> navigationEvent.emit(NavigationEvent.ConfirmDelete(note.id))
+    }
+  }
+
+  private fun togglePinned(id: String) {
+    viewModelScope.launch(dispatcherProvider.default()) {
+      togglePinnedNoteUseCase(id)
+      refresh()
     }
   }
 

--- a/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/preview/PreviewNoteActions.kt
+++ b/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/preview/PreviewNoteActions.kt
@@ -11,6 +11,7 @@ internal data class PreviewNoteActions(
   val onStatusClick: () -> Unit = {},
   val onShareClick: () -> Unit = {},
   val onArchiveClick: () -> Unit = {},
+  val onPinClick: () -> Unit = {},
   val onDeleteClick: () -> Unit = {},
   val onImageOpen: (Int) -> Unit = {},
   val onReminderEditClick: (String) -> Unit = {},

--- a/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/preview/PreviewNoteScreen.kt
+++ b/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/preview/PreviewNoteScreen.kt
@@ -32,11 +32,13 @@ import com.github.naz013.feature.note.R
 import com.github.naz013.ui.common.compose.AppIcons
 import com.github.naz013.ui.common.compose.foundation.component.AppDropdownMenu
 import com.github.naz013.ui.common.compose.foundation.component.PopupMenuItem
+import com.github.naz013.ui.common.icon.DrawableCatalog
 import com.github.naz013.ui.tag.TagChipRow
 
 private const val OVERFLOW_ITEM_SHARE = 0
 private const val OVERFLOW_ITEM_ARCHIVE = 1
-private const val OVERFLOW_ITEM_DELETE = 2
+private const val OVERFLOW_ITEM_PIN = 2
+private const val OVERFLOW_ITEM_DELETE = 3
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -109,6 +111,11 @@ internal fun PreviewNoteScreen(
               iconRes = R.drawable.ic_fluent_archive,
             ),
             PopupMenuItem(
+              id = OVERFLOW_ITEM_PIN,
+              title = stringResource(if (state.isPinned) R.string.unpin else R.string.pin),
+              iconRes = if (state.isPinned) DrawableCatalog.Fluent.PinOff else DrawableCatalog.Fluent.Pin,
+            ),
+            PopupMenuItem(
               id = OVERFLOW_ITEM_DELETE,
               title = stringResource(R.string.delete),
               iconRes = R.drawable.ic_fluent_delete,
@@ -118,6 +125,7 @@ internal fun PreviewNoteScreen(
             when (id) {
               OVERFLOW_ITEM_SHARE -> actions.onShareClick()
               OVERFLOW_ITEM_ARCHIVE -> actions.onArchiveClick()
+              OVERFLOW_ITEM_PIN -> actions.onPinClick()
               OVERFLOW_ITEM_DELETE -> actions.onDeleteClick()
             }
           },

--- a/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/preview/PreviewNoteState.kt
+++ b/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/preview/PreviewNoteState.kt
@@ -18,6 +18,7 @@ internal data class PreviewNoteState(
   val tags: List<TagChipState> = emptyList(),
   val reminders: List<UiNoteAttachedReminder> = emptyList(),
   val isArchived: Boolean = false,
+  val isPinned: Boolean = false,
   val isLoading: Boolean = false,
   val background: Color = Color.Transparent,
   val content: Color = Color.Unspecified,

--- a/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/preview/PreviewNoteViewModel.kt
+++ b/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/preview/PreviewNoteViewModel.kt
@@ -21,6 +21,7 @@ import com.github.naz013.feature.note.preview.reminders.ReminderToUiNoteAttached
 import com.github.naz013.feature.note.usecase.ChangeNoteArchiveStateUseCase
 import com.github.naz013.feature.note.usecase.CreateSharedNoteFileUseCase
 import com.github.naz013.feature.note.usecase.DeleteNoteUseCase
+import com.github.naz013.feature.note.usecase.TogglePinnedNoteUseCase
 import com.github.naz013.logging.Logger
 import com.github.naz013.logic.reminder.usecase.SaveReminderUseCase
 import com.github.naz013.repository.NoteRepository
@@ -49,6 +50,7 @@ internal class PreviewNoteViewModel(
   private val reminderToUiNoteAttachedReminder: ReminderToUiNoteAttachedReminder,
   private val deleteNoteUseCase: DeleteNoteUseCase,
   private val changeNoteArchiveStateUseCase: ChangeNoteArchiveStateUseCase,
+  private val togglePinnedNoteUseCase: TogglePinnedNoteUseCase,
   private val saveReminderUseCase: SaveReminderUseCase,
   private val createSharedNoteFileUseCase: CreateSharedNoteFileUseCase,
   private val imagesSingleton: ImagesSingleton,
@@ -89,6 +91,7 @@ internal class PreviewNoteViewModel(
               textSize = uiNotePreview.textSize,
               images = uiNotePreview.images,
               isArchived = uiNotePreview.isArchived,
+              isPinned = uiNotePreview.isPinned,
               background = noteColors.background,
               content = noteColors.content,
             )
@@ -154,6 +157,13 @@ internal class PreviewNoteViewModel(
       withContext(dispatcherProvider.main()) {
         event.emit(ViewModelEvent.Message(message))
       }
+    }
+  }
+
+  fun onPinClick() {
+    viewModelScope.launch(dispatcherProvider.default()) {
+      togglePinnedNoteUseCase(key)
+      loadInternal()
     }
   }
 

--- a/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/usecase/TogglePinnedNoteUseCase.kt
+++ b/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/usecase/TogglePinnedNoteUseCase.kt
@@ -1,0 +1,39 @@
+package com.github.naz013.feature.note.usecase
+
+import com.github.naz013.domain.sync.SyncState
+import com.github.naz013.files.DataType
+import com.github.naz013.logging.Logger
+import com.github.naz013.logic.schedule.ScheduleBackgroundWorkUseCase
+import com.github.naz013.logic.schedule.WorkType
+import com.github.naz013.repository.NoteRepository
+
+internal class TogglePinnedNoteUseCase(
+  private val noteRepository: NoteRepository,
+  private val scheduleBackgroundWorkUseCase: ScheduleBackgroundWorkUseCase,
+) {
+  suspend operator fun invoke(id: String) {
+    val noteWithImages = noteRepository.getById(id)
+    if (noteWithImages == null) {
+      return
+    }
+
+    val note = noteWithImages.note
+    if (note == null) {
+      return
+    }
+
+    note.isPinned = !note.isPinned
+    noteRepository.save(note.copy(version = note.version + 1))
+    noteRepository.updateSyncState(id, SyncState.WaitingForUpload)
+    scheduleBackgroundWorkUseCase(
+      workType = WorkType.Upload,
+      dataType = DataType.Notes,
+      id = note.key,
+    )
+    Logger.i(TAG, "Toggled pinned state for note: ${note.key}, isPinned=${note.isPinned}")
+  }
+
+  companion object {
+    private const val TAG = "TogglePinnedNoteUseCase"
+  }
+}

--- a/feature/feature-note/src/test/kotlin/com/github/naz013/feature/note/list/NotesViewModelTest.kt
+++ b/feature/feature-note/src/test/kotlin/com/github/naz013/feature/note/list/NotesViewModelTest.kt
@@ -18,6 +18,7 @@ import com.github.naz013.feature.note.usecase.ChangeNoteArchiveStateUseCase
 import com.github.naz013.feature.note.usecase.CreateSharedNoteFileUseCase
 import com.github.naz013.feature.note.usecase.DeleteNoteUseCase
 import com.github.naz013.feature.note.usecase.SaveNoteUseCase
+import com.github.naz013.feature.note.usecase.TogglePinnedNoteUseCase
 import com.github.naz013.repository.NoteRepository
 import com.github.naz013.repository.TagAssignmentRepository
 import com.github.naz013.repository.TagRepository
@@ -57,6 +58,7 @@ class NotesViewModelTest : BaseTest() {
   private val appWidgetUpdater = mockk<AppWidgetUpdater>(relaxed = true)
   private val deleteNoteUseCase = mockk<DeleteNoteUseCase>(relaxed = true)
   private val changeNoteArchiveStateUseCase = mockk<ChangeNoteArchiveStateUseCase>(relaxed = true)
+  private val togglePinnedNoteUseCase = mockk<TogglePinnedNoteUseCase>(relaxed = true)
   private val saveNoteUseCase = mockk<SaveNoteUseCase>(relaxed = true)
   private val createSharedNoteFileUseCase = mockk<CreateSharedNoteFileUseCase>()
   private val imagesSingleton = mockk<ImagesSingleton>(relaxed = true)
@@ -130,6 +132,7 @@ class NotesViewModelTest : BaseTest() {
       appWidgetUpdater = appWidgetUpdater,
       deleteNoteUseCase = deleteNoteUseCase,
       changeNoteArchiveStateUseCase = changeNoteArchiveStateUseCase,
+      togglePinnedNoteUseCase = togglePinnedNoteUseCase,
       saveNoteUseCase = saveNoteUseCase,
       createSharedNoteFileUseCase = createSharedNoteFileUseCase,
       imagesSingleton = imagesSingleton,

--- a/feature/feature-note/src/test/kotlin/com/github/naz013/feature/note/preview/PreviewNoteViewModelTest.kt
+++ b/feature/feature-note/src/test/kotlin/com/github/naz013/feature/note/preview/PreviewNoteViewModelTest.kt
@@ -21,6 +21,7 @@ import com.github.naz013.feature.note.preview.reminders.UiNoteAttachedReminder
 import com.github.naz013.feature.note.usecase.ChangeNoteArchiveStateUseCase
 import com.github.naz013.feature.note.usecase.CreateSharedNoteFileUseCase
 import com.github.naz013.feature.note.usecase.DeleteNoteUseCase
+import com.github.naz013.feature.note.usecase.TogglePinnedNoteUseCase
 import com.github.naz013.logic.reminder.usecase.SaveReminderUseCase
 import com.github.naz013.repository.NoteRepository
 import com.github.naz013.repository.ReminderV2Repository
@@ -59,6 +60,7 @@ class PreviewNoteViewModelTest : BaseTest() {
   private val reminderToUiNoteAttachedReminder = mockk<ReminderToUiNoteAttachedReminder>()
   private val deleteNoteUseCase = mockk<DeleteNoteUseCase>(relaxed = true)
   private val changeNoteArchiveStateUseCase = mockk<ChangeNoteArchiveStateUseCase>(relaxed = true)
+  private val togglePinnedNoteUseCase = mockk<TogglePinnedNoteUseCase>(relaxed = true)
   private val saveReminderUseCase = mockk<SaveReminderUseCase>(relaxed = true)
   private val createSharedNoteFileUseCase = mockk<CreateSharedNoteFileUseCase>()
   private val imagesSingleton = mockk<ImagesSingleton>(relaxed = true)
@@ -94,6 +96,7 @@ class PreviewNoteViewModelTest : BaseTest() {
     text: String = "Summary",
     images: List<UiNoteImage> = emptyList(),
     isArchived: Boolean = false,
+    isPinned: Boolean = false,
   ) = UiNotePreview(
     id = id,
     text = text,
@@ -105,6 +108,7 @@ class PreviewNoteViewModelTest : BaseTest() {
     titleTypeface = null,
     titleTextSize = 20f,
     isArchived = isArchived,
+    isPinned = isPinned,
   )
 
   private fun reminder(
@@ -132,6 +136,7 @@ class PreviewNoteViewModelTest : BaseTest() {
       reminderToUiNoteAttachedReminder = reminderToUiNoteAttachedReminder,
       deleteNoteUseCase = deleteNoteUseCase,
       changeNoteArchiveStateUseCase = changeNoteArchiveStateUseCase,
+      togglePinnedNoteUseCase = togglePinnedNoteUseCase,
       saveReminderUseCase = saveReminderUseCase,
       createSharedNoteFileUseCase = createSharedNoteFileUseCase,
       imagesSingleton = imagesSingleton,

--- a/feature/feature-note/src/test/kotlin/com/github/naz013/feature/note/usecase/TogglePinnedNoteUseCaseTest.kt
+++ b/feature/feature-note/src/test/kotlin/com/github/naz013/feature/note/usecase/TogglePinnedNoteUseCaseTest.kt
@@ -1,0 +1,63 @@
+package com.github.naz013.feature.note.usecase
+
+import com.github.naz013.domain.note.Note
+import com.github.naz013.domain.note.NoteWithImages
+import com.github.naz013.domain.sync.SyncState
+import com.github.naz013.logic.schedule.ScheduleBackgroundWorkUseCase
+import com.github.naz013.repository.NoteRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class TogglePinnedNoteUseCaseTest {
+  private lateinit var noteRepository: NoteRepository
+  private lateinit var scheduleBackgroundWorkUseCase: ScheduleBackgroundWorkUseCase
+
+  private lateinit var useCase: TogglePinnedNoteUseCase
+
+  @Before
+  fun setUp() {
+    noteRepository = mockk(relaxed = true)
+    scheduleBackgroundWorkUseCase = mockk(relaxed = true)
+    useCase = TogglePinnedNoteUseCase(noteRepository, scheduleBackgroundWorkUseCase)
+  }
+
+  private fun note(id: String, isPinned: Boolean) =
+    Note(key = id, summary = "Summary", isPinned = isPinned, version = 1L, syncState = SyncState.Synced)
+
+  @Test
+  fun `pins a note that was not pinned`() = runTest {
+    coEvery { noteRepository.getById("id-1") } returns NoteWithImages(note = note("id-1", isPinned = false))
+
+    useCase("id-1")
+
+    coVerify(exactly = 1) {
+      noteRepository.save(match<Note> { it.key == "id-1" && it.isPinned && it.version == 2L })
+    }
+    coVerify(exactly = 1) { noteRepository.updateSyncState("id-1", SyncState.WaitingForUpload) }
+  }
+
+  @Test
+  fun `unpins a note that was pinned`() = runTest {
+    coEvery { noteRepository.getById("id-2") } returns NoteWithImages(note = note("id-2", isPinned = true))
+
+    useCase("id-2")
+
+    coVerify(exactly = 1) { noteRepository.save(match<Note> { it.key == "id-2" && !it.isPinned }) }
+  }
+
+  @Test
+  fun `does nothing when note does not exist`() = runTest {
+    coEvery { noteRepository.getById("missing") } returns null
+
+    useCase("missing")
+
+    coVerify(exactly = 0) { noteRepository.save(any<Note>()) }
+    coVerify(exactly = 0) { noteRepository.updateSyncState(any(), any()) }
+  }
+}

--- a/ui/ui-note/src/main/kotlin/com/github/naz013/ui/note/UiNoteListItem.kt
+++ b/ui/ui-note/src/main/kotlin/com/github/naz013/ui/note/UiNoteListItem.kt
@@ -14,6 +14,7 @@ data class UiNoteListItem(
   val titleFontStyle: Int,
   val titleFontSize: Float,
   val images: List<UiNoteImage>,
+  val isPinned: Boolean = false,
   override val isSelected: Boolean = false,
 ) : Selectable<UiNoteListItem> {
   override fun withSelected(selected: Boolean) = copy(isSelected = selected)

--- a/ui/ui-note/src/main/kotlin/com/github/naz013/ui/note/UiNoteListItemAdapter.kt
+++ b/ui/ui-note/src/main/kotlin/com/github/naz013/ui/note/UiNoteListItemAdapter.kt
@@ -46,6 +46,7 @@ class UiNoteListItemAdapter(
       titleFontStyle = noteWithImages.getTitleFontStyle(),
       titleFontSize = titleFontSize.toFloat(),
       images = uiNoteImagesAdapter.convert(noteWithImages.images),
+      isPinned = noteWithImages.isPinned(),
     )
   }
 }


### PR DESCRIPTION
Mirrors the existing reminder pin feature: notes can be pinned/unpinned from the list overflow menu and the note preview screen, with pinned notes always sorted to the top of the list ahead of the selected sort order. The isPinned flag round-trips through cloud sync like every other note field.