### PR TITLE
REM-1166 - Limit tag and group title to 100 characters

### DIFF
--- a/feature/feature-group/src/main/kotlin/com/github/naz013/group/create/EditGroupViewModel.kt
+++ b/feature/feature-group/src/main/kotlin/com/github/naz013/group/create/EditGroupViewModel.kt
@@ -80,7 +80,7 @@ internal class EditGroupViewModel(
   }
 
   fun onNameChanged(text: String) {
-    _state.update { it.copy(title = text, titleError = false) }
+    _state.update { it.copy(title = text.take(MAX_TITLE_LENGTH), titleError = false) }
   }
 
   fun onColorSelected(position: Int) {
@@ -463,5 +463,6 @@ internal class EditGroupViewModel(
 
   companion object {
     private const val TAG = "EditGroupViewModel"
+    private const val MAX_TITLE_LENGTH = 100
   }
 }

--- a/feature/feature-group/src/test/kotlin/com/github/naz013/group/create/EditGroupViewModelTest.kt
+++ b/feature/feature-group/src/test/kotlin/com/github/naz013/group/create/EditGroupViewModelTest.kt
@@ -205,6 +205,15 @@ class EditGroupViewModelTest : BaseTest() {
   }
 
   @Test
+  fun `onNameChanged truncates title to 100 characters`() {
+    val latest = observeState()
+
+    viewModel.onNameChanged("a".repeat(150))
+
+    assertEquals(100, latest().title.length)
+  }
+
+  @Test
   fun `onColorSelected updates color position`() {
     val latest = observeState()
 

--- a/feature/feature-tags/src/main/kotlin/com/github/naz013/tags/compose/TagEditViewModel.kt
+++ b/feature/feature-tags/src/main/kotlin/com/github/naz013/tags/compose/TagEditViewModel.kt
@@ -58,7 +58,7 @@ internal class TagEditViewModel(
   }
 
   fun onNameChanged(name: String) {
-    _state.update { it.copy(name = name, nameError = false) }
+    _state.update { it.copy(name = name.take(MAX_NAME_LENGTH), nameError = false) }
   }
 
   fun onColorSelected(position: Int) {
@@ -103,5 +103,6 @@ internal class TagEditViewModel(
 
   companion object {
     private const val TAG = "TagEditViewModel"
+    private const val MAX_NAME_LENGTH = 100
   }
 }


### PR DESCRIPTION
Truncate input in TagEditViewModel and EditGroupViewModel so tag/group titles can't exceed 100 characters.