### PR TITLE
REM-1168 - Add M3 tooltip support to shared icon button wrappers

### DIFF
--- a/admin/cloudtestadmin/src/main/java/com/example/cloudtestadmin/CloudTestScreen.kt
+++ b/admin/cloudtestadmin/src/main/java/com/example/cloudtestadmin/CloudTestScreen.kt
@@ -40,7 +40,6 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -65,6 +64,7 @@ import com.github.naz013.cloudapi.Source
 import com.github.naz013.cloudapi.dropbox.DropboxAuthManager
 import com.github.naz013.cloudapi.googledrive.GoogleDriveAuthManager
 import com.github.naz013.logging.Logger
+import com.github.naz013.ui.common.compose.foundation.MenuIconButton
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.common.api.Scope
@@ -345,9 +345,11 @@ fun AuthenticationScreen(
           TopAppBar(
             title = { Text("Google Drive Login") },
             navigationIcon = {
-              IconButton(onClick = onBackPressed) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-              }
+              MenuIconButton(
+                icon = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = "Back",
+                onClick = onBackPressed
+              )
             }
           )
         }
@@ -409,9 +411,11 @@ fun AuthenticationScreen(
           TopAppBar(
             title = { Text("Dropbox Login") },
             navigationIcon = {
-              IconButton(onClick = onBackPressed) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-              }
+              MenuIconButton(
+                icon = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = "Back",
+                onClick = onBackPressed
+              )
             }
           )
         }
@@ -462,14 +466,18 @@ fun FolderListScreen(
       TopAppBar(
         title = { Text("Folders") },
         navigationIcon = {
-          IconButton(onClick = onBackPressed) {
-            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-          }
+          MenuIconButton(
+            icon = Icons.AutoMirrored.Filled.ArrowBack,
+            contentDescription = "Back",
+            onClick = onBackPressed
+          )
         },
         actions = {
-          IconButton(onClick = { showMenu = true }) {
-            Icon(Icons.Default.MoreVert, contentDescription = "More options")
-          }
+          MenuIconButton(
+            icon = Icons.Default.MoreVert,
+            contentDescription = "More options",
+            onClick = { showMenu = true }
+          )
           DropdownMenu(
             expanded = showMenu,
             onDismissRequest = { showMenu = false }
@@ -611,15 +619,19 @@ fun FileListScreen(
       TopAppBar(
         title = { Text("${dataType.name} Files") },
         navigationIcon = {
-          IconButton(onClick = onBackPressed) {
-            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-          }
+          MenuIconButton(
+            icon = Icons.AutoMirrored.Filled.ArrowBack,
+            contentDescription = "Back",
+            onClick = onBackPressed
+          )
         },
         actions = {
           if (files.isNotEmpty()) {
-            IconButton(onClick = { showDeleteAllDialog = true }) {
-              Icon(Icons.Default.DeleteForever, contentDescription = "Delete all files")
-            }
+            MenuIconButton(
+              icon = Icons.Default.DeleteForever,
+              contentDescription = "Delete all files",
+              onClick = { showDeleteAllDialog = true }
+            )
           }
         }
       )
@@ -741,15 +753,12 @@ fun FileItem(
           )
         }
       }
-      IconButton(
+      MenuIconButton(
+        icon = Icons.Default.Delete,
+        contentDescription = "Delete file",
+        iconColor = MaterialTheme.colorScheme.error,
         onClick = { showDeleteDialog = true }
-      ) {
-        Icon(
-          imageVector = Icons.Default.Delete,
-          contentDescription = "Delete file",
-          tint = MaterialTheme.colorScheme.error
-        )
-      }
+      )
     }
   }
 
@@ -802,9 +811,11 @@ fun FilePreviewScreen(
       TopAppBar(
         title = { Text("Preview: ${cloudFile.name}") },
         navigationIcon = {
-          IconButton(onClick = onBackPressed) {
-            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-          }
+          MenuIconButton(
+            icon = Icons.AutoMirrored.Filled.ArrowBack,
+            contentDescription = "Back",
+            onClick = onBackPressed
+          )
         }
       )
     }

--- a/admin/reviewsadmin/src/main/java/com/github/nsy/reviewsadmin/ui/dashboard/DashboardScreen.kt
+++ b/admin/reviewsadmin/src/main/java/com/github/nsy/reviewsadmin/ui/dashboard/DashboardScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.github.naz013.reviews.AppSource
+import com.github.naz013.ui.common.compose.foundation.MenuIconButton
 import com.github.nsy.reviewsadmin.R
 import org.koin.androidx.compose.koinViewModel
 
@@ -39,18 +40,16 @@ fun DashboardScreen(
       TopAppBar(
         title = { Text(stringResource(R.string.dashboard_title)) },
         actions = {
-          IconButton(onClick = { viewModel.loadData() }) {
-            Icon(
-              imageVector = Icons.Default.Refresh,
-              contentDescription = stringResource(R.string.refresh)
-            )
-          }
-          IconButton(onClick = onSignOut) {
-            Icon(
-              imageVector = Icons.AutoMirrored.Filled.ExitToApp,
-              contentDescription = stringResource(R.string.sign_out)
-            )
-          }
+          MenuIconButton(
+            icon = Icons.Default.Refresh,
+            contentDescription = stringResource(R.string.refresh),
+            onClick = { viewModel.loadData() }
+          )
+          MenuIconButton(
+            icon = Icons.AutoMirrored.Filled.ExitToApp,
+            contentDescription = stringResource(R.string.sign_out),
+            onClick = onSignOut
+          )
         },
         colors = TopAppBarDefaults.topAppBarColors(
           containerColor = MaterialTheme.colorScheme.primaryContainer,

--- a/admin/reviewsadmin/src/main/java/com/github/nsy/reviewsadmin/ui/logviewer/LogViewerScreen.kt
+++ b/admin/reviewsadmin/src/main/java/com/github/nsy/reviewsadmin/ui/logviewer/LogViewerScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.github.naz013.ui.common.compose.foundation.MenuIconButton
 import com.github.nsy.reviewsadmin.R
 import org.koin.androidx.compose.koinViewModel
 
@@ -44,12 +45,11 @@ fun LogViewerScreen(
       TopAppBar(
         title = { Text("Log Viewer") },
         navigationIcon = {
-          IconButton(onClick = onNavigateBack) {
-            Icon(
-              imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-              contentDescription = stringResource(R.string.back)
-            )
-          }
+          MenuIconButton(
+            icon = Icons.AutoMirrored.Filled.ArrowBack,
+            contentDescription = stringResource(R.string.back),
+            onClick = onNavigateBack
+          )
         },
         colors = TopAppBarDefaults.topAppBarColors(
           containerColor = MaterialTheme.colorScheme.primaryContainer,

--- a/admin/reviewsadmin/src/main/java/com/github/nsy/reviewsadmin/ui/reviewdetail/ReviewDetailScreen.kt
+++ b/admin/reviewsadmin/src/main/java/com/github/nsy/reviewsadmin/ui/reviewdetail/ReviewDetailScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.github.naz013.reviews.Review
+import com.github.naz013.ui.common.compose.foundation.MenuIconButton
 import com.github.nsy.reviewsadmin.R
 import org.koin.androidx.compose.koinViewModel
 import org.threeten.bp.format.DateTimeFormatter
@@ -58,20 +59,18 @@ fun ReviewDetailScreen(
       TopAppBar(
         title = { Text("Review Details") },
         navigationIcon = {
-          IconButton(onClick = onNavigateBack) {
-            Icon(
-              imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-              contentDescription = stringResource(R.string.back)
-            )
-          }
+          MenuIconButton(
+            icon = Icons.AutoMirrored.Filled.ArrowBack,
+            contentDescription = stringResource(R.string.back),
+            onClick = onNavigateBack
+          )
         },
         actions = {
-          IconButton(onClick = { viewModel.refreshReview(review.id) }) {
-            Icon(
-              imageVector = Icons.Default.Refresh,
-              contentDescription = stringResource(R.string.refresh)
-            )
-          }
+          MenuIconButton(
+            icon = Icons.Default.Refresh,
+            contentDescription = stringResource(R.string.refresh),
+            onClick = { viewModel.refreshReview(review.id) }
+          )
         },
         colors = TopAppBarDefaults.topAppBarColors(
           containerColor = MaterialTheme.colorScheme.primaryContainer,

--- a/admin/reviewsadmin/src/main/java/com/github/nsy/reviewsadmin/ui/reviewlist/ReviewListScreen.kt
+++ b/admin/reviewsadmin/src/main/java/com/github/nsy/reviewsadmin/ui/reviewlist/ReviewListScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.github.naz013.reviews.AppSource
 import com.github.naz013.reviews.Review
+import com.github.naz013.ui.common.compose.foundation.MenuIconButton
 import com.github.nsy.reviewsadmin.R
 import org.koin.androidx.compose.koinViewModel
 import org.threeten.bp.format.DateTimeFormatter
@@ -58,20 +59,18 @@ fun ReviewListScreen(
       TopAppBar(
         title = { Text("${appSource.name} Reviews") },
         navigationIcon = {
-          IconButton(onClick = onNavigateBack) {
-            Icon(
-              imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-              contentDescription = stringResource(R.string.back)
-            )
-          }
+          MenuIconButton(
+            icon = Icons.AutoMirrored.Filled.ArrowBack,
+            contentDescription = stringResource(R.string.back),
+            onClick = onNavigateBack
+          )
         },
         actions = {
-          IconButton(onClick = { viewModel.loadReviews(appSource) }) {
-            Icon(
-              imageVector = Icons.Default.Refresh,
-              contentDescription = stringResource(R.string.refresh)
-            )
-          }
+          MenuIconButton(
+            icon = Icons.Default.Refresh,
+            contentDescription = stringResource(R.string.refresh),
+            onClick = { viewModel.loadReviews(appSource) }
+          )
         },
         colors = TopAppBarDefaults.topAppBarColors(
           containerColor = MaterialTheme.colorScheme.primaryContainer,

--- a/feature/feature-home/src/main/kotlin/com/github/naz013/feature/home/ChronologicalHomeScreen.kt
+++ b/feature/feature-home/src/main/kotlin/com/github/naz013/feature/home/ChronologicalHomeScreen.kt
@@ -31,8 +31,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -481,18 +479,20 @@ private fun EventCard(
             )
           }
         }
-        event.action?.let {
-          IconButton(
-            onClick = { onEventActionClick(event.action) },
+        event.action?.let { action ->
+          MenuIconButton(
             modifier = Modifier.size(36.dp),
-            colors = IconButtonDefaults.iconButtonColors(containerColor = Color.Transparent),
-          ) {
-            Icon(
-              painter = painterResource(it.icon),
-              contentDescription = null,
-              tint = onContainerColor,
-            )
-          }
+            icon = painterResource(action.icon),
+            iconColor = onContainerColor,
+            contentDescription = when (action.value) {
+              is ResolvedEventAction.MakeCall -> stringResource(R.string.make_call)
+              is ResolvedEventAction.SendSms -> stringResource(R.string.send_sms)
+              is ResolvedEventAction.SendEmail -> stringResource(R.string.action_send_email)
+              is ResolvedEventAction.OpenApp -> stringResource(R.string.action_open)
+              is ResolvedEventAction.OpenLink -> stringResource(R.string.open_link)
+            },
+            onClick = { onEventActionClick(event.action) },
+          )
         }
       }
 

--- a/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/create/NoteEditFloatingBar.kt
+++ b/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/create/NoteEditFloatingBar.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.github.naz013.ui.common.compose.foundation.TooltipIconButton
 import com.github.naz013.ui.common.compose.foundation.component.CloudBubble
 
 private const val FLOATING_BAR_ANIMATION_DURATION_MS = 300
@@ -146,12 +147,14 @@ private fun NoteEditBarIconSlot(
     modifier = Modifier.size(BAR_ITEM_SIZE),
     contentAlignment = Alignment.Center,
   ) {
-    IconButton(
-      onClick = item.onClick,
-      interactionSource = interactionSource,
-      modifier = Modifier.fillMaxWidth().height(BAR_ITEM_SIZE),
-    ) {
-      item.icon()
+    TooltipIconButton(contentDescription = item.contentDescription) {
+      IconButton(
+        onClick = item.onClick,
+        interactionSource = interactionSource,
+        modifier = Modifier.fillMaxWidth().height(BAR_ITEM_SIZE),
+      ) {
+        item.icon()
+      }
     }
     if (item.showBadge) {
       Box(

--- a/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/create/NoteEditScreen.kt
+++ b/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/create/NoteEditScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -56,6 +55,7 @@ import androidx.compose.ui.unit.sp
 import com.github.naz013.common.uri.UriUtil
 import com.github.naz013.feature.note.R
 import com.github.naz013.ui.common.compose.AppIcons
+import com.github.naz013.ui.common.compose.foundation.MenuIconButton
 import com.github.naz013.ui.common.compose.foundation.MenuTextButton
 import com.github.naz013.ui.common.compose.foundation.dragAndDropHighlight
 import com.github.naz013.ui.note.NoteFontProvider
@@ -92,13 +92,12 @@ internal fun NoteEditScreen(
     Column(modifier = Modifier.fillMaxSize()) {
       TopAppBar(
         navigationIcon = {
-          IconButton(onClick = actions.onBackClick) {
-            Icon(
-              painter = AppIcons.Builder.ArrowLeft,
-              contentDescription = null,
-              tint = contentColor,
-            )
-          }
+          MenuIconButton(
+            icon = AppIcons.Builder.ArrowLeft,
+            contentDescription = stringResource(R.string.cd_back),
+            iconColor = contentColor,
+            onClick = actions.onBackClick,
+          )
         },
         title = {},
         actions = {
@@ -107,21 +106,19 @@ internal fun NoteEditScreen(
             color = contentColor,
             onClick = actions.onSaveClick,
           )
-          IconButton(onClick = actions.onShareClick) {
-            Icon(
-              painter = painterResource(R.drawable.ic_fluent_share_android),
-              contentDescription = stringResource(R.string.share),
-              tint = contentColor,
-            )
-          }
+          MenuIconButton(
+            icon = painterResource(R.drawable.ic_fluent_share_android),
+            iconColor = contentColor,
+            contentDescription = stringResource(R.string.share),
+            onClick = actions.onShareClick,
+          )
           if (state.canDelete) {
-            IconButton(onClick = actions.onDeleteClick) {
-              Icon(
-                painter = painterResource(R.drawable.ic_fluent_delete),
-                contentDescription = stringResource(R.string.delete),
-                tint = contentColor,
-              )
-            }
+            MenuIconButton(
+              icon = painterResource(R.drawable.ic_fluent_delete),
+              iconColor = contentColor,
+              contentDescription = stringResource(R.string.delete),
+              onClick = actions.onDeleteClick,
+            )
           }
         },
         colors =

--- a/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/preview/ImagePreviewScreen.kt
+++ b/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/preview/ImagePreviewScreen.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -24,6 +22,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.github.naz013.feature.note.R
 import com.github.naz013.ui.common.compose.AppIcons
+import com.github.naz013.ui.common.compose.foundation.MenuIconButton
 import com.github.naz013.ui.note.UiNoteImage
 import me.saket.telephoto.zoomable.coil.ZoomableAsyncImage
 import me.saket.telephoto.zoomable.rememberZoomableImageState
@@ -53,13 +52,12 @@ internal fun ImagePreviewScreen(
         }
       },
       navigationIcon = {
-        IconButton(onClick = onBackClick) {
-          Icon(
-            painter = AppIcons.Builder.ArrowLeft,
-            contentDescription = stringResource(R.string.cd_back),
-            tint = state.content,
-          )
-        }
+        MenuIconButton(
+          icon = AppIcons.Builder.ArrowLeft,
+          iconColor = state.content,
+          contentDescription = stringResource(R.string.cd_back),
+          onClick = onBackClick,
+        )
       },
       colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent),
       modifier = Modifier.statusBarsPadding(),

--- a/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/preview/PreviewNoteScreen.kt
+++ b/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/preview/PreviewNoteScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -30,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.naz013.feature.note.R
 import com.github.naz013.ui.common.compose.AppIcons
+import com.github.naz013.ui.common.compose.foundation.MenuIconButton
 import com.github.naz013.ui.common.compose.foundation.component.AppDropdownMenu
 import com.github.naz013.ui.common.compose.foundation.component.PopupMenuItem
 import com.github.naz013.ui.common.icon.DrawableCatalog
@@ -57,37 +57,33 @@ internal fun PreviewNoteScreen(
     TopAppBar(
       title = { },
       navigationIcon = {
-        IconButton(onClick = actions.onBackClick) {
-          Icon(
-            painter = AppIcons.Builder.ArrowLeft,
-            contentDescription = stringResource(R.string.cd_back),
-            tint = state.content,
-          )
-        }
+        MenuIconButton(
+          icon = AppIcons.Builder.ArrowLeft,
+          iconColor = state.content,
+          contentDescription = stringResource(R.string.cd_back),
+          onClick = actions.onBackClick,
+        )
       },
       actions = {
-        IconButton(onClick = actions.onEditClick) {
-          Icon(
-            painter = painterResource(R.drawable.ic_fluent_edit),
-            contentDescription = stringResource(R.string.edit),
-            tint = state.content,
-          )
-        }
-        IconButton(onClick = actions.onStatusClick) {
-          Icon(
-            painter = AppIcons.Fluent.Heart,
-            contentDescription = stringResource(R.string.show_in_status_bar),
-            tint = state.content,
-          )
-        }
+        MenuIconButton(
+          icon = painterResource(R.drawable.ic_fluent_edit),
+          iconColor = state.content,
+          contentDescription = stringResource(R.string.edit),
+          onClick = actions.onEditClick,
+        )
+        MenuIconButton(
+          icon = AppIcons.Fluent.Heart,
+          iconColor = state.content,
+          contentDescription = stringResource(R.string.show_in_status_bar),
+          onClick = actions.onStatusClick,
+        )
         var overflowExpanded by remember { mutableStateOf(false) }
-        IconButton(onClick = { overflowExpanded = true }) {
-          Icon(
-            painter = AppIcons.Fluent.MoreVertical,
-            contentDescription = null,
-            tint = state.content,
-          )
-        }
+        MenuIconButton(
+          icon = AppIcons.Fluent.MoreVertical,
+          iconColor = state.content,
+          contentDescription = stringResource(R.string.more_options),
+          onClick = { overflowExpanded = true },
+        )
         AppDropdownMenu(
           expanded = overflowExpanded,
           onDismissRequest = { overflowExpanded = false },

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/BuildReminderScreen.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/BuildReminderScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -62,7 +61,9 @@ import com.github.naz013.ui.common.R
 import com.github.naz013.ui.common.compose.AppIcons
 import com.github.naz013.ui.common.compose.AppTheme
 import com.github.naz013.ui.common.compose.TopAppbarColor
+import com.github.naz013.ui.common.compose.foundation.MenuIconButton
 import com.github.naz013.ui.common.compose.foundation.MenuTextButton
+import com.github.naz013.ui.common.compose.foundation.TooltipIconButton
 import com.github.naz013.ui.common.compose.foundation.component.AppDropdownMenu
 import com.github.naz013.ui.common.compose.foundation.component.BuilderItemStatus
 import com.github.naz013.ui.common.compose.foundation.component.BuilderListItemCard
@@ -117,9 +118,11 @@ internal fun BuildReminderScreen(
       TopAppBar(
         title = {},
         navigationIcon = {
-          IconButton(onClick = onBackClick) {
-            Icon(painter = AppIcons.Builder.ArrowLeft, contentDescription = null)
-          }
+          MenuIconButton(
+            icon = AppIcons.Builder.ArrowLeft,
+            contentDescription = stringResource(R.string.cd_back),
+            onClick = onBackClick,
+          )
         },
         actions = {
           MenuTextButton(
@@ -128,17 +131,18 @@ internal fun BuildReminderScreen(
             onClick = onSaveClick,
           )
           if (canRemove) {
-            IconButton(onClick = onDeleteClick) {
-              Icon(
-                painter = AppIcons.Fluent.Delete,
-                contentDescription = stringResource(R.string.delete),
-              )
-            }
+            MenuIconButton(
+              icon = AppIcons.Fluent.Delete,
+              contentDescription = stringResource(R.string.delete),
+              onClick = onDeleteClick,
+            )
           }
           var overflowExpanded by remember { mutableStateOf(false) }
-          IconButton(onClick = { overflowExpanded = true }) {
-            Icon(painter = AppIcons.Fluent.MoreVertical, contentDescription = null)
-          }
+          MenuIconButton(
+            icon = AppIcons.Fluent.MoreVertical,
+            contentDescription = stringResource(R.string.more_options),
+            onClick = { overflowExpanded = true },
+          )
           AppDropdownMenu(
             expanded = overflowExpanded,
             onDismissRequest = { overflowExpanded = false },
@@ -163,11 +167,13 @@ internal fun BuildReminderScreen(
       )
     },
     floatingActionButton = {
-      FloatingActionButton(onClick = onAddClick) {
-        Icon(
-          painter = painterResource(R.drawable.ic_builder_add_circle),
-          contentDescription = stringResource(R.string.acc_add),
-        )
+      TooltipIconButton(contentDescription = stringResource(R.string.acc_add)) {
+        FloatingActionButton(onClick = onAddClick) {
+          Icon(
+            painter = painterResource(R.drawable.ic_builder_add_circle),
+            contentDescription = stringResource(R.string.acc_add),
+          )
+        }
       }
     },
   ) { padding ->

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/help/ReminderHelpScreen.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/help/ReminderHelpScreen.kt
@@ -5,8 +5,6 @@ import android.webkit.WebView
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -23,6 +21,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import com.github.naz013.ui.common.R
 import com.github.naz013.ui.common.compose.AppIcons
 import com.github.naz013.ui.common.compose.TopAppbarColor
+import com.github.naz013.ui.common.compose.foundation.MenuIconButton
 
 /**
  * "How to Create a Reminder" help guide: a comprehensive HTML-based guide covering the reminder
@@ -42,12 +41,11 @@ internal fun ReminderHelpScreen(onBackClick: () -> Unit) {
           Text(text = stringResource(R.string.how_to_create_a_reminder))
         },
         navigationIcon = {
-          IconButton(onClick = onBackClick) {
-            Icon(
-              painter = AppIcons.Builder.ArrowLeft,
-              contentDescription = stringResource(R.string.cd_back),
-            )
-          }
+          MenuIconButton(
+            icon = AppIcons.Builder.ArrowLeft,
+            contentDescription = stringResource(R.string.cd_back),
+            onClick = onBackClick,
+          )
         },
         colors = TopAppbarColor,
         scrollBehavior =

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/preset/PresetListItem.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/preset/PresetListItem.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -20,6 +18,7 @@ import androidx.compose.ui.unit.dp
 import com.github.naz013.ui.common.R
 import com.github.naz013.feature.reminder.preset.UiPresetList
 import com.github.naz013.ui.common.compose.AppTheme
+import com.github.naz013.ui.common.compose.foundation.MenuIconButton
 
 /**
  * A single recur-preset row: name + description, with an optional trailing delete button.
@@ -57,13 +56,12 @@ internal fun PresetListItem(
         )
       }
       if (canDelete) {
-        IconButton(onClick = { onDeleteClick?.invoke() }) {
-          Icon(
-            painter = painterResource(R.drawable.ic_fluent_delete),
-            contentDescription = stringResource(R.string.delete),
-            tint = MaterialTheme.colorScheme.onSurface,
-          )
-        }
+        MenuIconButton(
+          icon = painterResource(R.drawable.ic_fluent_delete),
+          contentDescription = stringResource(R.string.delete),
+          iconColor = MaterialTheme.colorScheme.onSurface,
+          onClick = { onDeleteClick?.invoke() },
+        )
       }
     }
     if (dividerBottom) HorizontalDivider()

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/selectordialog/BuilderSelectorSheet.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/selectordialog/BuilderSelectorSheet.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SecondaryTabRow
 import androidx.compose.material3.Tab
@@ -34,6 +33,7 @@ import com.github.naz013.feature.reminder.build.BuilderItem
 import com.github.naz013.feature.reminder.build.UiSelectorItem
 import com.github.naz013.feature.reminder.build.UiSelectorItemState
 import com.github.naz013.feature.reminder.build.preset.PresetListItem
+import com.github.naz013.ui.common.compose.foundation.MenuIconButton
 import com.github.naz013.ui.common.compose.foundation.component.AppModalBottomSheet
 import com.github.naz013.ui.common.compose.foundation.component.SearchBar
 
@@ -84,16 +84,12 @@ internal fun BuilderSelectorSheet(
         color = MaterialTheme.colorScheme.onSurface,
         modifier = Modifier.weight(1f),
       )
-      IconButton(
-        onClick = onDismissRequest,
+      MenuIconButton(
         modifier = Modifier.testTag(builderSelectorSheetCloseTestTag),
-      ) {
-        Icon(
-          painter = painterResource(R.drawable.ic_builder_chevron_down),
-          contentDescription = null,
-          tint = MaterialTheme.colorScheme.onSurface,
-        )
-      }
+        icon = painterResource(R.drawable.ic_builder_chevron_down),
+        contentDescription = stringResource(R.string.cd_collapse),
+        onClick = onDismissRequest,
+      )
     }
 
     SearchBar(

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/valuedialog/ValueEditorSheet.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/valuedialog/ValueEditorSheet.kt
@@ -8,8 +8,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -17,9 +15,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.github.naz013.ui.common.R
+import com.github.naz013.ui.common.compose.foundation.MenuIconButton
 import com.github.naz013.feature.reminder.build.ApplicationBuilderItem
 import com.github.naz013.feature.reminder.build.AttachmentsBuilderItem
 import com.github.naz013.feature.reminder.build.BeforeTimeBuilderItem
@@ -168,24 +168,18 @@ internal fun ValueEditorSheet(
         modifier = Modifier.weight(1f),
       )
       if (onHelpClick != null) {
-        IconButton(onClick = onHelpClick) {
-          Icon(
-            painter = painterResource(R.drawable.ic_builder_ical_help),
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurface,
-          )
-        }
-      }
-      IconButton(
-        onClick = onDismissRequest,
-        modifier = Modifier.testTag(valueEditorSheetCloseTestTag),
-      ) {
-        Icon(
-          painter = painterResource(R.drawable.ic_builder_chevron_down),
-          contentDescription = null,
-          tint = MaterialTheme.colorScheme.onSurface,
+        MenuIconButton(
+          icon = painterResource(R.drawable.ic_builder_ical_help),
+          contentDescription = stringResource(R.string.help),
+          onClick = onHelpClick,
         )
       }
+      MenuIconButton(
+        modifier = Modifier.testTag(valueEditorSheetCloseTestTag),
+        icon = painterResource(R.drawable.ic_builder_chevron_down),
+        contentDescription = stringResource(R.string.cd_collapse),
+        onClick = onDismissRequest,
+      )
     }
 
     val description = builderItem.description

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/valuedialog/editor/ActionValueEditors.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/valuedialog/editor/ActionValueEditors.kt
@@ -32,6 +32,7 @@ import androidx.core.graphics.drawable.toBitmap
 import com.github.naz013.ui.common.R
 import com.github.naz013.feature.reminder.build.BuilderItem
 import com.github.naz013.common.PackageManagerWrapper
+import com.github.naz013.ui.common.compose.foundation.TooltipIconButton
 import com.github.naz013.ui.common.compose.foundation.component.PhoneNumberVisualTransformation
 
 /**
@@ -111,19 +112,23 @@ internal fun PhoneInputValueEditor(
       visualTransformation = PhoneNumberVisualTransformation,
     )
     Spacer(modifier = Modifier.width(8.dp))
-    IconButton(
-      onClick = {
-        onPickContact { phone ->
-          text = phone
-          builderItem.modifier.update(phone)
-          onValueChange(builderItem)
-        }
-      },
+    TooltipIconButton(
+      contentDescription = stringResource(R.string.acc_select_number_from_contacts),
     ) {
-      Icon(
-        painter = painterResource(R.drawable.ic_fluent_contacts),
-        contentDescription = stringResource(R.string.acc_select_number_from_contacts),
-      )
+      IconButton(
+        onClick = {
+          onPickContact { phone ->
+            text = phone
+            builderItem.modifier.update(phone)
+            onValueChange(builderItem)
+          }
+        },
+      ) {
+        Icon(
+          painter = painterResource(R.drawable.ic_fluent_contacts),
+          contentDescription = stringResource(R.string.acc_select_number_from_contacts),
+        )
+      }
     }
   }
 }

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/valuedialog/editor/AttachmentsValueEditor.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/valuedialog/editor/AttachmentsValueEditor.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
@@ -40,6 +39,7 @@ import com.github.naz013.feature.reminder.build.valuedialog.controller.attachmen
 import com.github.naz013.feature.reminder.build.valuedialog.controller.attachments.UriToAttachmentFileAdapter
 import com.github.naz013.ui.common.R
 import com.github.naz013.ui.common.compose.AppIcons
+import com.github.naz013.ui.common.compose.foundation.MenuIconButton
 
 private val GRID_MAX_HEIGHT = 320.dp
 
@@ -135,12 +135,11 @@ private fun AttachmentCell(attachmentFile: AttachmentFile, onRemove: () -> Unit)
         )
       }
     }
-    IconButton(onClick = onRemove, modifier = Modifier.align(Alignment.TopEnd).size(24.dp)) {
-      Icon(
-        painter = AppIcons.Fluent.Dismiss,
-        contentDescription = null,
-        tint = MaterialTheme.colorScheme.onSurface,
-      )
-    }
+    MenuIconButton(
+      modifier = Modifier.align(Alignment.TopEnd).size(24.dp),
+      icon = AppIcons.Fluent.Dismiss,
+      contentDescription = stringResource(R.string.cd_remove),
+      onClick = onRemove,
+    )
   }
 }

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/valuedialog/editor/MapEditorScreen.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/valuedialog/editor/MapEditorScreen.kt
@@ -18,8 +18,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -32,12 +30,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.github.naz013.ui.common.R
 import com.github.naz013.feature.reminder.build.BuilderItem
 import com.github.naz013.datecalc.DateTimeManager
 import com.github.naz013.domain.Place
+import com.github.naz013.ui.common.compose.foundation.MenuIconButton
 import kotlinx.coroutines.launch
 
 private const val SHEET_HEIGHT_FRACTION = 0.94f
@@ -137,13 +137,11 @@ internal fun MapEditorScreen(
             color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.weight(1f),
           )
-          IconButton(onClick = ::dismiss) {
-            Icon(
-              painter = painterResource(R.drawable.ic_builder_chevron_down),
-              contentDescription = null,
-              tint = MaterialTheme.colorScheme.onSurface,
-            )
-          }
+          MenuIconButton(
+            icon = painterResource(R.drawable.ic_builder_chevron_down),
+            contentDescription = stringResource(R.string.cd_collapse),
+            onClick = ::dismiss,
+          )
         }
       }
 

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/valuedialog/editor/SubTasksValueEditor.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/valuedialog/editor/SubTasksValueEditor.kt
@@ -66,6 +66,7 @@ import com.github.naz013.feature.reminder.build.valuedialog.controller.shopitems
 import com.github.naz013.feature.reminder.build.valuedialog.controller.shopitems.SubTasksViewModel
 import com.github.naz013.ui.common.R
 import com.github.naz013.ui.common.compose.AppIcons
+import com.github.naz013.ui.common.compose.foundation.TooltipIconButton
 import com.github.naz013.ui.common.livedata.ObserveNonNull
 
 private val LIST_MAX_HEIGHT = 400.dp
@@ -242,38 +243,46 @@ private fun ShopItemRow(
     } else {
       Box(modifier = Modifier.size(20.dp))
     }
-    IconButton(
-      onClick = {
-        if (hapticFeedbackEnabled) {
-          hapticFeedback.performHapticFeedback(HapticFeedbackType.ToggleOn)
-        }
-        onCheckClick()
+    TooltipIconButton(
+      contentDescription = if (item.isChecked) {
+        stringResource(R.string.cd_mark_as_not_done)
+      } else {
+        stringResource(R.string.cd_mark_as_done)
       },
-      modifier = Modifier
-        .size(40.dp)
-        .testTag(shopItemCheckTestTag(item.uuId)),
     ) {
-      AnimatedVisibility(
-        visible = item.isChecked,
-        enter = scaleIn(tween(CHECK_ANIMATION_MS)) + fadeIn(tween(CHECK_ANIMATION_MS)),
-        exit = scaleOut(tween(CHECK_ANIMATION_MS)) + fadeOut(tween(CHECK_ANIMATION_MS)),
+      IconButton(
+        onClick = {
+          if (hapticFeedbackEnabled) {
+            hapticFeedback.performHapticFeedback(HapticFeedbackType.ToggleOn)
+          }
+          onCheckClick()
+        },
+        modifier = Modifier
+          .size(40.dp)
+          .testTag(shopItemCheckTestTag(item.uuId)),
       ) {
-        Icon(
-          painter = painterResource(R.drawable.ic_fluent_checkbox_checked),
-          contentDescription = null,
-          tint = MaterialTheme.colorScheme.onSurface,
-        )
-      }
-      AnimatedVisibility(
-        visible = !item.isChecked,
-        enter = scaleIn(tween(CHECK_ANIMATION_MS)) + fadeIn(tween(CHECK_ANIMATION_MS)),
-        exit = scaleOut(tween(CHECK_ANIMATION_MS)) + fadeOut(tween(CHECK_ANIMATION_MS)),
-      ) {
-        Icon(
-          painter = painterResource(R.drawable.ic_fluent_checkbox_unchecked),
-          contentDescription = null,
-          tint = MaterialTheme.colorScheme.onSurface,
-        )
+        AnimatedVisibility(
+          visible = item.isChecked,
+          enter = scaleIn(tween(CHECK_ANIMATION_MS)) + fadeIn(tween(CHECK_ANIMATION_MS)),
+          exit = scaleOut(tween(CHECK_ANIMATION_MS)) + fadeOut(tween(CHECK_ANIMATION_MS)),
+        ) {
+          Icon(
+            painter = painterResource(R.drawable.ic_fluent_checkbox_checked),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurface,
+          )
+        }
+        AnimatedVisibility(
+          visible = !item.isChecked,
+          enter = scaleIn(tween(CHECK_ANIMATION_MS)) + fadeIn(tween(CHECK_ANIMATION_MS)),
+          exit = scaleOut(tween(CHECK_ANIMATION_MS)) + fadeOut(tween(CHECK_ANIMATION_MS)),
+        ) {
+          Icon(
+            painter = painterResource(R.drawable.ic_fluent_checkbox_unchecked),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurface,
+          )
+        }
       }
     }
     Box(modifier = Modifier.weight(1f)) {
@@ -323,20 +332,22 @@ private fun ShopItemRow(
       )
     }
     if (isFocused && text.isNotEmpty()) {
-      IconButton(
-        onClick = onRemoveClick,
-        modifier = Modifier
-          .size(40.dp)
-          .testTag(shopItemRemoveTestTag(item.uuId)),
-      ) {
-        Icon(
+      TooltipIconButton(contentDescription = stringResource(R.string.cd_remove)) {
+        IconButton(
+          onClick = onRemoveClick,
           modifier = Modifier
-            .fillMaxSize()
-            .padding(12.dp),
-          painter = AppIcons.Fluent.Dismiss,
-          contentDescription = null,
-          tint = MaterialTheme.colorScheme.onSurface,
-        )
+            .size(40.dp)
+            .testTag(shopItemRemoveTestTag(item.uuId)),
+        ) {
+          Icon(
+            modifier = Modifier
+              .fillMaxSize()
+              .padding(12.dp),
+            painter = AppIcons.Fluent.Dismiss,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurface,
+          )
+        }
       }
     }
   }

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/valuedialog/editor/SubTasksValueEditor.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/valuedialog/editor/SubTasksValueEditor.kt
@@ -57,6 +57,8 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.github.naz013.datecalc.DateTimeManager
@@ -243,13 +245,12 @@ private fun ShopItemRow(
     } else {
       Box(modifier = Modifier.size(20.dp))
     }
-    TooltipIconButton(
-      contentDescription = if (item.isChecked) {
-        stringResource(R.string.cd_mark_as_not_done)
-      } else {
-        stringResource(R.string.cd_mark_as_done)
-      },
-    ) {
+    val checkToggleDescription = if (item.isChecked) {
+      stringResource(R.string.cd_mark_as_not_done)
+    } else {
+      stringResource(R.string.cd_mark_as_done)
+    }
+    TooltipIconButton(contentDescription = checkToggleDescription) {
       IconButton(
         onClick = {
           if (hapticFeedbackEnabled) {
@@ -259,6 +260,7 @@ private fun ShopItemRow(
         },
         modifier = Modifier
           .size(40.dp)
+          .semantics { contentDescription = checkToggleDescription }
           .testTag(shopItemCheckTestTag(item.uuId)),
       ) {
         AnimatedVisibility(
@@ -344,7 +346,7 @@ private fun ShopItemRow(
               .fillMaxSize()
               .padding(12.dp),
             painter = AppIcons.Fluent.Dismiss,
-            contentDescription = null,
+            contentDescription = stringResource(R.string.cd_remove),
             tint = MaterialTheme.colorScheme.onSurface,
           )
         }

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/valuedialog/editor/TextInputValueEditor.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/valuedialog/editor/TextInputValueEditor.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import com.airbnb.lottie.compose.LottieAnimation
@@ -42,6 +43,7 @@ import com.github.naz013.common.speech.SpeechEngine
 import com.github.naz013.common.speech.SpeechEngineCallback
 import com.github.naz013.common.speech.SpeechError
 import com.github.naz013.common.speech.SpeechText
+import com.github.naz013.ui.common.compose.foundation.TooltipIconButton
 import com.github.naz013.ui.common.compose.foundation.component.GradientHighlightTextField
 import com.github.naz013.ui.common.compose.foundation.component.TextHighlight
 
@@ -143,46 +145,54 @@ internal fun TextInputValueEditor(
       )
       if (supportsSpeech) {
         Spacer(modifier = Modifier.width(8.dp))
-        IconButton(
-          modifier = Modifier.size(MIC_BUTTON_SIZE),
-          onClick = {
-            when {
-              speechEngine.isStarted() -> speechEngine.stopListening()
-
-              ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
-                PackageManager.PERMISSION_GRANTED
-              -> speechEngine.startListening(callback)
-
-              else -> permissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
-            }
+        TooltipIconButton(
+          contentDescription = if (speechState == SpeechUiState.IDLE) {
+            stringResource(R.string.cd_start_voice_input)
+          } else {
+            stringResource(R.string.cd_stop_voice_input)
           },
         ) {
-          when (speechState) {
-            SpeechUiState.SPEAKING -> {
-              val composition by rememberLottieComposition(
-                LottieCompositionSpec.RawRes(R.raw.mic_speaking_waves),
-              )
-              LottieAnimation(
-                composition = composition,
-                iterations = LottieConstants.IterateForever,
-                modifier = Modifier.size(MIC_BUTTON_SIZE),
-              )
-            }
+          IconButton(
+            modifier = Modifier.size(MIC_BUTTON_SIZE),
+            onClick = {
+              when {
+                speechEngine.isStarted() -> speechEngine.stopListening()
 
-            SpeechUiState.STARTED, SpeechUiState.STOPPED -> {
-              Icon(
-                painter = painterResource(R.drawable.ic_fluent_recording_stop),
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.error,
-              )
-            }
+                ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
+                  PackageManager.PERMISSION_GRANTED
+                -> speechEngine.startListening(callback)
 
-            SpeechUiState.IDLE -> {
-              Icon(
-                painter = painterResource(R.drawable.ic_builder_mic_on),
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurface,
-              )
+                else -> permissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+              }
+            },
+          ) {
+            when (speechState) {
+              SpeechUiState.SPEAKING -> {
+                val composition by rememberLottieComposition(
+                  LottieCompositionSpec.RawRes(R.raw.mic_speaking_waves),
+                )
+                LottieAnimation(
+                  composition = composition,
+                  iterations = LottieConstants.IterateForever,
+                  modifier = Modifier.size(MIC_BUTTON_SIZE),
+                )
+              }
+
+              SpeechUiState.STARTED, SpeechUiState.STOPPED -> {
+                Icon(
+                  painter = painterResource(R.drawable.ic_fluent_recording_stop),
+                  contentDescription = null,
+                  tint = MaterialTheme.colorScheme.error,
+                )
+              }
+
+              SpeechUiState.IDLE -> {
+                Icon(
+                  painter = painterResource(R.drawable.ic_builder_mic_on),
+                  contentDescription = null,
+                  tint = MaterialTheme.colorScheme.onSurface,
+                )
+              }
             }
           }
         }

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/valuedialog/editor/TextInputValueEditor.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/build/valuedialog/editor/TextInputValueEditor.kt
@@ -31,6 +31,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import com.airbnb.lottie.compose.LottieAnimation
@@ -145,15 +147,16 @@ internal fun TextInputValueEditor(
       )
       if (supportsSpeech) {
         Spacer(modifier = Modifier.width(8.dp))
-        TooltipIconButton(
-          contentDescription = if (speechState == SpeechUiState.IDLE) {
-            stringResource(R.string.cd_start_voice_input)
-          } else {
-            stringResource(R.string.cd_stop_voice_input)
-          },
-        ) {
+        val micButtonDescription = if (speechState == SpeechUiState.IDLE) {
+          stringResource(R.string.cd_start_voice_input)
+        } else {
+          stringResource(R.string.cd_stop_voice_input)
+        }
+        TooltipIconButton(contentDescription = micButtonDescription) {
           IconButton(
-            modifier = Modifier.size(MIC_BUTTON_SIZE),
+            modifier = Modifier
+              .size(MIC_BUTTON_SIZE)
+              .semantics { contentDescription = micButtonDescription },
             onClick = {
               when {
                 speechEngine.isStarted() -> speechEngine.stopListening()

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/preview/PreviewReminderScreen.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/preview/PreviewReminderScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -595,20 +594,22 @@ private fun SubTaskRow(
     verticalAlignment = Alignment.CenterVertically,
     modifier = Modifier.fillMaxWidth().padding(start = 4.dp, end = 4.dp),
   ) {
-    IconButton(onClick = { onCheck(subTask.id) }) {
-      Icon(
-        painter =
-          painterResource(
-            if (subTask.isChecked) {
-              R.drawable.ic_fluent_checkbox_checked
-            } else {
-              R.drawable.ic_fluent_checkbox_unchecked
-            },
-          ),
-        contentDescription = null,
-        tint = if (subTask.isChecked) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
-      )
-    }
+    MenuIconButton(
+      icon = painterResource(
+        if (subTask.isChecked) {
+          R.drawable.ic_fluent_checkbox_checked
+        } else {
+          R.drawable.ic_fluent_checkbox_unchecked
+        },
+      ),
+      contentDescription = if (subTask.isChecked) {
+        stringResource(R.string.cd_mark_as_not_done)
+      } else {
+        stringResource(R.string.cd_mark_as_done)
+      },
+      iconColor = if (subTask.isChecked) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+      onClick = { onCheck(subTask.id) },
+    )
     Text(
       text = subTask.text,
       style = MaterialTheme.typography.bodyLarge,
@@ -616,13 +617,12 @@ private fun SubTaskRow(
       textDecoration = if (subTask.isChecked) TextDecoration.LineThrough else TextDecoration.None,
       modifier = Modifier.weight(1f),
     )
-    IconButton(onClick = { onRemove(subTask.id) }) {
-      Icon(
-        painter = painterResource(R.drawable.ic_fluent_delete),
-        contentDescription = stringResource(R.string.delete),
-        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-      )
-    }
+    MenuIconButton(
+      icon = painterResource(R.drawable.ic_fluent_delete),
+      contentDescription = stringResource(R.string.delete),
+      iconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+      onClick = { onRemove(subTask.id) },
+    )
   }
 }
 

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/recur/RecurHelpScreen.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/recur/RecurHelpScreen.kt
@@ -8,8 +8,6 @@ import android.webkit.WebViewClient
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -21,6 +19,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import com.github.naz013.ui.common.R
 import com.github.naz013.ui.common.compose.AppIcons
 import com.github.naz013.ui.common.compose.TopAppbarColor
+import com.github.naz013.ui.common.compose.foundation.MenuIconButton
 
 private const val URL = "file:///android_asset/files/doc_rfc_5545.html"
 
@@ -34,12 +33,11 @@ internal fun RecurHelpScreen(onBackClick: () -> Unit) {
       TopAppBar(
         title = { Text(text = stringResource(R.string.recur_rfc_5545_doc)) },
         navigationIcon = {
-          IconButton(onClick = onBackClick) {
-            Icon(
-              painter = AppIcons.Builder.ArrowLeft,
-              contentDescription = stringResource(com.github.naz013.ui.common.R.string.cd_back),
-            )
-          }
+          MenuIconButton(
+            icon = AppIcons.Builder.ArrowLeft,
+            contentDescription = stringResource(com.github.naz013.ui.common.R.string.cd_back),
+            onClick = onBackClick,
+          )
         },
         colors = TopAppbarColor,
       )

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/settings/help/NotificationCustomizationHelpScreen.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/settings/help/NotificationCustomizationHelpScreen.kt
@@ -5,8 +5,6 @@ import android.webkit.WebView
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -23,6 +21,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import com.github.naz013.ui.common.R
 import com.github.naz013.ui.common.compose.AppIcons
 import com.github.naz013.ui.common.compose.TopAppbarColor
+import com.github.naz013.ui.common.compose.foundation.MenuIconButton
 
 /**
  * "How Notification Customization Works" help guide: explains the Settings -> Group -> Reminder
@@ -42,12 +41,11 @@ fun NotificationCustomizationHelpScreen(onBackClick: () -> Unit) {
           Text(text = stringResource(R.string.notification_customization))
         },
         navigationIcon = {
-          IconButton(onClick = onBackClick) {
-            Icon(
-              painter = AppIcons.Builder.ArrowLeft,
-              contentDescription = stringResource(R.string.cd_back),
-            )
-          }
+          MenuIconButton(
+            icon = AppIcons.Builder.ArrowLeft,
+            contentDescription = stringResource(R.string.cd_back),
+            onClick = onBackClick,
+          )
         },
         colors = TopAppbarColor,
         scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior().apply {

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/todo/TodoEditScreen.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/todo/TodoEditScreen.kt
@@ -14,8 +14,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.FilterChip
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -73,12 +71,11 @@ internal fun TodoEditScreen(
             onClick = onSaveClick,
           )
           if (state.isEditing) {
-            IconButton(onClick = onDeleteClick) {
-              Icon(
-                painter = painterResource(R.drawable.ic_fluent_delete),
-                contentDescription = stringResource(R.string.delete),
-              )
-            }
+            MenuIconButton(
+              icon = painterResource(R.drawable.ic_fluent_delete),
+              contentDescription = stringResource(R.string.delete),
+              onClick = onDeleteClick,
+            )
           }
         },
         colors = TopAppbarColor,

--- a/feature/feature-routine/src/main/kotlin/com/github/naz013/feature/routine/edit/RoutineEditScreen.kt
+++ b/feature/feature-routine/src/main/kotlin/com/github/naz013/feature/routine/edit/RoutineEditScreen.kt
@@ -41,6 +41,7 @@ import com.github.naz013.ui.common.compose.AppIcons
 import com.github.naz013.ui.common.compose.TopAppbarColor
 import com.github.naz013.ui.common.compose.foundation.MenuIconButton
 import com.github.naz013.ui.common.compose.foundation.MenuTextButton
+import com.github.naz013.ui.common.compose.foundation.TooltipIconButton
 import com.github.naz013.ui.common.compose.foundation.component.AppDropdownMenu
 import com.github.naz013.ui.common.compose.foundation.component.PopupMenuItem
 import com.github.naz013.ui.common.compose.foundation.component.WheelPicker
@@ -377,18 +378,24 @@ private fun RoutineStepRow(
           singleLine = true,
           modifier = Modifier.weight(1f),
         )
-        IconButton(onClick = onMoveUpClick, enabled = !isFirst) {
-          Icon(
-            AppIcons.Builder.ChevronDown,
-            contentDescription = stringResource(R.string.move_step_up),
-            modifier = Modifier.graphicsLayer { rotationZ = 180f },
-          )
+        TooltipIconButton(contentDescription = stringResource(R.string.move_step_up)) {
+          IconButton(onClick = onMoveUpClick, enabled = !isFirst) {
+            Icon(
+              AppIcons.Builder.ChevronDown,
+              contentDescription = stringResource(R.string.move_step_up),
+              modifier = Modifier.graphicsLayer { rotationZ = 180f },
+            )
+          }
         }
-        IconButton(onClick = onMoveDownClick, enabled = !isLast) {
-          Icon(AppIcons.Builder.ChevronDown, contentDescription = stringResource(R.string.move_step_down))
+        TooltipIconButton(contentDescription = stringResource(R.string.move_step_down)) {
+          IconButton(onClick = onMoveDownClick, enabled = !isLast) {
+            Icon(AppIcons.Builder.ChevronDown, contentDescription = stringResource(R.string.move_step_down))
+          }
         }
-        IconButton(onClick = onRemoveClick) {
-          Icon(AppIcons.Fluent.Dismiss, contentDescription = stringResource(R.string.delete))
+        TooltipIconButton(contentDescription = stringResource(R.string.delete)) {
+          IconButton(onClick = onRemoveClick) {
+            Icon(AppIcons.Fluent.Dismiss, contentDescription = stringResource(R.string.delete))
+          }
         }
       }
       FlowRow(

--- a/feature/feature-routine/src/main/kotlin/com/github/naz013/feature/routine/preview/RoutinePreviewScreen.kt
+++ b/feature/feature-routine/src/main/kotlin/com/github/naz013/feature/routine/preview/RoutinePreviewScreen.kt
@@ -38,6 +38,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import com.github.naz013.ui.common.R
@@ -179,14 +181,18 @@ private fun RoutineStepChecklistRow(
     modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
     verticalAlignment = Alignment.CenterVertically,
   ) {
-    TooltipIconButton(
-      contentDescription = if (step.isCompleted) {
-        stringResource(R.string.cd_mark_as_not_done)
-      } else {
-        stringResource(R.string.cd_mark_as_done)
-      },
-    ) {
-      IconButton(onClick = onCheckToggle, modifier = Modifier.size(40.dp)) {
+    val checkToggleDescription = if (step.isCompleted) {
+      stringResource(R.string.cd_mark_as_not_done)
+    } else {
+      stringResource(R.string.cd_mark_as_done)
+    }
+    TooltipIconButton(contentDescription = checkToggleDescription) {
+      IconButton(
+        onClick = onCheckToggle,
+        modifier = Modifier
+          .size(40.dp)
+          .semantics { contentDescription = checkToggleDescription },
+      ) {
         AnimatedVisibility(
           visible = step.isCompleted,
           enter = scaleIn(tween(CHECK_ANIMATION_MS)) + fadeIn(tween(CHECK_ANIMATION_MS)),

--- a/feature/feature-routine/src/main/kotlin/com/github/naz013/feature/routine/preview/RoutinePreviewScreen.kt
+++ b/feature/feature-routine/src/main/kotlin/com/github/naz013/feature/routine/preview/RoutinePreviewScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.unit.dp
 import com.github.naz013.ui.common.R
 import com.github.naz013.ui.common.compose.AppIcons
 import com.github.naz013.ui.common.compose.foundation.MenuIconButton
+import com.github.naz013.ui.common.compose.foundation.TooltipIconButton
 import com.github.naz013.ui.common.compose.foundation.component.AppDropdownMenu
 import com.github.naz013.ui.common.compose.foundation.component.PopupMenuItem
 import com.github.naz013.ui.common.icon.DrawableCatalog
@@ -178,28 +179,36 @@ private fun RoutineStepChecklistRow(
     modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
     verticalAlignment = Alignment.CenterVertically,
   ) {
-    IconButton(onClick = onCheckToggle, modifier = Modifier.size(40.dp)) {
-      AnimatedVisibility(
-        visible = step.isCompleted,
-        enter = scaleIn(tween(CHECK_ANIMATION_MS)) + fadeIn(tween(CHECK_ANIMATION_MS)),
-        exit = scaleOut(tween(CHECK_ANIMATION_MS)) + fadeOut(tween(CHECK_ANIMATION_MS)),
-      ) {
-        Icon(
-          painter = AppIcons.Fluent.CheckboxChecked,
-          contentDescription = null,
-          tint = MaterialTheme.colorScheme.primary,
-        )
-      }
-      AnimatedVisibility(
-        visible = !step.isCompleted,
-        enter = scaleIn(tween(CHECK_ANIMATION_MS)) + fadeIn(tween(CHECK_ANIMATION_MS)),
-        exit = scaleOut(tween(CHECK_ANIMATION_MS)) + fadeOut(tween(CHECK_ANIMATION_MS)),
-      ) {
-        Icon(
-          painter = AppIcons.Fluent.CheckboxUnchecked,
-          contentDescription = null,
-          tint = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+    TooltipIconButton(
+      contentDescription = if (step.isCompleted) {
+        stringResource(R.string.cd_mark_as_not_done)
+      } else {
+        stringResource(R.string.cd_mark_as_done)
+      },
+    ) {
+      IconButton(onClick = onCheckToggle, modifier = Modifier.size(40.dp)) {
+        AnimatedVisibility(
+          visible = step.isCompleted,
+          enter = scaleIn(tween(CHECK_ANIMATION_MS)) + fadeIn(tween(CHECK_ANIMATION_MS)),
+          exit = scaleOut(tween(CHECK_ANIMATION_MS)) + fadeOut(tween(CHECK_ANIMATION_MS)),
+        ) {
+          Icon(
+            painter = AppIcons.Fluent.CheckboxChecked,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+          )
+        }
+        AnimatedVisibility(
+          visible = !step.isCompleted,
+          enter = scaleIn(tween(CHECK_ANIMATION_MS)) + fadeIn(tween(CHECK_ANIMATION_MS)),
+          exit = scaleOut(tween(CHECK_ANIMATION_MS)) + fadeOut(tween(CHECK_ANIMATION_MS)),
+        ) {
+          Icon(
+            painter = AppIcons.Fluent.CheckboxUnchecked,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+        }
       }
     }
     Column(modifier = Modifier.weight(1f)) {

--- a/feature/feature-settings/src/main/kotlin/com/github/naz013/feature/settings/export/services/CloudServicesScreen.kt
+++ b/feature/feature-settings/src/main/kotlin/com/github/naz013/feature/settings/export/services/CloudServicesScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.github.naz013.ui.common.R
 import com.github.naz013.ui.common.compose.AppIcons
+import com.github.naz013.ui.common.compose.foundation.TooltipIconButton
 import com.github.naz013.ui.common.compose.foundation.component.AnimatedGradientBackground
 import com.github.naz013.ui.common.compose.withAlpha
 
@@ -54,19 +55,21 @@ internal fun CloudServicesScreen(
         verticalAlignment = Alignment.CenterVertically,
       ) {
         Spacer(modifier = Modifier.width(16.dp))
-        IconButton(
-          onClick = onBackClick,
-          modifier =
-            Modifier
-              .size(40.dp)
-              .clip(CircleShape)
-              .background(MaterialTheme.colorScheme.background.withAlpha(0.25f)),
-        ) {
-          Icon(
-            painter = AppIcons.Builder.ArrowLeft,
-            contentDescription = stringResource(R.string.cd_back),
-            tint = MaterialTheme.colorScheme.onSurface,
-          )
+        TooltipIconButton(contentDescription = stringResource(R.string.cd_back)) {
+          IconButton(
+            onClick = onBackClick,
+            modifier =
+              Modifier
+                .size(40.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.background.withAlpha(0.25f)),
+          ) {
+            Icon(
+              painter = AppIcons.Builder.ArrowLeft,
+              contentDescription = stringResource(R.string.cd_back),
+              tint = MaterialTheme.colorScheme.onSurface,
+            )
+          }
         }
       }
       Column(

--- a/feature/feature-settings/src/main/kotlin/com/github/naz013/feature/settings/other/whatsnew/WhatsNewScreen.kt
+++ b/feature/feature-settings/src/main/kotlin/com/github/naz013/feature/settings/other/whatsnew/WhatsNewScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.github.naz013.ui.common.R
 import com.github.naz013.ui.common.compose.AppIcons
+import com.github.naz013.ui.common.compose.foundation.TooltipIconButton
 import com.github.naz013.ui.common.compose.foundation.component.AnimatedGradientBackground
 import com.github.naz013.ui.common.compose.withAlpha
 
@@ -50,19 +51,21 @@ internal fun WhatsNewScreen(
         verticalAlignment = Alignment.CenterVertically,
       ) {
         Spacer(modifier = Modifier.width(16.dp))
-        IconButton(
-          onClick = onBackClick,
-          modifier =
-            Modifier
-              .size(40.dp)
-              .clip(CircleShape)
-              .background(MaterialTheme.colorScheme.background.withAlpha(0.25f)),
-        ) {
-          Icon(
-            painter = AppIcons.Builder.ArrowLeft,
-            contentDescription = stringResource(R.string.cd_back),
-            tint = MaterialTheme.colorScheme.onSurface,
-          )
+        TooltipIconButton(contentDescription = stringResource(R.string.cd_back)) {
+          IconButton(
+            onClick = onBackClick,
+            modifier =
+              Modifier
+                .size(40.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.background.withAlpha(0.25f)),
+          ) {
+            Icon(
+              painter = AppIcons.Builder.ArrowLeft,
+              contentDescription = stringResource(R.string.cd_back),
+              tint = MaterialTheme.colorScheme.onSurface,
+            )
+          }
         }
       }
       Column(

--- a/feature/feature-settings/src/main/kotlin/com/github/naz013/feature/settings/proversion/ProVersionScreen.kt
+++ b/feature/feature-settings/src/main/kotlin/com/github/naz013/feature/settings/proversion/ProVersionScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import com.github.naz013.ui.common.R
 import com.github.naz013.ui.common.compose.AppIcons
 import com.github.naz013.ui.common.compose.AppTheme
+import com.github.naz013.ui.common.compose.foundation.TooltipIconButton
 import com.github.naz013.ui.common.compose.foundation.component.AnimatedGradientBackground
 import com.github.naz013.ui.common.compose.withAlpha
 
@@ -52,19 +53,21 @@ internal fun ProVersionScreen(
         verticalAlignment = Alignment.CenterVertically,
       ) {
         Spacer(modifier = Modifier.width(16.dp))
-        IconButton(
-          onClick = onBackClick,
-          modifier =
-            Modifier
-              .size(40.dp)
-              .clip(CircleShape)
-              .background(MaterialTheme.colorScheme.background.withAlpha(0.25f)),
-        ) {
-          Icon(
-            painter = AppIcons.Builder.ArrowLeft,
-            contentDescription = stringResource(R.string.cd_back),
-            tint = MaterialTheme.colorScheme.onSurface,
-          )
+        TooltipIconButton(contentDescription = stringResource(R.string.cd_back)) {
+          IconButton(
+            onClick = onBackClick,
+            modifier =
+              Modifier
+                .size(40.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.background.withAlpha(0.25f)),
+          ) {
+            Icon(
+              painter = AppIcons.Builder.ArrowLeft,
+              contentDescription = stringResource(R.string.cd_back),
+              tint = MaterialTheme.colorScheme.onSurface,
+            )
+          }
         }
       }
       Column(

--- a/feature/feature-workflow/src/main/kotlin/com/github/naz013/feature/workflow/WorkflowGalleryScreen.kt
+++ b/feature/feature-workflow/src/main/kotlin/com/github/naz013/feature/workflow/WorkflowGalleryScreen.kt
@@ -23,6 +23,7 @@ import com.github.naz013.domain.workflow.WorkflowTemplateCategory
 import com.github.naz013.ui.common.compose.AppIcons
 import com.github.naz013.ui.common.compose.AppTheme
 import com.github.naz013.ui.common.compose.foundation.MenuIconButton
+import com.github.naz013.ui.common.compose.foundation.TooltipIconButton
 import com.github.naz013.ui.common.compose.foundation.component.SettingsSectionHeader
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -53,8 +54,10 @@ internal fun WorkflowGalleryScreen(
       )
     },
     floatingActionButton = {
-      FloatingActionButton(onClick = onCreateRuleClick) {
-        Icon(imageVector = Icons.Default.Add, contentDescription = stringResource(R.string.workflow_create_custom_rule))
+      TooltipIconButton(contentDescription = stringResource(R.string.workflow_create_custom_rule)) {
+        FloatingActionButton(onClick = onCreateRuleClick) {
+          Icon(imageVector = Icons.Default.Add, contentDescription = stringResource(R.string.workflow_create_custom_rule))
+        }
       }
     },
   ) { padding ->

--- a/feature/feature-workflow/src/main/kotlin/com/github/naz013/feature/workflow/WorkflowRuleRow.kt
+++ b/feature/feature-workflow/src/main/kotlin/com/github/naz013/feature/workflow/WorkflowRuleRow.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.github.naz013.ui.common.compose.AppTheme
+import com.github.naz013.ui.common.compose.foundation.TooltipIconButton
 import com.github.naz013.ui.common.compose.foundation.component.AnchoredPopupMenu
 import com.github.naz013.ui.common.compose.foundation.component.PopupMenuItem
 
@@ -74,8 +75,10 @@ internal fun WorkflowRuleRow(
         }
       },
     ) {
-      IconButton(onClick = {}) {
-        Icon(imageVector = Icons.Default.MoreVert, contentDescription = stringResource(R.string.more_options))
+      TooltipIconButton(contentDescription = stringResource(R.string.more_options)) {
+        IconButton(onClick = {}) {
+          Icon(imageVector = Icons.Default.MoreVert, contentDescription = stringResource(R.string.more_options))
+        }
       }
     }
   }

--- a/feature/feature-workflow/src/main/kotlin/com/github/naz013/feature/workflow/WorkflowRulesForGroupScreen.kt
+++ b/feature/feature-workflow/src/main/kotlin/com/github/naz013/feature/workflow/WorkflowRulesForGroupScreen.kt
@@ -23,6 +23,7 @@ import com.github.naz013.domain.workflow.WorkflowTemplateCategory
 import com.github.naz013.ui.common.compose.AppIcons
 import com.github.naz013.ui.common.compose.AppTheme
 import com.github.naz013.ui.common.compose.foundation.MenuIconButton
+import com.github.naz013.ui.common.compose.foundation.TooltipIconButton
 import com.github.naz013.ui.common.compose.foundation.component.SettingsSectionHeader
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -53,8 +54,10 @@ internal fun WorkflowRulesForGroupScreen(
       )
     },
     floatingActionButton = {
-      FloatingActionButton(onClick = onCreateRuleClick) {
-        Icon(imageVector = Icons.Default.Add, contentDescription = stringResource(R.string.workflow_create_custom_rule))
+      TooltipIconButton(contentDescription = stringResource(R.string.workflow_create_custom_rule)) {
+        FloatingActionButton(onClick = onCreateRuleClick) {
+          Icon(imageVector = Icons.Default.Add, contentDescription = stringResource(R.string.workflow_create_custom_rule))
+        }
       }
     },
   ) { padding ->

--- a/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/MenuIconButton.kt
+++ b/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/MenuIconButton.kt
@@ -25,24 +25,25 @@ fun MenuIconButton(
   enabled: Boolean = true,
   onClick: () -> Unit,
 ) {
-  IconButton(
-    modifier = modifier,
-    onClick = onClick,
-    enabled = enabled,
-    colors = IconButtonDefaults.iconButtonColors(
-      containerColor = color,
-      contentColor = iconColor,
-      disabledContainerColor = disabledColor,
-      disabledContentColor = disabledIconColor
-    ),
-    shape = IconButtonDefaults.outlinedShape,
-    content = {
-      Icon(
-        imageVector = icon,
-        contentDescription = contentDescription
-      )
-    }
-  )
+  TooltipIconButton(modifier = modifier, contentDescription = contentDescription) {
+    IconButton(
+      onClick = onClick,
+      enabled = enabled,
+      colors = IconButtonDefaults.iconButtonColors(
+        containerColor = color,
+        contentColor = iconColor,
+        disabledContainerColor = disabledColor,
+        disabledContentColor = disabledIconColor
+      ),
+      shape = IconButtonDefaults.outlinedShape,
+      content = {
+        Icon(
+          imageVector = icon,
+          contentDescription = contentDescription
+        )
+      }
+    )
+  }
 }
 
 @Composable
@@ -57,24 +58,25 @@ fun MenuIconButton(
   enabled: Boolean = true,
   onClick: () -> Unit,
 ) {
-  IconButton(
-    modifier = modifier,
-    onClick = onClick,
-    enabled = enabled,
-    colors = IconButtonDefaults.iconButtonColors(
-      containerColor = color,
-      contentColor = iconColor,
-      disabledContainerColor = disabledColor,
-      disabledContentColor = disabledIconColor
-    ),
-    shape = IconButtonDefaults.outlinedShape,
-    content = {
-      Icon(
-        painter = icon,
-        contentDescription = contentDescription
-      )
-    }
-  )
+  TooltipIconButton(modifier = modifier, contentDescription = contentDescription) {
+    IconButton(
+      onClick = onClick,
+      enabled = enabled,
+      colors = IconButtonDefaults.iconButtonColors(
+        containerColor = color,
+        contentColor = iconColor,
+        disabledContainerColor = disabledColor,
+        disabledContentColor = disabledIconColor
+      ),
+      shape = IconButtonDefaults.outlinedShape,
+      content = {
+        Icon(
+          painter = icon,
+          contentDescription = contentDescription
+        )
+      }
+    )
+  }
 }
 
 @Preview(showBackground = true)

--- a/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/PrimaryIconButton.kt
+++ b/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/PrimaryIconButton.kt
@@ -27,24 +27,25 @@ fun PrimaryIconButton(
   enabled: Boolean = true,
   onClick: () -> Unit,
 ) {
-  IconButton(
-    modifier = modifier,
-    onClick = onClick,
-    enabled = enabled,
-    colors = IconButtonDefaults.outlinedIconButtonColors(
-      containerColor = color,
-      contentColor = iconColor,
-      disabledContainerColor = disabledColor,
-      disabledContentColor = disabledIconColor
-    ),
-    shape = IconButtonDefaults.outlinedShape,
-    content = {
-      Icon(
-        imageVector = icon,
-        contentDescription = contentDescription
-      )
-    }
-  )
+  TooltipIconButton(modifier = modifier, contentDescription = contentDescription) {
+    IconButton(
+      onClick = onClick,
+      enabled = enabled,
+      colors = IconButtonDefaults.outlinedIconButtonColors(
+        containerColor = color,
+        contentColor = iconColor,
+        disabledContainerColor = disabledColor,
+        disabledContentColor = disabledIconColor
+      ),
+      shape = IconButtonDefaults.outlinedShape,
+      content = {
+        Icon(
+          imageVector = icon,
+          contentDescription = contentDescription
+        )
+      }
+    )
+  }
 }
 
 @Composable
@@ -59,24 +60,25 @@ fun PrimaryIconButton(
   enabled: Boolean = true,
   onClick: () -> Unit,
 ) {
-  IconButton(
-    modifier = modifier,
-    onClick = onClick,
-    enabled = enabled,
-    colors = IconButtonDefaults.outlinedIconButtonColors(
-      containerColor = color,
-      contentColor = iconColor,
-      disabledContainerColor = disabledColor,
-      disabledContentColor = disabledIconColor
-    ),
-    shape = IconButtonDefaults.outlinedShape,
-    content = {
-      Icon(
-        painter = icon,
-        contentDescription = contentDescription
-      )
-    }
-  )
+  TooltipIconButton(modifier = modifier, contentDescription = contentDescription) {
+    IconButton(
+      onClick = onClick,
+      enabled = enabled,
+      colors = IconButtonDefaults.outlinedIconButtonColors(
+        containerColor = color,
+        contentColor = iconColor,
+        disabledContainerColor = disabledColor,
+        disabledContentColor = disabledIconColor
+      ),
+      shape = IconButtonDefaults.outlinedShape,
+      content = {
+        Icon(
+          painter = icon,
+          contentDescription = contentDescription
+        )
+      }
+    )
+  }
 }
 
 // Preview functions

--- a/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/TooltipIconButton.kt
+++ b/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/TooltipIconButton.kt
@@ -1,0 +1,30 @@
+package com.github.naz013.ui.common.compose.foundation
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.PlainTooltip
+import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TooltipIconButton(
+  modifier: Modifier = Modifier,
+  contentDescription: String?,
+  content: @Composable () -> Unit,
+) {
+  if (contentDescription.isNullOrBlank()) {
+    content()
+    return
+  }
+  TooltipBox(
+    positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+    tooltip = { PlainTooltip { Text(contentDescription) } },
+    state = rememberTooltipState(),
+    modifier = modifier,
+    content = content,
+  )
+}

--- a/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/TooltipIconButton.kt
+++ b/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/TooltipIconButton.kt
@@ -3,6 +3,7 @@ package com.github.naz013.ui.common.compose.foundation
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipAnchorPosition
 import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.rememberTooltipState
@@ -21,7 +22,7 @@ fun TooltipIconButton(
     return
   }
   TooltipBox(
-    positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+    positionProvider = TooltipDefaults.rememberTooltipPositionProvider(TooltipAnchorPosition.Above),
     tooltip = { PlainTooltip { Text(contentDescription) } },
     state = rememberTooltipState(),
     modifier = modifier,

--- a/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/component/BottomSheet.kt
+++ b/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/component/BottomSheet.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.github.naz013.ui.common.compose.AppTheme
+import com.github.naz013.ui.common.compose.foundation.TooltipIconButton
 import kotlinx.coroutines.launch
 
 /**
@@ -171,15 +172,17 @@ fun BottomSheetHeader(
     }
 
     if (showCloseButton) {
-      IconButton(
-        onClick = onCloseClick,
-        modifier = Modifier.align(Alignment.CenterEnd)
+      TooltipIconButton(
+        contentDescription = "Close",
+        modifier = Modifier.align(Alignment.CenterEnd),
       ) {
-        Icon(
-          imageVector = Icons.Default.Close,
-          contentDescription = "Close",
-          tint = MaterialTheme.colorScheme.onSurfaceVariant
-        )
+        IconButton(onClick = onCloseClick) {
+          Icon(
+            imageVector = Icons.Default.Close,
+            contentDescription = "Close",
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
+          )
+        }
       }
     }
   }

--- a/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/component/NumberStepperField.kt
+++ b/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/component/NumberStepperField.kt
@@ -5,8 +5,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.runtime.Composable
@@ -14,12 +12,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.github.naz013.ui.common.R
 import com.github.naz013.ui.common.compose.AppIcons
 import com.github.naz013.ui.common.compose.AppTheme
+import com.github.naz013.ui.common.compose.foundation.MenuIconButton
 
 private val STEP_BUTTON_SIZE = 40.dp
 private val TEXT_FIELD_WIDTH = 64.dp
@@ -53,16 +54,16 @@ fun NumberStepperField(
     horizontalArrangement = Arrangement.Center,
     verticalAlignment = Alignment.CenterVertically,
   ) {
-    IconButton(
+    MenuIconButton(
+      modifier = Modifier.size(STEP_BUTTON_SIZE),
+      icon = AppIcons.Fluent.Remove,
+      contentDescription = stringResource(R.string.cd_decrease),
+      enabled = enabled && value > minValue,
       onClick = {
         if (hapticFeedbackEnabled) hapticFeedback.performHapticFeedback(HapticFeedbackType.TextHandleMove)
         onValueChange((value - step).coerceIn(minValue, maxValue))
       },
-      enabled = enabled && value > minValue,
-      modifier = Modifier.size(STEP_BUTTON_SIZE),
-    ) {
-      Icon(painter = AppIcons.Fluent.Remove, contentDescription = null)
-    }
+    )
 
     OutlinedTextField(
       value = value.toString(),
@@ -81,16 +82,16 @@ fun NumberStepperField(
       keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
     )
 
-    IconButton(
+    MenuIconButton(
+      modifier = Modifier.size(STEP_BUTTON_SIZE),
+      icon = AppIcons.Fluent.Add,
+      contentDescription = stringResource(R.string.cd_increase),
+      enabled = enabled && value < maxValue,
       onClick = {
         if (hapticFeedbackEnabled) hapticFeedback.performHapticFeedback(HapticFeedbackType.TextHandleMove)
         onValueChange((value + step).coerceIn(minValue, maxValue))
       },
-      enabled = enabled && value < maxValue,
-      modifier = Modifier.size(STEP_BUTTON_SIZE),
-    ) {
-      Icon(painter = AppIcons.Fluent.Add, contentDescription = null)
-    }
+    )
   }
 }
 

--- a/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/component/PinInput.kt
+++ b/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/component/PinInput.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.github.naz013.ui.common.R
 import com.github.naz013.ui.common.compose.AppTheme
+import com.github.naz013.ui.common.compose.foundation.TooltipIconButton
 
 private val DigitButtonSize = 64.dp
 private val DotSize = 20.dp
@@ -89,12 +90,17 @@ fun PinInput(
         fingerprintButton?.invoke()
       }
       PinDigitButton(digit = digitOrder[9], onClick = onDigitClick)
-      IconButton(onClick = onDeleteClick, modifier = Modifier.size(DigitButtonSize)) {
-        Icon(
-          painter = painterResource(R.drawable.ic_fluent_dismiss),
-          contentDescription = stringResource(R.string.delete),
-          tint = MaterialTheme.colorScheme.onSurface,
-        )
+      TooltipIconButton(
+        contentDescription = stringResource(R.string.delete),
+        modifier = Modifier.size(DigitButtonSize),
+      ) {
+        IconButton(onClick = onDeleteClick) {
+          Icon(
+            painter = painterResource(R.drawable.ic_fluent_dismiss),
+            contentDescription = stringResource(R.string.delete),
+            tint = MaterialTheme.colorScheme.onSurface,
+          )
+        }
       }
     }
   }

--- a/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/component/PopupMenu.kt
+++ b/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/component/PopupMenu.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
 import com.github.naz013.ui.common.compose.AppTheme
+import com.github.naz013.ui.common.compose.foundation.TooltipIconButton
 
 private val PopupMenuCornerRadius = 16.dp
 private val PopupMenuIconSize = 20.dp
@@ -708,11 +709,13 @@ private fun AnchoredPopupMenuPreview() {
           // Handle item click
         }
       ) {
-        IconButton(onClick = { }) {
-          Icon(
-            imageVector = Icons.Default.MoreVert,
-            contentDescription = "More options"
-          )
+        TooltipIconButton(contentDescription = "More options") {
+          IconButton(onClick = { }) {
+            Icon(
+              imageVector = Icons.Default.MoreVert,
+              contentDescription = "More options"
+            )
+          }
         }
       }
     }
@@ -796,11 +799,13 @@ private fun AnchoredPopupMenuEndAlignmentPreview() {
           horizontalAlignment = PopupMenuAlignment.End,
           verticalAlignment = PopupMenuVerticalAlignment.Auto
         ) {
-          IconButton(onClick = { }) {
-            Icon(
-              imageVector = Icons.Default.MoreVert,
-              contentDescription = "Menu"
-            )
+          TooltipIconButton(contentDescription = "Menu") {
+            IconButton(onClick = { }) {
+              Icon(
+                imageVector = Icons.Default.MoreVert,
+                contentDescription = "Menu"
+              )
+            }
           }
         }
       }
@@ -837,11 +842,13 @@ private fun AnchoredPopupMenuAboveAlignmentPreview() {
           horizontalAlignment = PopupMenuAlignment.Start,
           verticalAlignment = PopupMenuVerticalAlignment.Above
         ) {
-          IconButton(onClick = { }) {
-            Icon(
-              imageVector = Icons.Default.MoreVert,
-              contentDescription = "Actions"
-            )
+          TooltipIconButton(contentDescription = "Actions") {
+            IconButton(onClick = { }) {
+              Icon(
+                imageVector = Icons.Default.MoreVert,
+                contentDescription = "Actions"
+              )
+            }
           }
         }
       }

--- a/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/component/SearchBar.kt
+++ b/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/component/SearchBar.kt
@@ -79,7 +79,7 @@ fun SearchBar(
           IconButton(onClick = { onQueryChange("") }) {
             Icon(
               painter = AppIcons.Fluent.Dismiss,
-              contentDescription = null,
+              contentDescription = stringResource(R.string.cd_clear_search),
               tint = MaterialTheme.colorScheme.onSurfaceVariant,
               modifier = Modifier.fillMaxSize()
                 .padding(10.dp)

--- a/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/component/SearchBar.kt
+++ b/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/component/SearchBar.kt
@@ -22,11 +22,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.github.naz013.ui.common.R
 import com.github.naz013.ui.common.compose.AppIcons
 import com.github.naz013.ui.common.compose.AppTheme
+import com.github.naz013.ui.common.compose.foundation.TooltipIconButton
 
 /**
  * A rounded, single-line search input following Material 3 styling.
@@ -72,14 +75,16 @@ fun SearchBar(
         exit = scaleOut(animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy)) +
           fadeOut()
       ) {
-        IconButton(onClick = { onQueryChange("") }) {
-          Icon(
-            painter = AppIcons.Fluent.Dismiss,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.fillMaxSize()
-              .padding(10.dp)
-          )
+        TooltipIconButton(contentDescription = stringResource(R.string.cd_clear_search)) {
+          IconButton(onClick = { onQueryChange("") }) {
+            Icon(
+              painter = AppIcons.Fluent.Dismiss,
+              contentDescription = null,
+              tint = MaterialTheme.colorScheme.onSurfaceVariant,
+              modifier = Modifier.fillMaxSize()
+                .padding(10.dp)
+            )
+          }
         }
       }
     },

--- a/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/login/PinLoginScreen.kt
+++ b/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/login/PinLoginScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.github.naz013.ui.common.R
 import com.github.naz013.ui.common.compose.AppTheme
+import com.github.naz013.ui.common.compose.foundation.TooltipIconButton
 import com.github.naz013.ui.common.compose.foundation.component.PinInput
 
 @Composable
@@ -58,12 +59,14 @@ internal fun PinLoginScreen(
         shuffleDigits = shuffleDigits,
         fingerprintButton = if (showFingerprintButton) {
           {
-            IconButton(onClick = onFingerprintClick) {
-              Icon(
-                painter = painterResource(R.drawable.ic_fluent_fingerprint),
-                contentDescription = stringResource(R.string.enter_your_pin),
-                tint = MaterialTheme.colorScheme.onBackground,
-              )
+            TooltipIconButton(contentDescription = stringResource(R.string.enter_your_pin)) {
+              IconButton(onClick = onFingerprintClick) {
+                Icon(
+                  painter = painterResource(R.drawable.ic_fluent_fingerprint),
+                  contentDescription = stringResource(R.string.enter_your_pin),
+                  tint = MaterialTheme.colorScheme.onBackground,
+                )
+              }
             }
           }
         } else {
@@ -73,18 +76,20 @@ internal fun PinLoginScreen(
       Spacer(modifier = Modifier.weight(1.4f))
     }
 
-    IconButton(
-      onClick = onCloseClick,
+    TooltipIconButton(
+      contentDescription = stringResource(R.string.cd_back),
       modifier = Modifier
         .align(Alignment.TopStart)
         .statusBarsPadding()
         .padding(8.dp),
     ) {
-      Icon(
-        painter = painterResource(R.drawable.ic_fluent_dismiss),
-        contentDescription = stringResource(R.string.cd_back),
-        tint = MaterialTheme.colorScheme.onBackground,
-      )
+      IconButton(onClick = onCloseClick) {
+        Icon(
+          painter = painterResource(R.drawable.ic_fluent_dismiss),
+          contentDescription = stringResource(R.string.cd_back),
+          tint = MaterialTheme.colorScheme.onBackground,
+        )
+      }
     }
   }
 }

--- a/ui/ui-common/src/main/res/values-ar/strings.xml
+++ b/ui/ui-common/src/main/res/values-ar/strings.xml
@@ -1205,4 +1205,13 @@
     <string name="header_items">عناصر الرأس</string>
     <string name="header_items_subtitle">اختر العناصر التي تظهر في الشاشة الرئيسية وترتيبها</string>
     <string name="header_item_always_shown">معروض دائمًا</string>
+    <string name="cd_collapse">طي</string>
+    <string name="cd_remove">إزالة</string>
+    <string name="cd_decrease">تقليل</string>
+    <string name="cd_increase">زيادة</string>
+    <string name="cd_clear_search">مسح البحث</string>
+    <string name="cd_start_voice_input">بدء الإدخال الصوتي</string>
+    <string name="cd_stop_voice_input">إيقاف الإدخال الصوتي</string>
+    <string name="cd_mark_as_done">تحديد كمكتمل</string>
+    <string name="cd_mark_as_not_done">تحديد كغير مكتمل</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-bg/strings.xml
+++ b/ui/ui-common/src/main/res/values-bg/strings.xml
@@ -1208,4 +1208,13 @@
     <string name="header_items">Елементи на заглавието</string>
     <string name="header_items_subtitle">Изберете кои елементи да се показват на началния екран и в какъв ред</string>
     <string name="header_item_always_shown">Винаги видимо</string>
+    <string name="cd_collapse">Свиване</string>
+    <string name="cd_remove">Премахване</string>
+    <string name="cd_decrease">Намаляване</string>
+    <string name="cd_increase">Увеличаване</string>
+    <string name="cd_clear_search">Изчистване на търсенето</string>
+    <string name="cd_start_voice_input">Стартиране на гласово въвеждане</string>
+    <string name="cd_stop_voice_input">Спиране на гласово въвеждане</string>
+    <string name="cd_mark_as_done">Маркиране като изпълнено</string>
+    <string name="cd_mark_as_not_done">Маркиране като неизпълнено</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-cs/strings.xml
+++ b/ui/ui-common/src/main/res/values-cs/strings.xml
@@ -1207,4 +1207,13 @@
     <string name="header_items">Položky záhlaví</string>
     <string name="header_items_subtitle">Vyberte, které položky se zobrazí na domovské obrazovce a v jakém pořadí</string>
     <string name="header_item_always_shown">Vždy zobrazeno</string>
+    <string name="cd_collapse">Sbalit</string>
+    <string name="cd_remove">Odebrat</string>
+    <string name="cd_decrease">Snížit</string>
+    <string name="cd_increase">Zvýšit</string>
+    <string name="cd_clear_search">Vymazat hledání</string>
+    <string name="cd_start_voice_input">Spustit hlasový vstup</string>
+    <string name="cd_stop_voice_input">Zastavit hlasový vstup</string>
+    <string name="cd_mark_as_done">Označit jako dokončené</string>
+    <string name="cd_mark_as_not_done">Označit jako nedokončené</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-da/strings.xml
+++ b/ui/ui-common/src/main/res/values-da/strings.xml
@@ -1205,4 +1205,13 @@
     <string name="header_items">Sidehovedelementer</string>
     <string name="header_items_subtitle">Vælg hvilke elementer der vises på startskærmen, og i hvilken rækkefølge</string>
     <string name="header_item_always_shown">Vises altid</string>
+    <string name="cd_collapse">Skjul</string>
+    <string name="cd_remove">Fjern</string>
+    <string name="cd_decrease">Formindsk</string>
+    <string name="cd_increase">Forøg</string>
+    <string name="cd_clear_search">Ryd søgning</string>
+    <string name="cd_start_voice_input">Start stemmeinput</string>
+    <string name="cd_stop_voice_input">Stop stemmeinput</string>
+    <string name="cd_mark_as_done">Markér som udført</string>
+    <string name="cd_mark_as_not_done">Markér som ikke udført</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-de/strings.xml
+++ b/ui/ui-common/src/main/res/values-de/strings.xml
@@ -1203,4 +1203,13 @@
     <string name="in_app_notification_banner">In-App-Benachrichtigungsbanner</string>
     <string name="in_app_notification_banner_enabled">Banner in der App anzeigen, wenn eine Erinnerungs- oder Geburtstagsbenachrichtigung ausgelöst wird</string>
     <string name="in_app_notification_banner_disabled">Nur die Systembenachrichtigung anzeigen</string>
+    <string name="cd_collapse">Einklappen</string>
+    <string name="cd_remove">Entfernen</string>
+    <string name="cd_decrease">Verringern</string>
+    <string name="cd_increase">Erhöhen</string>
+    <string name="cd_clear_search">Suche löschen</string>
+    <string name="cd_start_voice_input">Spracheingabe starten</string>
+    <string name="cd_stop_voice_input">Spracheingabe stoppen</string>
+    <string name="cd_mark_as_done">Als erledigt markieren</string>
+    <string name="cd_mark_as_not_done">Als nicht erledigt markieren</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-es/strings.xml
+++ b/ui/ui-common/src/main/res/values-es/strings.xml
@@ -1207,4 +1207,13 @@
     <string name="header_items">Elementos de cabecera</string>
     <string name="header_items_subtitle">Elige qué elementos aparecen en la pantalla de inicio y en qué orden</string>
     <string name="header_item_always_shown">Siempre visible</string>
+    <string name="cd_collapse">Contraer</string>
+    <string name="cd_remove">Quitar</string>
+    <string name="cd_decrease">Disminuir</string>
+    <string name="cd_increase">Aumentar</string>
+    <string name="cd_clear_search">Borrar búsqueda</string>
+    <string name="cd_start_voice_input">Iniciar entrada de voz</string>
+    <string name="cd_stop_voice_input">Detener entrada de voz</string>
+    <string name="cd_mark_as_done">Marcar como hecho</string>
+    <string name="cd_mark_as_not_done">Marcar como no hecho</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-fr/strings.xml
+++ b/ui/ui-common/src/main/res/values-fr/strings.xml
@@ -1207,4 +1207,13 @@
     <string name="header_items">Éléments d\'en-tête</string>
     <string name="header_items_subtitle">Choisissez les éléments affichés sur l\'écran d\'accueil et leur ordre</string>
     <string name="header_item_always_shown">Toujours affiché</string>
+    <string name="cd_collapse">Réduire</string>
+    <string name="cd_remove">Supprimer</string>
+    <string name="cd_decrease">Diminuer</string>
+    <string name="cd_increase">Augmenter</string>
+    <string name="cd_clear_search">Effacer la recherche</string>
+    <string name="cd_start_voice_input">Démarrer la saisie vocale</string>
+    <string name="cd_stop_voice_input">Arrêter la saisie vocale</string>
+    <string name="cd_mark_as_done">Marquer comme terminé</string>
+    <string name="cd_mark_as_not_done">Marquer comme non terminé</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-hi/strings.xml
+++ b/ui/ui-common/src/main/res/values-hi/strings.xml
@@ -1209,4 +1209,13 @@
     <string name="header_items">हेडर आइटम</string>
     <string name="header_items_subtitle">चुनें कि होम स्क्रीन पर कौन से आइटम और किस क्रम में दिखाई दें</string>
     <string name="header_item_always_shown">हमेशा दिखाया जाता है</string>
+    <string name="cd_collapse">संक्षिप्त करें</string>
+    <string name="cd_remove">हटाएं</string>
+    <string name="cd_decrease">घटाएं</string>
+    <string name="cd_increase">बढ़ाएं</string>
+    <string name="cd_clear_search">खोज साफ़ करें</string>
+    <string name="cd_start_voice_input">आवाज़ इनपुट शुरू करें</string>
+    <string name="cd_stop_voice_input">आवाज़ इनपुट रोकें</string>
+    <string name="cd_mark_as_done">पूर्ण के रूप में चिह्नित करें</string>
+    <string name="cd_mark_as_not_done">अपूर्ण के रूप में चिह्नित करें</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-id/strings.xml
+++ b/ui/ui-common/src/main/res/values-id/strings.xml
@@ -1205,4 +1205,13 @@
     <string name="header_items">Item header</string>
     <string name="header_items_subtitle">Pilih item mana yang muncul di layar Beranda dan urutannya</string>
     <string name="header_item_always_shown">Selalu ditampilkan</string>
+    <string name="cd_collapse">Ciutkan</string>
+    <string name="cd_remove">Hapus</string>
+    <string name="cd_decrease">Kurangi</string>
+    <string name="cd_increase">Tambah</string>
+    <string name="cd_clear_search">Hapus pencarian</string>
+    <string name="cd_start_voice_input">Mulai masukan suara</string>
+    <string name="cd_stop_voice_input">Hentikan masukan suara</string>
+    <string name="cd_mark_as_done">Tandai selesai</string>
+    <string name="cd_mark_as_not_done">Tandai belum selesai</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-it/strings.xml
+++ b/ui/ui-common/src/main/res/values-it/strings.xml
@@ -1207,4 +1207,13 @@
     <string name="header_items">Elementi dell\'intestazione</string>
     <string name="header_items_subtitle">Scegli quali elementi vengono visualizzati nella schermata Home e in quale ordine</string>
     <string name="header_item_always_shown">Sempre visibile</string>
+    <string name="cd_collapse">Comprimi</string>
+    <string name="cd_remove">Rimuovi</string>
+    <string name="cd_decrease">Diminuisci</string>
+    <string name="cd_increase">Aumenta</string>
+    <string name="cd_clear_search">Cancella ricerca</string>
+    <string name="cd_start_voice_input">Avvia inserimento vocale</string>
+    <string name="cd_stop_voice_input">Interrompi inserimento vocale</string>
+    <string name="cd_mark_as_done">Contrassegna come completato</string>
+    <string name="cd_mark_as_not_done">Contrassegna come non completato</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-ja/strings.xml
+++ b/ui/ui-common/src/main/res/values-ja/strings.xml
@@ -1207,4 +1207,13 @@
     <string name="header_items">ヘッダー項目</string>
     <string name="header_items_subtitle">ホーム画面に表示する項目と順序を選択します</string>
     <string name="header_item_always_shown">常に表示</string>
+    <string name="cd_collapse">折りたたむ</string>
+    <string name="cd_remove">削除</string>
+    <string name="cd_decrease">減らす</string>
+    <string name="cd_increase">増やす</string>
+    <string name="cd_clear_search">検索をクリア</string>
+    <string name="cd_start_voice_input">音声入力を開始</string>
+    <string name="cd_stop_voice_input">音声入力を停止</string>
+    <string name="cd_mark_as_done">完了にする</string>
+    <string name="cd_mark_as_not_done">未完了にする</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-ko/strings.xml
+++ b/ui/ui-common/src/main/res/values-ko/strings.xml
@@ -1207,4 +1207,13 @@
     <string name="header_items">헤더 항목</string>
     <string name="header_items_subtitle">홈 화면에 표시할 항목과 순서를 선택하세요</string>
     <string name="header_item_always_shown">항상 표시됨</string>
+    <string name="cd_collapse">접기</string>
+    <string name="cd_remove">제거</string>
+    <string name="cd_decrease">감소</string>
+    <string name="cd_increase">증가</string>
+    <string name="cd_clear_search">검색 지우기</string>
+    <string name="cd_start_voice_input">음성 입력 시작</string>
+    <string name="cd_stop_voice_input">음성 입력 중지</string>
+    <string name="cd_mark_as_done">완료로 표시</string>
+    <string name="cd_mark_as_not_done">미완료로 표시</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-nb/strings.xml
+++ b/ui/ui-common/src/main/res/values-nb/strings.xml
@@ -1205,4 +1205,13 @@
     <string name="header_items">Topptekstelementer</string>
     <string name="header_items_subtitle">Velg hvilke elementer som vises på hjem-skjermen og i hvilken rekkefølge</string>
     <string name="header_item_always_shown">Vises alltid</string>
+    <string name="cd_collapse">Skjul</string>
+    <string name="cd_remove">Fjern</string>
+    <string name="cd_decrease">Reduser</string>
+    <string name="cd_increase">Øk</string>
+    <string name="cd_clear_search">Tøm søk</string>
+    <string name="cd_start_voice_input">Start taleinntasting</string>
+    <string name="cd_stop_voice_input">Stopp taleinntasting</string>
+    <string name="cd_mark_as_done">Merk som fullført</string>
+    <string name="cd_mark_as_not_done">Merk som ikke fullført</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-nl/strings.xml
+++ b/ui/ui-common/src/main/res/values-nl/strings.xml
@@ -1205,4 +1205,13 @@
     <string name="header_items">Kopregel-items</string>
     <string name="header_items_subtitle">Kies welke items op het startscherm worden weergegeven en in welke volgorde</string>
     <string name="header_item_always_shown">Altijd zichtbaar</string>
+    <string name="cd_collapse">Samenvouwen</string>
+    <string name="cd_remove">Verwijderen</string>
+    <string name="cd_decrease">Verlagen</string>
+    <string name="cd_increase">Verhogen</string>
+    <string name="cd_clear_search">Zoekopdracht wissen</string>
+    <string name="cd_start_voice_input">Spraakinvoer starten</string>
+    <string name="cd_stop_voice_input">Spraakinvoer stoppen</string>
+    <string name="cd_mark_as_done">Markeren als voltooid</string>
+    <string name="cd_mark_as_not_done">Markeren als niet voltooid</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-pl/strings.xml
+++ b/ui/ui-common/src/main/res/values-pl/strings.xml
@@ -1207,4 +1207,13 @@
     <string name="header_items">Elementy nagłówka</string>
     <string name="header_items_subtitle">Wybierz, które elementy pojawiają się na ekranie głównym i w jakiej kolejności</string>
     <string name="header_item_always_shown">Zawsze widoczne</string>
+    <string name="cd_collapse">Zwiń</string>
+    <string name="cd_remove">Usuń</string>
+    <string name="cd_decrease">Zmniejsz</string>
+    <string name="cd_increase">Zwiększ</string>
+    <string name="cd_clear_search">Wyczyść wyszukiwanie</string>
+    <string name="cd_start_voice_input">Rozpocznij wprowadzanie głosowe</string>
+    <string name="cd_stop_voice_input">Zatrzymaj wprowadzanie głosowe</string>
+    <string name="cd_mark_as_done">Oznacz jako wykonane</string>
+    <string name="cd_mark_as_not_done">Oznacz jako niewykonane</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-pt/strings.xml
+++ b/ui/ui-common/src/main/res/values-pt/strings.xml
@@ -1207,4 +1207,13 @@
     <string name="header_items">Itens do cabeçalho</string>
     <string name="header_items_subtitle">Escolha quais itens aparecem na tela inicial e em que ordem</string>
     <string name="header_item_always_shown">Sempre exibido</string>
+    <string name="cd_collapse">Recolher</string>
+    <string name="cd_remove">Remover</string>
+    <string name="cd_decrease">Diminuir</string>
+    <string name="cd_increase">Aumentar</string>
+    <string name="cd_clear_search">Limpar pesquisa</string>
+    <string name="cd_start_voice_input">Iniciar entrada de voz</string>
+    <string name="cd_stop_voice_input">Parar entrada de voz</string>
+    <string name="cd_mark_as_done">Marcar como concluído</string>
+    <string name="cd_mark_as_not_done">Marcar como não concluído</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-ro/strings.xml
+++ b/ui/ui-common/src/main/res/values-ro/strings.xml
@@ -1207,4 +1207,13 @@
     <string name="header_items">Elemente antet</string>
     <string name="header_items_subtitle">Alege ce elemente apar pe ecranul Acasă și în ce ordine</string>
     <string name="header_item_always_shown">Afișat mereu</string>
+    <string name="cd_collapse">Restrânge</string>
+    <string name="cd_remove">Elimină</string>
+    <string name="cd_decrease">Micșorează</string>
+    <string name="cd_increase">Mărește</string>
+    <string name="cd_clear_search">Șterge căutarea</string>
+    <string name="cd_start_voice_input">Începe introducerea vocală</string>
+    <string name="cd_stop_voice_input">Oprește introducerea vocală</string>
+    <string name="cd_mark_as_done">Marchează ca finalizat</string>
+    <string name="cd_mark_as_not_done">Marchează ca nefinalizat</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-ru/strings.xml
+++ b/ui/ui-common/src/main/res/values-ru/strings.xml
@@ -1206,4 +1206,13 @@
     <string name="header_items">Элементы заголовка</string>
     <string name="header_items_subtitle">Выберите, какие элементы отображаются на главном экране и в каком порядке</string>
     <string name="header_item_always_shown">Всегда отображается</string>
+    <string name="cd_collapse">Свернуть</string>
+    <string name="cd_remove">Удалить</string>
+    <string name="cd_decrease">Уменьшить</string>
+    <string name="cd_increase">Увеличить</string>
+    <string name="cd_clear_search">Очистить поиск</string>
+    <string name="cd_start_voice_input">Начать голосовой ввод</string>
+    <string name="cd_stop_voice_input">Остановить голосовой ввод</string>
+    <string name="cd_mark_as_done">Отметить как выполнено</string>
+    <string name="cd_mark_as_not_done">Отметить как невыполненное</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-sv/strings.xml
+++ b/ui/ui-common/src/main/res/values-sv/strings.xml
@@ -1205,4 +1205,13 @@
     <string name="header_items">Sidhuvudobjekt</string>
     <string name="header_items_subtitle">Välj vilka objekt som visas på hemskärmen och i vilken ordning</string>
     <string name="header_item_always_shown">Visas alltid</string>
+    <string name="cd_collapse">Fäll ihop</string>
+    <string name="cd_remove">Ta bort</string>
+    <string name="cd_decrease">Minska</string>
+    <string name="cd_increase">Öka</string>
+    <string name="cd_clear_search">Rensa sökning</string>
+    <string name="cd_start_voice_input">Starta röstinmatning</string>
+    <string name="cd_stop_voice_input">Stoppa röstinmatning</string>
+    <string name="cd_mark_as_done">Markera som klar</string>
+    <string name="cd_mark_as_not_done">Markera som ej klar</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-th/strings.xml
+++ b/ui/ui-common/src/main/res/values-th/strings.xml
@@ -1205,4 +1205,13 @@
     <string name="header_items">รายการส่วนหัว</string>
     <string name="header_items_subtitle">เลือกรายการที่จะแสดงบนหน้าจอหลักและลำดับการแสดงผล</string>
     <string name="header_item_always_shown">แสดงตลอดเวลา</string>
+    <string name="cd_collapse">ยุบ</string>
+    <string name="cd_remove">ลบ</string>
+    <string name="cd_decrease">ลด</string>
+    <string name="cd_increase">เพิ่ม</string>
+    <string name="cd_clear_search">ล้างการค้นหา</string>
+    <string name="cd_start_voice_input">เริ่มการป้อนข้อมูลด้วยเสียง</string>
+    <string name="cd_stop_voice_input">หยุดการป้อนข้อมูลด้วยเสียง</string>
+    <string name="cd_mark_as_done">ทำเครื่องหมายว่าเสร็จสิ้น</string>
+    <string name="cd_mark_as_not_done">ทำเครื่องหมายว่ายังไม่เสร็จสิ้น</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-tr/strings.xml
+++ b/ui/ui-common/src/main/res/values-tr/strings.xml
@@ -1208,4 +1208,13 @@
     <string name="header_items">Üst bilgi öğeleri</string>
     <string name="header_items_subtitle">Ana ekranda hangi öğelerin ve hangi sırayla görüneceğini seçin</string>
     <string name="header_item_always_shown">Her zaman gösterilir</string>
+    <string name="cd_collapse">Daralt</string>
+    <string name="cd_remove">Kaldır</string>
+    <string name="cd_decrease">Azalt</string>
+    <string name="cd_increase">Artır</string>
+    <string name="cd_clear_search">Aramayı temizle</string>
+    <string name="cd_start_voice_input">Sesli girişi başlat</string>
+    <string name="cd_stop_voice_input">Sesli girişi durdur</string>
+    <string name="cd_mark_as_done">Tamamlandı olarak işaretle</string>
+    <string name="cd_mark_as_not_done">Tamamlanmadı olarak işaretle</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-uk/strings.xml
+++ b/ui/ui-common/src/main/res/values-uk/strings.xml
@@ -1208,4 +1208,13 @@
     <string name="header_items">Елементи заголовка</string>
     <string name="header_items_subtitle">Виберіть, які елементи відображаються на головному екрані та в якому порядку</string>
     <string name="header_item_always_shown">Завжди відображається</string>
+    <string name="cd_collapse">Згорнути</string>
+    <string name="cd_remove">Видалити</string>
+    <string name="cd_decrease">Зменшити</string>
+    <string name="cd_increase">Збільшити</string>
+    <string name="cd_clear_search">Очистити пошук</string>
+    <string name="cd_start_voice_input">Почати голосове введення</string>
+    <string name="cd_stop_voice_input">Зупинити голосове введення</string>
+    <string name="cd_mark_as_done">Позначити як виконане</string>
+    <string name="cd_mark_as_not_done">Позначити як невиконане</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-vi/strings.xml
+++ b/ui/ui-common/src/main/res/values-vi/strings.xml
@@ -1205,4 +1205,13 @@
     <string name="header_items">Mục tiêu đề</string>
     <string name="header_items_subtitle">Chọn các mục xuất hiện trên màn hình Trang chủ và thứ tự của chúng</string>
     <string name="header_item_always_shown">Luôn hiển thị</string>
+    <string name="cd_collapse">Thu gọn</string>
+    <string name="cd_remove">Xóa</string>
+    <string name="cd_decrease">Giảm</string>
+    <string name="cd_increase">Tăng</string>
+    <string name="cd_clear_search">Xóa tìm kiếm</string>
+    <string name="cd_start_voice_input">Bắt đầu nhập bằng giọng nói</string>
+    <string name="cd_stop_voice_input">Dừng nhập bằng giọng nói</string>
+    <string name="cd_mark_as_done">Đánh dấu là đã hoàn thành</string>
+    <string name="cd_mark_as_not_done">Đánh dấu là chưa hoàn thành</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-zh/strings.xml
+++ b/ui/ui-common/src/main/res/values-zh/strings.xml
@@ -1208,4 +1208,13 @@
     <string name="header_items">标题项目</string>
     <string name="header_items_subtitle">选择主屏幕上显示哪些项目及其顺序</string>
     <string name="header_item_always_shown">始终显示</string>
+    <string name="cd_collapse">收起</string>
+    <string name="cd_remove">移除</string>
+    <string name="cd_decrease">减少</string>
+    <string name="cd_increase">增加</string>
+    <string name="cd_clear_search">清除搜索</string>
+    <string name="cd_start_voice_input">开始语音输入</string>
+    <string name="cd_stop_voice_input">停止语音输入</string>
+    <string name="cd_mark_as_done">标记为已完成</string>
+    <string name="cd_mark_as_not_done">标记为未完成</string>
 </resources>

--- a/ui/ui-common/src/main/res/values/strings.xml
+++ b/ui/ui-common/src/main/res/values/strings.xml
@@ -1210,4 +1210,14 @@
     <string name="header_items">Header items</string>
     <string name="header_items_subtitle">Choose which items appear on the Home screen and in what order</string>
     <string name="header_item_always_shown">Always shown</string>
+
+    <string name="cd_collapse">Collapse</string>
+    <string name="cd_remove">Remove</string>
+    <string name="cd_decrease">Decrease</string>
+    <string name="cd_increase">Increase</string>
+    <string name="cd_clear_search">Clear search</string>
+    <string name="cd_start_voice_input">Start voice input</string>
+    <string name="cd_stop_voice_input">Stop voice input</string>
+    <string name="cd_mark_as_done">Mark as done</string>
+    <string name="cd_mark_as_not_done">Mark as not done</string>
 </resources>


### PR DESCRIPTION
Introduces TooltipIconButton, a reusable primitive that wraps content in a Material3 TooltipBox (long-press on touch, hover on mouse/trackpad), using the existing contentDescription as the tooltip label. Wires it into MenuIconButton and PrimaryIconButton with no signature changes, so every existing call site through those wrappers gets a tooltip for free.

First step of the app-wide icon button tooltip rework per https://m3.material.io/components/tooltips/overview.