### PR TITLE
REM-1165 - Keep the build-reminder screen open until the feedback review di…

### DIFF
--- a/admin/reviews/src/main/kotlin/com/github/naz013/reviews/ReviewsFormLauncher.kt
+++ b/admin/reviews/src/main/kotlin/com/github/naz013/reviews/ReviewsFormLauncher.kt
@@ -24,7 +24,7 @@ interface ReviewsFormLauncher {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun rememberReviewsFormLauncher(): ReviewsFormLauncher {
+fun rememberReviewsFormLauncher(onDismiss: () -> Unit = {}): ReviewsFormLauncher {
   val data = remember { mutableStateOf<Data?>(null) }
 
   // Resolving ReviewDialogViewModel touches Firebase (via the reviews Koin module's
@@ -34,7 +34,13 @@ fun rememberReviewsFormLauncher(): ReviewsFormLauncher {
   // never opened the feedback form. Deferring resolution to only while the sheet is shown keeps
   // that failure scoped to the rare case of actually submitting feedback offline.
   data.value?.let { request ->
-    ReviewFormSheet(request = request, onDismissRequest = { data.value = null })
+    ReviewFormSheet(
+      request = request,
+      onDismissRequest = {
+        data.value = null
+        onDismiss()
+      },
+    )
   }
 
   return object : ReviewsFormLauncher {

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/BuildReminderNavGraph.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/BuildReminderNavGraph.kt
@@ -85,7 +85,7 @@ private fun MainEntry(
   Logger.i("BuildReminderNavGraph", "Opening the reminder edit screen for id: ${Logger.data(viewModel.id)}")
 
   val dialogDispatcher = rememberDialogDispatcher()
-  val reviewsFormLauncher = rememberReviewsFormLauncher()
+  val reviewsFormLauncher = rememberReviewsFormLauncher(onDismiss = { viewModel.onReviewDialogDismissed() })
   val playReviewLauncher = rememberPlayReviewLauncher()
   val toastDispatcher = rememberToastDispatcher()
 

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/BuildReminderViewModel.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/BuildReminderViewModel.kt
@@ -321,14 +321,20 @@ internal class BuildReminderViewModel(
             }
 
           isSaving = true
-          saveAndStartReminder(finalV2, isEdit = isEdited)
+          val reviewDialogShown = saveAndStartReminder(finalV2, isEdit = isEdited)
 
           if (_state.value.saveAsPresetChecked && _state.value.presetName.isNotEmpty()) {
             savePreset(builderItems)
           }
 
-          withContext(dispatcherProvider.main()) {
-            event.emit(ViewModelEvent.MoveBack)
+          // Skip the close if the feedback-form review dialog was just requested - it's Compose
+          // state owned by this screen's nav entry, so popping the back stack here would tear it
+          // down before it can ever appear. onReviewDialogDismissed() closes the screen instead,
+          // once the user is done with the dialog.
+          if (!reviewDialogShown) {
+            withContext(dispatcherProvider.main()) {
+              event.emit(ViewModelEvent.MoveBack)
+            }
           }
         }
 
@@ -988,10 +994,13 @@ internal class BuildReminderViewModel(
     analyticsEventSender.send(PresetUsed(PresetAction.CREATE))
   }
 
+  /** @return true if the feedback-form review dialog ([ViewModelEvent.ShowReviewDialog]) was just
+   * requested - the caller must not close the screen in that case, since the dialog is Compose
+   * state owned by this screen's own nav entry. */
   private suspend fun saveAndStartReminder(
     reminder: ReminderV2,
     isEdit: Boolean = true,
-  ) {
+  ): Boolean {
     Logger.i(
       TAG,
       "Start reminder saving, id = ${reminder.uuId} and group id = ${reminder.groupId}",
@@ -1010,6 +1019,7 @@ internal class BuildReminderViewModel(
     // Track reminder creation, show the feedback-form review dialog after 4 reminders, then -
     // staggered after that, never in the same session - nudge the real Play Store review flow
     // after 10, since the feedback form never touches the actual Play Store rating.
+    var reviewDialogShown = false
     if (!isEdit) {
       val currentCount = reminderPreferences.remindersCreatedCount
       val newCount = currentCount + 1
@@ -1022,6 +1032,7 @@ internal class BuildReminderViewModel(
           askReview(R.string.share_your_experience)
         }
         reminderPreferences.reviewDialogShown = true
+        reviewDialogShown = true
       } else if (reminderPreferences.reviewDialogShown && !reminderPreferences.playReviewFlowShown && newCount >= 10) {
         Logger.i(TAG, "Launching Play Store review flow after 10 reminders created")
         withContext(dispatcherProvider.main()) {
@@ -1030,6 +1041,14 @@ internal class BuildReminderViewModel(
         reminderPreferences.playReviewFlowShown = true
       }
     }
+    return reviewDialogShown
+  }
+
+  /** Called once the feedback-form review dialog shown from [saveReminder] has been dismissed, to
+   * finally close the screen the way [ViewModelEvent.MoveBack] normally would have right after
+   * saving. */
+  fun onReviewDialogDismissed() {
+    event.emit(ViewModelEvent.MoveBack)
   }
 
   /** Mirrors [UiReminderType.getEventType]'s priority order, reading straight off [ReminderV2]'s

--- a/feature/feature-reminder/src/test/kotlin/com/github/naz013/feature/reminder/build/BuildReminderViewModelTest.kt
+++ b/feature/feature-reminder/src/test/kotlin/com/github/naz013/feature/reminder/build/BuildReminderViewModelTest.kt
@@ -550,6 +550,34 @@ class BuildReminderViewModelTest : BaseTest() {
     }
 
   @Test
+  fun `saveReminder does not close the screen when the review dialog is shown`() =
+    runTest {
+      every { reminderPreferences.reviewDialogShown } returns false
+      every { reminderPreferences.remindersCreatedCount } returns 3
+      val viewModel = createViewModel()
+
+      viewModel.saveReminder(newId = false)
+
+      assertEquals(
+        BuildReminderViewModel.ViewModelEvent.ShowReviewDialog::class,
+        viewModel.event.value?.peekContent()?.let { it::class },
+      )
+    }
+
+  @Test
+  fun `onReviewDialogDismissed closes the screen after the review dialog was shown`() =
+    runTest {
+      every { reminderPreferences.reviewDialogShown } returns false
+      every { reminderPreferences.remindersCreatedCount } returns 3
+      val viewModel = createViewModel()
+      viewModel.saveReminder(newId = false)
+
+      viewModel.onReviewDialogDismissed()
+
+      assertEquals(BuildReminderViewModel.ViewModelEvent.MoveBack, viewModel.event.value?.peekContent())
+    }
+
+  @Test
   fun `onPermissionsGranted retries saving with the previously requested newId flag`() =
     runTest {
       every { permissionValidator(any()) } returns PermissionValidator.Result.Failure(listOf("perm.X"))


### PR DESCRIPTION
…alog is dismissed

MoveBack was fired unconditionally right after saving, popping the Nav3 back-stack entry that owns the review dialog's Compose state before the dialog could ever render. The dialog's dismissal now triggers the close instead.