### PR TITLE
REM-1118 - Extend Gemini AppFunctions with update/delete/search coverage

### DIFF
--- a/app/src/main/assets/files/app_functions.html
+++ b/app/src/main/assets/files/app_functions.html
@@ -55,6 +55,20 @@
     </div>
   </details>
 
+  <details>
+    <summary><span class="summary-title">Update a reminder</span><span class="badge badge-action">Action</span></summary>
+    <div class="section-body">
+      <p>Changes a reminder's title, due date/time, and notes.</p>
+    </div>
+  </details>
+
+  <details>
+    <summary><span class="summary-title">Search reminders</span><span class="badge badge-core">Lookup</span></summary>
+    <div class="section-body">
+      <p>Searches your existing reminders by title and notes text.</p>
+    </div>
+  </details>
+
   <h2>Notes</h2>
 
   <details>
@@ -71,6 +85,20 @@
     </div>
   </details>
 
+  <details>
+    <summary><span class="summary-title">Update a note</span><span class="badge badge-action">Action</span></summary>
+    <div class="section-body">
+      <p>Changes a note's title and body text.</p>
+    </div>
+  </details>
+
+  <details>
+    <summary><span class="summary-title">Delete a note</span><span class="badge badge-action">Action</span></summary>
+    <div class="section-body">
+      <p>Permanently removes a note.</p>
+    </div>
+  </details>
+
   <h2>Birthdays</h2>
 
   <details>
@@ -84,6 +112,27 @@
     <summary><span class="summary-title">List upcoming birthdays</span><span class="badge badge-core">Lookup</span></summary>
     <div class="section-body">
       <p>Returns birthdays coming up within a number of days from now (30 by default), soonest first.</p>
+    </div>
+  </details>
+
+  <details>
+    <summary><span class="summary-title">Update a birthday</span><span class="badge badge-action">Action</span></summary>
+    <div class="section-body">
+      <p>Changes a birthday's name, date, and whether the birth year is shown.</p>
+    </div>
+  </details>
+
+  <details>
+    <summary><span class="summary-title">Delete a birthday</span><span class="badge badge-action">Action</span></summary>
+    <div class="section-body">
+      <p>Permanently removes a birthday.</p>
+    </div>
+  </details>
+
+  <details>
+    <summary><span class="summary-title">Search birthdays</span><span class="badge badge-core">Lookup</span></summary>
+    <div class="section-body">
+      <p>Searches your existing birthdays by name.</p>
     </div>
   </details>
 
@@ -111,6 +160,27 @@
     <summary><span class="summary-title">Complete a Google Task</span><span class="badge badge-action">Action</span></summary>
     <div class="section-body">
       <p>Marks a Google Task as done.</p>
+    </div>
+  </details>
+
+  <details>
+    <summary><span class="summary-title">Update a Google Task</span><span class="badge badge-action">Action</span></summary>
+    <div class="section-body">
+      <p>Changes a Google Task's title, notes, and due date/time, without affecting whether it's marked done.</p>
+    </div>
+  </details>
+
+  <details>
+    <summary><span class="summary-title">Delete a Google Task</span><span class="badge badge-action">Action</span></summary>
+    <div class="section-body">
+      <p>Permanently removes a Google Task.</p>
+    </div>
+  </details>
+
+  <details>
+    <summary><span class="summary-title">Search Google Tasks</span><span class="badge badge-core">Lookup</span></summary>
+    <div class="section-body">
+      <p>Searches your locally cached Google Tasks by title and notes text.</p>
     </div>
   </details>
 

--- a/core/analytics/src/main/kotlin/com/github/naz013/analytics/AnalyticEvent.kt
+++ b/core/analytics/src/main/kotlin/com/github/naz013/analytics/AnalyticEvent.kt
@@ -150,16 +150,26 @@ enum class Feature(val value: String) {
   APP_FUNCTION_LIST_REMINDERS("app_function_list_reminders"),
   APP_FUNCTION_COMPLETE_REMINDER("app_function_complete_reminder"),
   APP_FUNCTION_DELETE_REMINDER("app_function_delete_reminder"),
+  APP_FUNCTION_UPDATE_REMINDER("app_function_update_reminder"),
+  APP_FUNCTION_SEARCH_REMINDERS("app_function_search_reminders"),
 
   APP_FUNCTION_CREATE_NOTE("app_function_create_note"),
   APP_FUNCTION_SEARCH_NOTES("app_function_search_notes"),
+  APP_FUNCTION_UPDATE_NOTE("app_function_update_note"),
+  APP_FUNCTION_DELETE_NOTE("app_function_delete_note"),
 
   APP_FUNCTION_CREATE_BIRTHDAY("app_function_create_birthday"),
   APP_FUNCTION_LIST_BIRTHDAYS("app_function_list_birthdays"),
+  APP_FUNCTION_UPDATE_BIRTHDAY("app_function_update_birthday"),
+  APP_FUNCTION_DELETE_BIRTHDAY("app_function_delete_birthday"),
+  APP_FUNCTION_SEARCH_BIRTHDAYS("app_function_search_birthdays"),
 
   APP_FUNCTION_CREATE_GOOGLE_TASK("app_function_create_google_task"),
   APP_FUNCTION_LIST_GOOGLE_TASKS("app_function_list_google_tasks"),
   APP_FUNCTION_COMPLETE_GOOGLE_TASK("app_function_complete_google_task"),
+  APP_FUNCTION_UPDATE_GOOGLE_TASK("app_function_update_google_task"),
+  APP_FUNCTION_DELETE_GOOGLE_TASK("app_function_delete_google_task"),
+  APP_FUNCTION_SEARCH_GOOGLE_TASKS("app_function_search_google_tasks"),
 
   INSIGHTS("insights"),
   LOCAL_BACKUP("local_backup"),

--- a/docs/app-overview.md
+++ b/docs/app-overview.md
@@ -48,7 +48,7 @@ The app is available on [Google Play](https://play.google.com/store/apps/details
 
 ### Gemini AppFunctions integration (PRO)
 
-- Exposes reminder, note, birthday, and Google Task actions (create, list, complete, search, delete) to Gemini and other on-device assistants via Android's `androidx.appfunctions` platform API — no network round trip, everything runs on-device
+- Exposes reminder, note, birthday, and Google Task actions (create, list, complete, update, delete, search) to Gemini and other on-device assistants via Android's `androidx.appfunctions` platform API — no network round trip, everything runs on-device
 - PRO-only; a "Gemini functions" screen under Settings → Other explains what's supported
 
 ### Calendar View

--- a/docs/appfunctions-testing.md
+++ b/docs/appfunctions-testing.md
@@ -65,7 +65,7 @@ Windows PowerShell:
 .\gradlew.bat :appfunctions:test
 ```
 
-Runs all 24 use-case tests (reminders, notes, birthdays, Google Tasks) with MockK — no device
+Runs all 43 use-case tests (reminders, notes, birthdays, Google Tasks) with MockK — no device
 needed. Run this after any change to `appfunctions/src/main/kotlin/**` before moving on to on-device
 testing; it's the fast feedback loop and will catch most logic bugs before you burn time on `adb`.
 
@@ -114,7 +114,7 @@ Windows PowerShell:
 adb shell cmd app_function list-app-functions | Select-String com.cray.software.justreminderpro
 ```
 
-This should list all 10 functions across the four services. If it comes back empty:
+This should list all 21 functions across the four services. If it comes back empty:
 
 - Confirm the app was actually installed as the **pro** build:
   - Bash: `adb shell pm list packages | grep justreminder`
@@ -196,6 +196,18 @@ adb shell cmd app_function execute-app-function \
     --package com.cray.software.justreminderpro \
     --function 'com.github.naz013.appfunctions.ReminderAppFunctionService#deleteReminder' \
     --parameters '{"id": "<uuid-from-a-previous-result>"}'
+
+# updateReminder
+adb shell cmd app_function execute-app-function \
+    --package com.cray.software.justreminderpro \
+    --function 'com.github.naz013.appfunctions.ReminderAppFunctionService#updateReminder' \
+    --parameters '{"id": "<uuid-from-a-previous-result>", "title": "Pay rent - updated", "dueDateTime": "2026-08-05T10:00:00", "notes": "before 5pm"}'
+
+# searchReminders
+adb shell cmd app_function execute-app-function \
+    --package com.cray.software.justreminderpro \
+    --function 'com.github.naz013.appfunctions.ReminderAppFunctionService#searchReminders' \
+    --parameters '{"query": "rent"}'
 ```
 
 PowerShell, single-line form (easiest to copy-paste one at a time):
@@ -208,6 +220,10 @@ adb shell cmd app_function execute-app-function --package com.cray.software.just
 adb shell cmd app_function execute-app-function --package com.cray.software.justreminderpro --function 'com.github.naz013.appfunctions.ReminderAppFunctionService#completeReminder' --parameters '{"id": "<uuid-from-a-previous-result>"}'
 
 adb shell cmd app_function execute-app-function --package com.cray.software.justreminderpro --function 'com.github.naz013.appfunctions.ReminderAppFunctionService#deleteReminder' --parameters '{"id": "<uuid-from-a-previous-result>"}'
+
+adb shell cmd app_function execute-app-function --package com.cray.software.justreminderpro --function 'com.github.naz013.appfunctions.ReminderAppFunctionService#updateReminder' --parameters '{"id": "<uuid-from-a-previous-result>", "title": "Pay rent - updated", "dueDateTime": "2026-08-05T10:00:00", "notes": "before 5pm"}'
+
+adb shell cmd app_function execute-app-function --package com.cray.software.justreminderpro --function 'com.github.naz013.appfunctions.ReminderAppFunctionService#searchReminders' --parameters '{"query": "rent"}'
 ```
 
 After `createReminder`, open the app's reminder list and confirm it actually shows up there — the
@@ -227,6 +243,17 @@ adb shell cmd app_function execute-app-function \
     --package com.cray.software.justreminderpro \
     --function 'com.github.naz013.appfunctions.NoteAppFunctionService#searchNotes' \
     --parameters '{"query": "wifi"}'
+
+# updateNote / deleteNote - id comes from the createNote or searchNotes result
+adb shell cmd app_function execute-app-function \
+    --package com.cray.software.justreminderpro \
+    --function 'com.github.naz013.appfunctions.NoteAppFunctionService#updateNote' \
+    --parameters '{"id": "<key-from-a-previous-result>", "title": "Wi-Fi password", "content": "hunter3"}'
+
+adb shell cmd app_function execute-app-function \
+    --package com.cray.software.justreminderpro \
+    --function 'com.github.naz013.appfunctions.NoteAppFunctionService#deleteNote' \
+    --parameters '{"id": "<key-from-a-previous-result>"}'
 ```
 
 PowerShell:
@@ -235,6 +262,10 @@ PowerShell:
 adb shell cmd app_function execute-app-function --package com.cray.software.justreminderpro --function 'com.github.naz013.appfunctions.NoteAppFunctionService#createNote' --parameters '{"title": "Wi-Fi password", "content": "hunter2"}'
 
 adb shell cmd app_function execute-app-function --package com.cray.software.justreminderpro --function 'com.github.naz013.appfunctions.NoteAppFunctionService#searchNotes' --parameters '{"query": "wifi"}'
+
+adb shell cmd app_function execute-app-function --package com.cray.software.justreminderpro --function 'com.github.naz013.appfunctions.NoteAppFunctionService#updateNote' --parameters '{"id": "<key-from-a-previous-result>", "title": "Wi-Fi password", "content": "hunter3"}'
+
+adb shell cmd app_function execute-app-function --package com.cray.software.justreminderpro --function 'com.github.naz013.appfunctions.NoteAppFunctionService#deleteNote' --parameters '{"id": "<key-from-a-previous-result>"}'
 ```
 
 ### Birthdays — `com.github.naz013.appfunctions.BirthdayAppFunctionService`
@@ -249,6 +280,22 @@ adb shell cmd app_function execute-app-function \
     --package com.cray.software.justreminderpro \
     --function 'com.github.naz013.appfunctions.BirthdayAppFunctionService#listUpcomingBirthdays' \
     --parameters '{"withinDays": 30}'
+
+# updateBirthday / deleteBirthday - id comes from a previous result; searchBirthdays by name
+adb shell cmd app_function execute-app-function \
+    --package com.cray.software.justreminderpro \
+    --function 'com.github.naz013.appfunctions.BirthdayAppFunctionService#updateBirthday' \
+    --parameters '{"id": "<uuid-from-a-previous-result>", "name": "Ada Lovelace", "date": "1999-11-04", "ignoreYear": false}'
+
+adb shell cmd app_function execute-app-function \
+    --package com.cray.software.justreminderpro \
+    --function 'com.github.naz013.appfunctions.BirthdayAppFunctionService#deleteBirthday' \
+    --parameters '{"id": "<uuid-from-a-previous-result>"}'
+
+adb shell cmd app_function execute-app-function \
+    --package com.cray.software.justreminderpro \
+    --function 'com.github.naz013.appfunctions.BirthdayAppFunctionService#searchBirthdays' \
+    --parameters '{"query": "ada"}'
 ```
 
 PowerShell:
@@ -257,6 +304,12 @@ PowerShell:
 adb shell cmd app_function execute-app-function --package com.cray.software.justreminderpro --function 'com.github.naz013.appfunctions.BirthdayAppFunctionService#createBirthday' --parameters '{"name": "Ada", "date": "1999-10-03", "ignoreYear": false}'
 
 adb shell cmd app_function execute-app-function --package com.cray.software.justreminderpro --function 'com.github.naz013.appfunctions.BirthdayAppFunctionService#listUpcomingBirthdays' --parameters '{"withinDays": 30}'
+
+adb shell cmd app_function execute-app-function --package com.cray.software.justreminderpro --function 'com.github.naz013.appfunctions.BirthdayAppFunctionService#updateBirthday' --parameters '{"id": "<uuid-from-a-previous-result>", "name": "Ada Lovelace", "date": "1999-11-04", "ignoreYear": false}'
+
+adb shell cmd app_function execute-app-function --package com.cray.software.justreminderpro --function 'com.github.naz013.appfunctions.BirthdayAppFunctionService#deleteBirthday' --parameters '{"id": "<uuid-from-a-previous-result>"}'
+
+adb shell cmd app_function execute-app-function --package com.cray.software.justreminderpro --function 'com.github.naz013.appfunctions.BirthdayAppFunctionService#searchBirthdays' --parameters '{"query": "ada"}'
 ```
 
 Worth a dedicated check: create a birthday on **Feb 29** with a past leap year, then
@@ -283,6 +336,22 @@ adb shell cmd app_function execute-app-function \
     --package com.cray.software.justreminderpro \
     --function 'com.github.naz013.appfunctions.GoogleTaskAppFunctionService#completeGoogleTask' \
     --parameters '{"id": "<taskId-from-createGoogleTask-result>"}'
+
+# updateGoogleTask / deleteGoogleTask - id comes from a previous result; searchGoogleTasks is local-cache only
+adb shell cmd app_function execute-app-function \
+    --package com.cray.software.justreminderpro \
+    --function 'com.github.naz013.appfunctions.GoogleTaskAppFunctionService#updateGoogleTask' \
+    --parameters '{"id": "<taskId-from-a-previous-result>", "title": "Buy oat milk", "notes": "2%", "dueDateTime": "2026-08-05T10:00:00"}'
+
+adb shell cmd app_function execute-app-function \
+    --package com.cray.software.justreminderpro \
+    --function 'com.github.naz013.appfunctions.GoogleTaskAppFunctionService#deleteGoogleTask' \
+    --parameters '{"id": "<taskId-from-a-previous-result>"}'
+
+adb shell cmd app_function execute-app-function \
+    --package com.cray.software.justreminderpro \
+    --function 'com.github.naz013.appfunctions.GoogleTaskAppFunctionService#searchGoogleTasks' \
+    --parameters '{"query": "milk"}'
 ```
 
 PowerShell:
@@ -293,6 +362,12 @@ adb shell cmd app_function execute-app-function --package com.cray.software.just
 adb shell cmd app_function execute-app-function --package com.cray.software.justreminderpro --function 'com.github.naz013.appfunctions.GoogleTaskAppFunctionService#listGoogleTasks' --parameters '{"includeCompleted": false}'
 
 adb shell cmd app_function execute-app-function --package com.cray.software.justreminderpro --function 'com.github.naz013.appfunctions.GoogleTaskAppFunctionService#completeGoogleTask' --parameters '{"id": "<taskId-from-createGoogleTask-result>"}'
+
+adb shell cmd app_function execute-app-function --package com.cray.software.justreminderpro --function 'com.github.naz013.appfunctions.GoogleTaskAppFunctionService#updateGoogleTask' --parameters '{"id": "<taskId-from-a-previous-result>", "title": "Buy oat milk", "notes": "2%", "dueDateTime": "2026-08-05T10:00:00"}'
+
+adb shell cmd app_function execute-app-function --package com.cray.software.justreminderpro --function 'com.github.naz013.appfunctions.GoogleTaskAppFunctionService#deleteGoogleTask' --parameters '{"id": "<taskId-from-a-previous-result>"}'
+
+adb shell cmd app_function execute-app-function --package com.cray.software.justreminderpro --function 'com.github.naz013.appfunctions.GoogleTaskAppFunctionService#searchGoogleTasks' --parameters '{"query": "milk"}'
 ```
 
 Unlike the other three services, `createGoogleTask`/`completeGoogleTask` make a **live network

--- a/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/BaseBirthdayAppFunctionService.kt
+++ b/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/BaseBirthdayAppFunctionService.kt
@@ -2,6 +2,8 @@ package com.github.naz013.appfunctions
 
 import androidx.annotation.RequiresApi
 import androidx.appfunctions.AppFunction
+import androidx.appfunctions.AppFunctionAppUnknownException
+import androidx.appfunctions.AppFunctionElementNotFoundException
 import androidx.appfunctions.AppFunctionInvalidArgumentException
 import androidx.appfunctions.AppFunctionPermissionRequiredException
 import androidx.appfunctions.AppFunctionService
@@ -10,12 +12,18 @@ import com.github.naz013.analytics.AnalyticsEventSender
 import com.github.naz013.analytics.Feature
 import com.github.naz013.analytics.FeatureUsedEvent
 import com.github.naz013.appfunctions.birthday.BirthdayFunctionResult
+import com.github.naz013.appfunctions.birthday.BirthdayIdParams
 import com.github.naz013.appfunctions.birthday.CreateBirthdayParams
 import com.github.naz013.appfunctions.birthday.CreateSimpleBirthdayUseCase
+import com.github.naz013.appfunctions.birthday.DeleteBirthdayUseCase
 import com.github.naz013.appfunctions.birthday.ListUpcomingBirthdaysParams
 import com.github.naz013.appfunctions.birthday.ListUpcomingBirthdaysUseCase
-import com.github.naz013.datecalc.DateTimeManager
+import com.github.naz013.appfunctions.birthday.SearchBirthdaysParams
+import com.github.naz013.appfunctions.birthday.SearchBirthdaysUseCase
+import com.github.naz013.appfunctions.birthday.UpdateBirthdayParams
+import com.github.naz013.appfunctions.birthday.UpdateBirthdayUseCase
 import com.github.naz013.common.system.BuildInfo
+import com.github.naz013.datecalc.DateTimeManager
 import com.github.naz013.domain.Birthday
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -38,6 +46,9 @@ abstract class BaseBirthdayAppFunctionService :
   private val dateTimeManager: DateTimeManager by inject()
   private val createSimpleBirthdayUseCase: CreateSimpleBirthdayUseCase by inject()
   private val listUpcomingBirthdaysUseCase: ListUpcomingBirthdaysUseCase by inject()
+  private val updateBirthdayUseCase: UpdateBirthdayUseCase by inject()
+  private val deleteBirthdayUseCase: DeleteBirthdayUseCase by inject()
+  private val searchBirthdaysUseCase: SearchBirthdaysUseCase by inject()
   private val analyticsEventSender: AnalyticsEventSender by inject()
 
   /**
@@ -82,6 +93,72 @@ abstract class BaseBirthdayAppFunctionService :
       analyticsEventSender.send(FeatureUsedEvent(Feature.APP_FUNCTION_LIST_BIRTHDAYS))
 
       listUpcomingBirthdaysUseCase(params.withinDays).mapNotNull { it.toFunctionResult() }
+    }
+
+  /**
+   * Updates an existing birthday's name, date, and year-visibility.
+   *
+   * @param params The id of the birthday to update, plus its new name, date, and whether to hide the year.
+   */
+  @AppFunction(isDescribedByKDoc = true)
+  internal suspend fun updateBirthday(params: UpdateBirthdayParams): BirthdayFunctionResult =
+    withContext(Dispatchers.IO) {
+      requirePro()
+      if (params.name.isBlank()) {
+        throw AppFunctionInvalidArgumentException("Name must not be blank")
+      }
+
+      val birthday =
+        updateBirthdayUseCase(
+          id = params.id,
+          name = params.name,
+          date = params.date,
+          ignoreYear = params.ignoreYear,
+        ) ?: throw AppFunctionElementNotFoundException("No birthday found with id = ${params.id}")
+
+      analyticsEventSender.send(FeatureUsedEvent(Feature.APP_FUNCTION_UPDATE_BIRTHDAY))
+
+      BirthdayFunctionResult(id = birthday.uuId, name = birthday.name, date = params.date)
+    }
+
+  /**
+   * Permanently deletes a birthday.
+   *
+   * @param params The id of the birthday to delete.
+   */
+  @AppFunction(isDescribedByKDoc = true)
+  internal suspend fun deleteBirthday(params: BirthdayIdParams): BirthdayFunctionResult =
+    withContext(Dispatchers.IO) {
+      requirePro()
+
+      val birthday =
+        deleteBirthdayUseCase(params.id)
+          ?: throw AppFunctionElementNotFoundException("No birthday found with id = ${params.id}")
+
+      analyticsEventSender.send(FeatureUsedEvent(Feature.APP_FUNCTION_DELETE_BIRTHDAY))
+
+      birthday.toFunctionResult()
+        ?: throw AppFunctionAppUnknownException(
+          "Birthday with id = ${params.id} was deleted, but its stored date could not be parsed.",
+        )
+    }
+
+  /**
+   * Searches for birthdays by name.
+   *
+   * @param params The name text to search for.
+   */
+  @AppFunction(isDescribedByKDoc = true)
+  internal suspend fun searchBirthdays(params: SearchBirthdaysParams): List<BirthdayFunctionResult> =
+    withContext(Dispatchers.IO) {
+      requirePro()
+      if (params.query.isBlank()) {
+        throw AppFunctionInvalidArgumentException("Query must not be blank")
+      }
+
+      analyticsEventSender.send(FeatureUsedEvent(Feature.APP_FUNCTION_SEARCH_BIRTHDAYS))
+
+      searchBirthdaysUseCase(params.query).mapNotNull { it.toFunctionResult() }
     }
 
   private fun requirePro() {

--- a/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/BaseGoogleTaskAppFunctionService.kt
+++ b/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/BaseGoogleTaskAppFunctionService.kt
@@ -15,13 +15,18 @@ import com.github.naz013.analytics.FeatureUsedEvent
 import com.github.naz013.appfunctions.googletask.CompleteGoogleTaskUseCase
 import com.github.naz013.appfunctions.googletask.CreateGoogleTaskParams
 import com.github.naz013.appfunctions.googletask.CreateGoogleTaskUseCase
+import com.github.naz013.appfunctions.googletask.DeleteGoogleTaskUseCase
 import com.github.naz013.appfunctions.googletask.GoogleTaskFunctionResult
 import com.github.naz013.appfunctions.googletask.GoogleTaskIdParams
 import com.github.naz013.appfunctions.googletask.ListGoogleTasksParams
 import com.github.naz013.appfunctions.googletask.ListGoogleTasksUseCase
+import com.github.naz013.appfunctions.googletask.SearchGoogleTasksParams
+import com.github.naz013.appfunctions.googletask.SearchGoogleTasksUseCase
+import com.github.naz013.appfunctions.googletask.UpdateGoogleTaskParams
+import com.github.naz013.appfunctions.googletask.UpdateGoogleTaskUseCase
 import com.github.naz013.cloudapi.googletasks.GoogleTasksAuthManager
-import com.github.naz013.datecalc.DateTimeManager
 import com.github.naz013.common.system.BuildInfo
+import com.github.naz013.datecalc.DateTimeManager
 import com.github.naz013.domain.GoogleTask
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -47,6 +52,9 @@ abstract class BaseGoogleTaskAppFunctionService :
   private val createGoogleTaskUseCase: CreateGoogleTaskUseCase by inject()
   private val listGoogleTasksUseCase: ListGoogleTasksUseCase by inject()
   private val completeGoogleTaskUseCase: CompleteGoogleTaskUseCase by inject()
+  private val updateGoogleTaskUseCase: UpdateGoogleTaskUseCase by inject()
+  private val deleteGoogleTaskUseCase: DeleteGoogleTaskUseCase by inject()
+  private val searchGoogleTasksUseCase: SearchGoogleTasksUseCase by inject()
   private val analyticsEventSender: AnalyticsEventSender by inject()
 
   /**
@@ -111,6 +119,76 @@ abstract class BaseGoogleTaskAppFunctionService :
       analyticsEventSender.send(FeatureUsedEvent(Feature.APP_FUNCTION_COMPLETE_GOOGLE_TASK))
 
       task.toFunctionResult()
+    }
+
+  /**
+   * Updates an existing Google Task's title, notes, and due date/time.
+   *
+   * @param params The id of the task to update, plus its new title, optional notes, and optional due date/time.
+   */
+  @AppFunction(isDescribedByKDoc = true)
+  internal suspend fun updateGoogleTask(params: UpdateGoogleTaskParams): GoogleTaskFunctionResult =
+    withContext(Dispatchers.IO) {
+      requirePro()
+      requireGoogleTasksLinked()
+      if (params.title.isBlank()) {
+        throw AppFunctionInvalidArgumentException("Title must not be blank")
+      }
+
+      val task =
+        updateGoogleTaskUseCase(
+          id = params.id,
+          title = params.title,
+          notes = params.notes,
+          dueDateTime = params.dueDateTime,
+        ) ?: throw AppFunctionElementNotFoundException(
+          "No Google Task found with id = ${params.id}, or the update failed - check your connection and try again.",
+        )
+
+      analyticsEventSender.send(FeatureUsedEvent(Feature.APP_FUNCTION_UPDATE_GOOGLE_TASK))
+
+      task.toFunctionResult()
+    }
+
+  /**
+   * Permanently deletes a Google Task.
+   *
+   * @param params The id of the task to delete.
+   */
+  @AppFunction(isDescribedByKDoc = true)
+  internal suspend fun deleteGoogleTask(params: GoogleTaskIdParams): GoogleTaskFunctionResult =
+    withContext(Dispatchers.IO) {
+      requirePro()
+      requireGoogleTasksLinked()
+
+      val task =
+        deleteGoogleTaskUseCase(params.id)
+          ?: throw AppFunctionElementNotFoundException(
+            "No Google Task found with id = ${params.id}, or the delete failed - check your connection and try again.",
+          )
+
+      analyticsEventSender.send(FeatureUsedEvent(Feature.APP_FUNCTION_DELETE_GOOGLE_TASK))
+
+      task.toFunctionResult()
+    }
+
+  /**
+   * Searches for Google Tasks by title or notes text, from the locally cached list.
+   *
+   * @param params The text to search for.
+   */
+  @AppFunction(isDescribedByKDoc = true)
+  internal suspend fun searchGoogleTasks(params: SearchGoogleTasksParams): List<GoogleTaskFunctionResult> =
+    withContext(Dispatchers.IO) {
+      requirePro()
+      requireGoogleTasksLinked()
+      if (params.query.isBlank()) {
+        throw AppFunctionInvalidArgumentException("Query must not be blank")
+      }
+
+      analyticsEventSender.send(FeatureUsedEvent(Feature.APP_FUNCTION_SEARCH_GOOGLE_TASKS))
+
+      searchGoogleTasksUseCase(params.query).map { it.toFunctionResult() }
     }
 
   private fun requirePro() {

--- a/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/BaseNoteAppFunctionService.kt
+++ b/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/BaseNoteAppFunctionService.kt
@@ -2,6 +2,7 @@ package com.github.naz013.appfunctions
 
 import androidx.annotation.RequiresApi
 import androidx.appfunctions.AppFunction
+import androidx.appfunctions.AppFunctionElementNotFoundException
 import androidx.appfunctions.AppFunctionInvalidArgumentException
 import androidx.appfunctions.AppFunctionPermissionRequiredException
 import androidx.appfunctions.AppFunctionService
@@ -11,8 +12,12 @@ import com.github.naz013.analytics.Feature
 import com.github.naz013.analytics.FeatureUsedEvent
 import com.github.naz013.appfunctions.note.CreateNoteParams
 import com.github.naz013.appfunctions.note.CreateSimpleNoteUseCase
+import com.github.naz013.appfunctions.note.DeleteNoteUseCase
 import com.github.naz013.appfunctions.note.NoteFunctionResult
+import com.github.naz013.appfunctions.note.NoteIdParams
 import com.github.naz013.appfunctions.note.SearchNotesParams
+import com.github.naz013.appfunctions.note.UpdateNoteParams
+import com.github.naz013.appfunctions.note.UpdateNoteUseCase
 import com.github.naz013.common.system.BuildInfo
 import com.github.naz013.domain.note.displayTitle
 import com.github.naz013.repository.NoteRepository
@@ -35,6 +40,8 @@ abstract class BaseNoteAppFunctionService :
   KoinComponent {
   private val buildInfo: BuildInfo by inject()
   private val createSimpleNoteUseCase: CreateSimpleNoteUseCase by inject()
+  private val updateNoteUseCase: UpdateNoteUseCase by inject()
+  private val deleteNoteUseCase: DeleteNoteUseCase by inject()
   private val noteRepository: NoteRepository by inject()
   private val analyticsEventSender: AnalyticsEventSender by inject()
 
@@ -76,6 +83,47 @@ abstract class BaseNoteAppFunctionService :
       noteRepository.searchByText(params.query)
         .mapNotNull { it.note }
         .map { NoteFunctionResult(id = it.key, title = it.content.displayTitle(), content = it.content.text) }
+    }
+
+  /**
+   * Updates an existing note's title and body text.
+   *
+   * @param params The id of the note to update, plus its new title and content.
+   */
+  @AppFunction(isDescribedByKDoc = true)
+  internal suspend fun updateNote(params: UpdateNoteParams): NoteFunctionResult =
+    withContext(Dispatchers.IO) {
+      requirePro()
+      if (params.title.isBlank() && params.content.isBlank()) {
+        throw AppFunctionInvalidArgumentException("Title or content must not be blank")
+      }
+
+      val note =
+        updateNoteUseCase(id = params.id, title = params.title, content = params.content)
+          ?: throw AppFunctionElementNotFoundException("No note found with id = ${params.id}")
+
+      analyticsEventSender.send(FeatureUsedEvent(Feature.APP_FUNCTION_UPDATE_NOTE))
+
+      NoteFunctionResult(id = note.key, title = note.content.displayTitle(), content = note.content.text)
+    }
+
+  /**
+   * Permanently deletes a note.
+   *
+   * @param params The id of the note to delete.
+   */
+  @AppFunction(isDescribedByKDoc = true)
+  internal suspend fun deleteNote(params: NoteIdParams): NoteFunctionResult =
+    withContext(Dispatchers.IO) {
+      requirePro()
+
+      val note =
+        deleteNoteUseCase(params.id)
+          ?: throw AppFunctionElementNotFoundException("No note found with id = ${params.id}")
+
+      analyticsEventSender.send(FeatureUsedEvent(Feature.APP_FUNCTION_DELETE_NOTE))
+
+      NoteFunctionResult(id = note.key, title = note.content.displayTitle(), content = note.content.text)
     }
 
   private fun requirePro() {

--- a/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/BaseReminderAppFunctionService.kt
+++ b/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/BaseReminderAppFunctionService.kt
@@ -18,8 +18,12 @@ import com.github.naz013.appfunctions.reminder.ListUpcomingRemindersParams
 import com.github.naz013.appfunctions.reminder.ListUpcomingRemindersUseCase
 import com.github.naz013.appfunctions.reminder.ReminderFunctionResult
 import com.github.naz013.appfunctions.reminder.ReminderIdParams
-import com.github.naz013.datecalc.DateTimeManager
+import com.github.naz013.appfunctions.reminder.SearchRemindersParams
+import com.github.naz013.appfunctions.reminder.SearchRemindersUseCase
+import com.github.naz013.appfunctions.reminder.UpdateReminderParams
+import com.github.naz013.appfunctions.reminder.UpdateReminderUseCase
 import com.github.naz013.common.system.BuildInfo
+import com.github.naz013.datecalc.DateTimeManager
 import com.github.naz013.domain.reminder.v2.ReminderV2
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -44,6 +48,8 @@ abstract class BaseReminderAppFunctionService :
   private val listUpcomingRemindersUseCase: ListUpcomingRemindersUseCase by inject()
   private val completeReminderUseCase: CompleteReminderUseCase by inject()
   private val deleteReminderUseCase: DeleteReminderUseCase by inject()
+  private val updateReminderUseCase: UpdateReminderUseCase by inject()
+  private val searchRemindersUseCase: SearchRemindersUseCase by inject()
   private val analyticsEventSender: AnalyticsEventSender by inject()
 
   /**
@@ -126,6 +132,50 @@ abstract class BaseReminderAppFunctionService :
       analyticsEventSender.send(FeatureUsedEvent(Feature.APP_FUNCTION_DELETE_REMINDER))
 
       reminder.toFunctionResult()
+    }
+
+  /**
+   * Updates an existing reminder's title, due date/time, and notes.
+   *
+   * @param params The id of the reminder to update, plus its new title, due date/time, and optional notes.
+   */
+  @AppFunction(isDescribedByKDoc = true)
+  internal suspend fun updateReminder(params: UpdateReminderParams): ReminderFunctionResult =
+    withContext(Dispatchers.IO) {
+      requirePro()
+      if (params.title.isBlank()) {
+        throw AppFunctionInvalidArgumentException("Title must not be blank")
+      }
+
+      val reminder =
+        updateReminderUseCase(
+          id = params.id,
+          title = params.title,
+          dueDateTime = params.dueDateTime,
+          notes = params.notes,
+        ) ?: throw AppFunctionElementNotFoundException("No reminder found with id = ${params.id}")
+
+      analyticsEventSender.send(FeatureUsedEvent(Feature.APP_FUNCTION_UPDATE_REMINDER))
+
+      reminder.toFunctionResult()
+    }
+
+  /**
+   * Searches for reminders by title or notes text.
+   *
+   * @param params The text to search for.
+   */
+  @AppFunction(isDescribedByKDoc = true)
+  internal suspend fun searchReminders(params: SearchRemindersParams): List<ReminderFunctionResult> =
+    withContext(Dispatchers.IO) {
+      requirePro()
+      if (params.query.isBlank()) {
+        throw AppFunctionInvalidArgumentException("Query must not be blank")
+      }
+
+      analyticsEventSender.send(FeatureUsedEvent(Feature.APP_FUNCTION_SEARCH_REMINDERS))
+
+      searchRemindersUseCase(params.query).map { it.toFunctionResult() }
     }
 
   private fun requirePro() {

--- a/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/KoinModule.kt
+++ b/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/KoinModule.kt
@@ -1,15 +1,25 @@
 package com.github.naz013.appfunctions
 
 import com.github.naz013.appfunctions.birthday.CreateSimpleBirthdayUseCase
+import com.github.naz013.appfunctions.birthday.DeleteBirthdayUseCase
 import com.github.naz013.appfunctions.birthday.ListUpcomingBirthdaysUseCase
+import com.github.naz013.appfunctions.birthday.SearchBirthdaysUseCase
+import com.github.naz013.appfunctions.birthday.UpdateBirthdayUseCase
 import com.github.naz013.appfunctions.googletask.CompleteGoogleTaskUseCase
 import com.github.naz013.appfunctions.googletask.CreateGoogleTaskUseCase
+import com.github.naz013.appfunctions.googletask.DeleteGoogleTaskUseCase
 import com.github.naz013.appfunctions.googletask.ListGoogleTasksUseCase
+import com.github.naz013.appfunctions.googletask.SearchGoogleTasksUseCase
+import com.github.naz013.appfunctions.googletask.UpdateGoogleTaskUseCase
 import com.github.naz013.appfunctions.note.CreateSimpleNoteUseCase
+import com.github.naz013.appfunctions.note.DeleteNoteUseCase
+import com.github.naz013.appfunctions.note.UpdateNoteUseCase
 import com.github.naz013.appfunctions.reminder.CompleteReminderUseCase
 import com.github.naz013.appfunctions.reminder.CreateSimpleReminderUseCase
 import com.github.naz013.appfunctions.reminder.DeleteReminderUseCase
 import com.github.naz013.appfunctions.reminder.ListUpcomingRemindersUseCase
+import com.github.naz013.appfunctions.reminder.SearchRemindersUseCase
+import com.github.naz013.appfunctions.reminder.UpdateReminderUseCase
 import org.koin.dsl.module
 
 val appFunctionsModule =
@@ -18,13 +28,23 @@ val appFunctionsModule =
     factory { ListUpcomingRemindersUseCase(get(), get()) }
     factory { CompleteReminderUseCase(get()) }
     factory { DeleteReminderUseCase(get()) }
+    factory { UpdateReminderUseCase(get(), get()) }
+    factory { SearchRemindersUseCase(get()) }
 
     factory { CreateSimpleNoteUseCase(get(), get()) }
+    factory { UpdateNoteUseCase(get()) }
+    factory { DeleteNoteUseCase(get()) }
 
     factory { CreateSimpleBirthdayUseCase(get(), get()) }
     factory { ListUpcomingBirthdaysUseCase(get(), get(), get()) }
+    factory { UpdateBirthdayUseCase(get(), get()) }
+    factory { DeleteBirthdayUseCase(get()) }
+    factory { SearchBirthdaysUseCase(get()) }
 
     factory { CreateGoogleTaskUseCase(get(), get(), get()) }
     factory { ListGoogleTasksUseCase(get()) }
     factory { CompleteGoogleTaskUseCase(get(), get()) }
+    factory { UpdateGoogleTaskUseCase(get(), get(), get()) }
+    factory { DeleteGoogleTaskUseCase(get(), get()) }
+    factory { SearchGoogleTasksUseCase(get()) }
   }

--- a/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/birthday/BirthdayDateFields.kt
+++ b/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/birthday/BirthdayDateFields.kt
@@ -1,0 +1,22 @@
+package com.github.naz013.appfunctions.birthday
+
+import com.github.naz013.datecalc.DateTimeManager
+import org.threeten.bp.LocalDate as ThreeTenLocalDate
+
+/** The birthday fields derived purely from a date of birth. Kept in one place since
+ * [com.github.naz013.domain.Birthday] stores them denormalized (`day`/`month`/`dayMonth`/`date`),
+ * and both create and update need to recompute all four identically whenever the date changes. */
+internal data class BirthdayDateFields(
+  val date: String,
+  val day: Int,
+  val month: Int,
+  val dayMonth: String,
+)
+
+internal fun DateTimeManager.toBirthdayDateFields(birthDate: ThreeTenLocalDate): BirthdayDateFields =
+  BirthdayDateFields(
+    date = formatBirthdayDate(birthDate),
+    day = birthDate.dayOfMonth,
+    month = birthDate.monthValue - 1,
+    dayMonth = "${birthDate.dayOfMonth}|${birthDate.monthValue - 1}",
+  )

--- a/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/birthday/BirthdayFunctionModels.kt
+++ b/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/birthday/BirthdayFunctionModels.kt
@@ -21,6 +21,33 @@ data class ListUpcomingBirthdaysParams(
   val withinDays: Int = 30,
 )
 
+/** Identifies a single birthday for an update/delete action. */
+@AppFunctionSerializable(isDescribedByKDoc = true)
+data class BirthdayIdParams(
+  /** The unique identifier of the birthday, as returned by another birthday AppFunction. */
+  val id: String,
+)
+
+/** The parameters needed to update an existing birthday. */
+@AppFunctionSerializable(isDescribedByKDoc = true)
+data class UpdateBirthdayParams(
+  /** The unique identifier of the birthday to update, as returned by another birthday AppFunction. */
+  val id: String,
+  /** The new name of the person whose birthday this is. */
+  val name: String,
+  /** The new date of birth. */
+  val date: LocalDate,
+  /** Whether to hide the birth year (show only day and month) when displaying this birthday. */
+  val ignoreYear: Boolean = false,
+)
+
+/** The parameters needed to search existing birthdays by name. */
+@AppFunctionSerializable(isDescribedByKDoc = true)
+data class SearchBirthdaysParams(
+  /** The name text to search for. */
+  val query: String,
+)
+
 /** A birthday. */
 @AppFunctionSerializable(isDescribedByKDoc = true)
 data class BirthdayFunctionResult(

--- a/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/birthday/DeleteBirthdayUseCase.kt
+++ b/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/birthday/DeleteBirthdayUseCase.kt
@@ -1,0 +1,14 @@
+package com.github.naz013.appfunctions.birthday
+
+import com.github.naz013.domain.Birthday
+import com.github.naz013.repository.BirthdayRepository
+
+class DeleteBirthdayUseCase(
+  private val birthdayRepository: BirthdayRepository,
+) {
+  suspend operator fun invoke(id: String): Birthday? {
+    val existing = birthdayRepository.getById(id) ?: return null
+    birthdayRepository.delete(id)
+    return existing
+  }
+}

--- a/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/birthday/SearchBirthdaysUseCase.kt
+++ b/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/birthday/SearchBirthdaysUseCase.kt
@@ -1,0 +1,10 @@
+package com.github.naz013.appfunctions.birthday
+
+import com.github.naz013.domain.Birthday
+import com.github.naz013.repository.BirthdayRepository
+
+class SearchBirthdaysUseCase(
+  private val birthdayRepository: BirthdayRepository,
+) {
+  suspend operator fun invoke(query: String): List<Birthday> = birthdayRepository.searchByName(query)
+}

--- a/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/birthday/UpdateBirthdayUseCase.kt
+++ b/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/birthday/UpdateBirthdayUseCase.kt
@@ -7,19 +7,20 @@ import com.github.naz013.domain.sync.SyncState
 import com.github.naz013.repository.BirthdayRepository
 import java.time.LocalDate as JavaLocalDate
 
-class CreateSimpleBirthdayUseCase(
+class UpdateBirthdayUseCase(
   private val birthdayRepository: BirthdayRepository,
   private val dateTimeManager: DateTimeManager,
 ) {
   suspend operator fun invoke(
+    id: String,
     name: String,
     date: JavaLocalDate,
     ignoreYear: Boolean,
-  ): Birthday {
-    val birthDate = date.toThreeTen()
-    val fields = dateTimeManager.toBirthdayDateFields(birthDate)
-    val birthday =
-      Birthday(
+  ): Birthday? {
+    val existing = birthdayRepository.getById(id) ?: return null
+    val fields = dateTimeManager.toBirthdayDateFields(date.toThreeTen())
+    val updated =
+      existing.copy(
         name = name,
         date = fields.date,
         day = fields.day,
@@ -27,10 +28,10 @@ class CreateSimpleBirthdayUseCase(
         dayMonth = fields.dayMonth,
         updatedAt = dateTimeManager.getNowGmtDateTime(),
         ignoreYear = ignoreYear,
-        syncState = SyncState.WaitingForUpload,
-        version = 0,
+        version = existing.version + 1,
       )
-    birthdayRepository.save(birthday)
-    return birthday
+    birthdayRepository.save(updated)
+    birthdayRepository.updateSyncState(existing.uuId, SyncState.WaitingForUpload)
+    return updated
   }
 }

--- a/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/googletask/DeleteGoogleTaskUseCase.kt
+++ b/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/googletask/DeleteGoogleTaskUseCase.kt
@@ -1,0 +1,20 @@
+package com.github.naz013.appfunctions.googletask
+
+import com.github.naz013.cloudapi.googletasks.GoogleTasksApi
+import com.github.naz013.domain.GoogleTask
+import com.github.naz013.repository.GoogleTaskRepository
+
+class DeleteGoogleTaskUseCase(
+  private val googleTasksApi: GoogleTasksApi,
+  private val googleTaskRepository: GoogleTaskRepository,
+) {
+  suspend operator fun invoke(id: String): GoogleTask? {
+    val existing = googleTaskRepository.getById(id) ?: return null
+    return if (googleTasksApi.deleteTask(existing)) {
+      googleTaskRepository.delete(id)
+      existing
+    } else {
+      null
+    }
+  }
+}

--- a/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/googletask/GoogleTaskFunctionModels.kt
+++ b/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/googletask/GoogleTaskFunctionModels.kt
@@ -28,6 +28,26 @@ data class GoogleTaskIdParams(
   val id: String,
 )
 
+/** The parameters needed to update an existing Google Task. */
+@AppFunctionSerializable(isDescribedByKDoc = true)
+data class UpdateGoogleTaskParams(
+  /** The unique identifier of the task to update, as returned by another Google Task AppFunction. */
+  val id: String,
+  /** The new title of the task. */
+  val title: String,
+  /** Optional new notes for the task. */
+  val notes: String? = null,
+  /** Optional new date and time, in the device's local time zone, the task is due at. */
+  val dueDateTime: LocalDateTime? = null,
+)
+
+/** The parameters needed to search existing Google Tasks. */
+@AppFunctionSerializable(isDescribedByKDoc = true)
+data class SearchGoogleTasksParams(
+  /** The text to search for within task titles and notes. */
+  val query: String,
+)
+
 /** A Google Task. */
 @AppFunctionSerializable(isDescribedByKDoc = true)
 data class GoogleTaskFunctionResult(

--- a/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/googletask/SearchGoogleTasksUseCase.kt
+++ b/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/googletask/SearchGoogleTasksUseCase.kt
@@ -1,0 +1,13 @@
+package com.github.naz013.appfunctions.googletask
+
+import com.github.naz013.domain.GoogleTask
+import com.github.naz013.repository.GoogleTaskRepository
+
+/** Local-cache only, same characteristic as [ListGoogleTasksUseCase] - no live call to
+ * [com.github.naz013.cloudapi.googletasks.GoogleTasksApi], so results can be stale relative to the
+ * real Google Tasks account if the app hasn't synced recently. */
+class SearchGoogleTasksUseCase(
+  private val googleTaskRepository: GoogleTaskRepository,
+) {
+  suspend operator fun invoke(query: String): List<GoogleTask> = googleTaskRepository.search(query)
+}

--- a/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/googletask/UpdateGoogleTaskUseCase.kt
+++ b/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/googletask/UpdateGoogleTaskUseCase.kt
@@ -1,0 +1,33 @@
+package com.github.naz013.appfunctions.googletask
+
+import com.github.naz013.appfunctions.toThreeTen
+import com.github.naz013.cloudapi.googletasks.GoogleTasksApi
+import com.github.naz013.datecalc.DateTimeManager
+import com.github.naz013.domain.GoogleTask
+import com.github.naz013.repository.GoogleTaskRepository
+import java.time.LocalDateTime as JavaLocalDateTime
+
+/** Deliberately leaves [GoogleTask.status] untouched, unlike the UI's edit flow (which resets it to
+ * [GoogleTask.TASKS_NEED_ACTION] on every save) - an AI-driven "change the due date" shouldn't
+ * silently un-complete an already-finished task. */
+class UpdateGoogleTaskUseCase(
+  private val googleTasksApi: GoogleTasksApi,
+  private val googleTaskRepository: GoogleTaskRepository,
+  private val dateTimeManager: DateTimeManager,
+) {
+  suspend operator fun invoke(
+    id: String,
+    title: String,
+    notes: String?,
+    dueDateTime: JavaLocalDateTime?,
+  ): GoogleTask? {
+    val existing = googleTaskRepository.getById(id) ?: return null
+    val updated =
+      existing.copy(
+        title = title,
+        notes = notes ?: "",
+        dueDate = dueDateTime?.let { dateTimeManager.toMillis(it.toThreeTen()) } ?: 0L,
+      )
+    return googleTasksApi.updateTask(updated)?.also { googleTaskRepository.save(it) }
+  }
+}

--- a/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/note/DeleteNoteUseCase.kt
+++ b/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/note/DeleteNoteUseCase.kt
@@ -1,0 +1,19 @@
+package com.github.naz013.appfunctions.note
+
+import com.github.naz013.domain.note.Note
+import com.github.naz013.repository.NoteRepository
+
+/** Deliberately thin, mirroring this module's
+ * [com.github.naz013.appfunctions.reminder.DeleteReminderUseCase] precedent - doesn't clean up
+ * attached images/tags or schedule background delete-work the way feature-note's fuller
+ * DeleteNoteUseCase does. This module doesn't depend on that one (see
+ * extensions/appfunctions/build.gradle.kts) - an accepted trade-off, not an oversight. */
+class DeleteNoteUseCase(
+  private val noteRepository: NoteRepository,
+) {
+  suspend operator fun invoke(id: String): Note? {
+    val existing = noteRepository.getById(id)?.note ?: return null
+    noteRepository.delete(id)
+    return existing
+  }
+}

--- a/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/note/NoteFunctionModels.kt
+++ b/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/note/NoteFunctionModels.kt
@@ -18,6 +18,24 @@ data class SearchNotesParams(
   val query: String,
 )
 
+/** Identifies a single note for an update/delete action. */
+@AppFunctionSerializable(isDescribedByKDoc = true)
+data class NoteIdParams(
+  /** The unique identifier of the note, as returned by another note AppFunction. */
+  val id: String,
+)
+
+/** The parameters needed to update an existing note. */
+@AppFunctionSerializable(isDescribedByKDoc = true)
+data class UpdateNoteParams(
+  /** The unique identifier of the note to update, as returned by another note AppFunction. */
+  val id: String,
+  /** The new title of the note. */
+  val title: String,
+  /** The new body text of the note. */
+  val content: String,
+)
+
 /** A note. */
 @AppFunctionSerializable(isDescribedByKDoc = true)
 data class NoteFunctionResult(

--- a/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/note/UpdateNoteUseCase.kt
+++ b/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/note/UpdateNoteUseCase.kt
@@ -1,0 +1,26 @@
+package com.github.naz013.appfunctions.note
+
+import com.github.naz013.domain.note.Note
+import com.github.naz013.domain.note.NoteDocument
+import com.github.naz013.domain.sync.SyncState
+import com.github.naz013.repository.NoteRepository
+
+class UpdateNoteUseCase(
+  private val noteRepository: NoteRepository,
+) {
+  suspend operator fun invoke(
+    id: String,
+    title: String,
+    content: String,
+  ): Note? {
+    val existing = noteRepository.getById(id)?.note ?: return null
+    val updated =
+      existing.copy(
+        content = NoteDocument.fromLegacy(title = title, summary = content),
+        version = existing.version + 1,
+      )
+    noteRepository.save(updated)
+    noteRepository.updateSyncState(existing.key, SyncState.WaitingForUpload)
+    return updated
+  }
+}

--- a/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/reminder/ReminderFunctionModels.kt
+++ b/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/reminder/ReminderFunctionModels.kt
@@ -28,6 +28,26 @@ data class ReminderIdParams(
   val id: String,
 )
 
+/** The parameters needed to update an existing reminder. */
+@AppFunctionSerializable(isDescribedByKDoc = true)
+data class UpdateReminderParams(
+  /** The unique identifier of the reminder to update, as returned by another reminder AppFunction. */
+  val id: String,
+  /** The new short title of the reminder. */
+  val title: String,
+  /** The new date and time, in the device's local time zone, the reminder should trigger at. */
+  val dueDateTime: LocalDateTime,
+  /** Optional free-text notes to attach to the reminder. */
+  val notes: String? = null,
+)
+
+/** The parameters needed to search existing reminders. */
+@AppFunctionSerializable(isDescribedByKDoc = true)
+data class SearchRemindersParams(
+  /** The text to search for within reminder titles and notes. */
+  val query: String,
+)
+
 /** A reminder. */
 @AppFunctionSerializable(isDescribedByKDoc = true)
 data class ReminderFunctionResult(

--- a/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/reminder/SearchRemindersUseCase.kt
+++ b/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/reminder/SearchRemindersUseCase.kt
@@ -1,0 +1,10 @@
+package com.github.naz013.appfunctions.reminder
+
+import com.github.naz013.domain.reminder.v2.ReminderV2
+import com.github.naz013.repository.ReminderV2Repository
+
+class SearchRemindersUseCase(
+  private val reminderV2Repository: ReminderV2Repository,
+) {
+  suspend operator fun invoke(query: String): List<ReminderV2> = reminderV2Repository.search(query)
+}

--- a/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/reminder/UpdateReminderUseCase.kt
+++ b/extensions/appfunctions/src/main/kotlin/com/github/naz013/appfunctions/reminder/UpdateReminderUseCase.kt
@@ -1,0 +1,33 @@
+package com.github.naz013.appfunctions.reminder
+
+import com.github.naz013.appfunctions.toThreeTen
+import com.github.naz013.datecalc.DateTimeManager
+import com.github.naz013.domain.reminder.v2.ReminderV2
+import com.github.naz013.repository.ReminderV2Repository
+import java.time.LocalDateTime as JavaLocalDateTime
+
+/** Deliberately does not touch [ReminderV2.sync] - neither this module's [CompleteReminderUseCase]
+ * nor the app's own canonical reminder-save path bump reminder sync bookkeeping on edit, unlike
+ * Note/Birthday which explicitly version-bump and mark for upload. */
+class UpdateReminderUseCase(
+  private val reminderV2Repository: ReminderV2Repository,
+  private val dateTimeManager: DateTimeManager,
+) {
+  suspend operator fun invoke(
+    id: String,
+    title: String,
+    dueDateTime: JavaLocalDateTime,
+    notes: String?,
+  ): ReminderV2? {
+    val existing = reminderV2Repository.getById(id) ?: return null
+    val utcDateTime = dateTimeManager.localToUtc(dueDateTime.toThreeTen())
+    val updated =
+      existing.copy(
+        summary = title,
+        description = notes,
+        schedule = existing.schedule.copy(startDateTime = utcDateTime, eventDateTime = utcDateTime),
+      )
+    reminderV2Repository.save(updated)
+    return updated
+  }
+}

--- a/extensions/appfunctions/src/test/kotlin/com/github/naz013/appfunctions/birthday/DeleteBirthdayUseCaseTest.kt
+++ b/extensions/appfunctions/src/test/kotlin/com/github/naz013/appfunctions/birthday/DeleteBirthdayUseCaseTest.kt
@@ -1,0 +1,39 @@
+package com.github.naz013.appfunctions.birthday
+
+import com.github.naz013.domain.Birthday
+import com.github.naz013.domain.sync.SyncState
+import com.github.naz013.repository.BirthdayRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class DeleteBirthdayUseCaseTest {
+
+  private val birthdayRepository = mockk<BirthdayRepository>(relaxUnitFun = true)
+  private val useCase = DeleteBirthdayUseCase(birthdayRepository)
+
+  @Test
+  fun `invoke deletes and returns the birthday when it exists`() = runTest {
+    val birthday = Birthday(uuId = "birthday-1", name = "Ada", syncState = SyncState.Synced)
+    coEvery { birthdayRepository.getById("birthday-1") } returns birthday
+
+    val result = useCase("birthday-1")
+
+    assertEquals(birthday, result)
+    coVerify { birthdayRepository.delete("birthday-1") }
+  }
+
+  @Test
+  fun `invoke returns null and does not delete when no birthday exists`() = runTest {
+    coEvery { birthdayRepository.getById("missing") } returns null
+
+    val result = useCase("missing")
+
+    assertNull(result)
+    coVerify(exactly = 0) { birthdayRepository.delete(any()) }
+  }
+}

--- a/extensions/appfunctions/src/test/kotlin/com/github/naz013/appfunctions/birthday/SearchBirthdaysUseCaseTest.kt
+++ b/extensions/appfunctions/src/test/kotlin/com/github/naz013/appfunctions/birthday/SearchBirthdaysUseCaseTest.kt
@@ -1,0 +1,26 @@
+package com.github.naz013.appfunctions.birthday
+
+import com.github.naz013.domain.Birthday
+import com.github.naz013.domain.sync.SyncState
+import com.github.naz013.repository.BirthdayRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SearchBirthdaysUseCaseTest {
+
+  private val birthdayRepository = mockk<BirthdayRepository>()
+  private val useCase = SearchBirthdaysUseCase(birthdayRepository)
+
+  @Test
+  fun `invoke returns matches from the repository`() = runTest {
+    val matches = listOf(Birthday(uuId = "birthday-1", name = "Ada", syncState = SyncState.Synced))
+    coEvery { birthdayRepository.searchByName("ada") } returns matches
+
+    val result = useCase("ada")
+
+    assertEquals(matches, result)
+  }
+}

--- a/extensions/appfunctions/src/test/kotlin/com/github/naz013/appfunctions/birthday/UpdateBirthdayUseCaseTest.kt
+++ b/extensions/appfunctions/src/test/kotlin/com/github/naz013/appfunctions/birthday/UpdateBirthdayUseCaseTest.kt
@@ -1,0 +1,67 @@
+package com.github.naz013.appfunctions.birthday
+
+import com.github.naz013.datecalc.DateTimeManager
+import com.github.naz013.domain.Birthday
+import com.github.naz013.domain.sync.SyncState
+import com.github.naz013.repository.BirthdayRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.time.LocalDate as JavaLocalDate
+import org.threeten.bp.LocalDate as ThreeTenLocalDate
+
+class UpdateBirthdayUseCaseTest {
+
+  private val birthdayRepository = mockk<BirthdayRepository>(relaxUnitFun = true)
+  private val dateTimeManager = mockk<DateTimeManager>()
+  private val useCase = UpdateBirthdayUseCase(birthdayRepository, dateTimeManager)
+
+  @Test
+  fun `invoke recomputes derived date fields, bumps version and marks for upload`() = runTest {
+    val existing =
+      Birthday(
+        uuId = "birthday-1",
+        name = "Ada",
+        date = "1999-10-03",
+        day = 3,
+        month = 9,
+        dayMonth = "3|9",
+        syncState = SyncState.Synced,
+        version = 2L,
+      )
+    coEvery { birthdayRepository.getById("birthday-1") } returns existing
+    every {
+      dateTimeManager.formatBirthdayDate(ThreeTenLocalDate.of(1999, 11, 4))
+    } returns "1999-11-04"
+    every { dateTimeManager.getNowGmtDateTime() } returns "2026-08-01 00:00:00.000+0000"
+
+    val result =
+      useCase(id = "birthday-1", name = "Ada Lovelace", date = JavaLocalDate.of(1999, 11, 4), ignoreYear = true)
+
+    assertEquals("Ada Lovelace", result?.name)
+    assertEquals("1999-11-04", result?.date)
+    assertEquals(4, result?.day)
+    assertEquals(10, result?.month)
+    assertEquals("4|10", result?.dayMonth)
+    assertEquals(true, result?.ignoreYear)
+    assertEquals(3L, result?.version)
+    coVerify { birthdayRepository.save(result!!) }
+    coVerify { birthdayRepository.updateSyncState("birthday-1", SyncState.WaitingForUpload) }
+  }
+
+  @Test
+  fun `invoke returns null and does not save when no birthday exists`() = runTest {
+    coEvery { birthdayRepository.getById("missing") } returns null
+
+    val result = useCase(id = "missing", name = "Ada", date = JavaLocalDate.of(1999, 10, 3), ignoreYear = false)
+
+    assertNull(result)
+    coVerify(exactly = 0) { birthdayRepository.save(any()) }
+    coVerify(exactly = 0) { birthdayRepository.updateSyncState(any(), any()) }
+  }
+}

--- a/extensions/appfunctions/src/test/kotlin/com/github/naz013/appfunctions/googletask/DeleteGoogleTaskUseCaseTest.kt
+++ b/extensions/appfunctions/src/test/kotlin/com/github/naz013/appfunctions/googletask/DeleteGoogleTaskUseCaseTest.kt
@@ -1,0 +1,54 @@
+package com.github.naz013.appfunctions.googletask
+
+import com.github.naz013.cloudapi.googletasks.GoogleTasksApi
+import com.github.naz013.domain.GoogleTask
+import com.github.naz013.repository.GoogleTaskRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class DeleteGoogleTaskUseCaseTest {
+
+  private val googleTasksApi = mockk<GoogleTasksApi>()
+  private val googleTaskRepository = mockk<GoogleTaskRepository>(relaxUnitFun = true)
+  private val useCase = DeleteGoogleTaskUseCase(googleTasksApi, googleTaskRepository)
+
+  @Test
+  fun `invoke deletes through the api and locally when it succeeds`() = runTest {
+    val existing = GoogleTask(taskId = "task-1", listId = "list-1", title = "Buy milk")
+    coEvery { googleTaskRepository.getById("task-1") } returns existing
+    coEvery { googleTasksApi.deleteTask(existing) } returns true
+
+    val result = useCase("task-1")
+
+    assertEquals(existing, result)
+    coVerify { googleTaskRepository.delete("task-1") }
+  }
+
+  @Test
+  fun `invoke returns null and never calls the api when no local task exists`() = runTest {
+    coEvery { googleTaskRepository.getById("missing") } returns null
+
+    val result = useCase("missing")
+
+    assertNull(result)
+    coVerify(exactly = 0) { googleTasksApi.deleteTask(any()) }
+    coVerify(exactly = 0) { googleTaskRepository.delete(any()) }
+  }
+
+  @Test
+  fun `invoke returns null and does not delete locally when the api delete fails`() = runTest {
+    val existing = GoogleTask(taskId = "task-1", listId = "list-1", title = "Buy milk")
+    coEvery { googleTaskRepository.getById("task-1") } returns existing
+    coEvery { googleTasksApi.deleteTask(existing) } returns false
+
+    val result = useCase("task-1")
+
+    assertNull(result)
+    coVerify(exactly = 0) { googleTaskRepository.delete(any()) }
+  }
+}

--- a/extensions/appfunctions/src/test/kotlin/com/github/naz013/appfunctions/googletask/SearchGoogleTasksUseCaseTest.kt
+++ b/extensions/appfunctions/src/test/kotlin/com/github/naz013/appfunctions/googletask/SearchGoogleTasksUseCaseTest.kt
@@ -1,0 +1,25 @@
+package com.github.naz013.appfunctions.googletask
+
+import com.github.naz013.domain.GoogleTask
+import com.github.naz013.repository.GoogleTaskRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SearchGoogleTasksUseCaseTest {
+
+  private val googleTaskRepository = mockk<GoogleTaskRepository>()
+  private val useCase = SearchGoogleTasksUseCase(googleTaskRepository)
+
+  @Test
+  fun `invoke returns matches from the repository`() = runTest {
+    val matches = listOf(GoogleTask(taskId = "task-1", listId = "list-1", title = "Buy milk"))
+    coEvery { googleTaskRepository.search("milk") } returns matches
+
+    val result = useCase("milk")
+
+    assertEquals(matches, result)
+  }
+}

--- a/extensions/appfunctions/src/test/kotlin/com/github/naz013/appfunctions/googletask/UpdateGoogleTaskUseCaseTest.kt
+++ b/extensions/appfunctions/src/test/kotlin/com/github/naz013/appfunctions/googletask/UpdateGoogleTaskUseCaseTest.kt
@@ -1,0 +1,71 @@
+package com.github.naz013.appfunctions.googletask
+
+import com.github.naz013.cloudapi.googletasks.GoogleTasksApi
+import com.github.naz013.datecalc.DateTimeManager
+import com.github.naz013.domain.GoogleTask
+import com.github.naz013.repository.GoogleTaskRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.time.LocalDateTime as JavaLocalDateTime
+import org.threeten.bp.LocalDateTime as ThreeTenLocalDateTime
+
+class UpdateGoogleTaskUseCaseTest {
+
+  private val googleTasksApi = mockk<GoogleTasksApi>()
+  private val googleTaskRepository = mockk<GoogleTaskRepository>(relaxUnitFun = true)
+  private val dateTimeManager = mockk<DateTimeManager>()
+  private val useCase = UpdateGoogleTaskUseCase(googleTasksApi, googleTaskRepository, dateTimeManager)
+
+  @Test
+  fun `invoke updates the task through the api and saves the result locally, preserving status`() = runTest {
+    val existing =
+      GoogleTask(taskId = "task-1", listId = "list-1", title = "Buy milk", status = GoogleTask.TASKS_COMPLETE)
+    every {
+      dateTimeManager.toMillis(ThreeTenLocalDateTime.of(2026, 8, 5, 10, 0))
+    } returns 123L
+    val expectedUpdate = existing.copy(title = "Buy oat milk", notes = "2%", dueDate = 123L)
+    coEvery { googleTaskRepository.getById("task-1") } returns existing
+    coEvery { googleTasksApi.updateTask(expectedUpdate) } returns expectedUpdate
+
+    val result =
+      useCase(
+        id = "task-1",
+        title = "Buy oat milk",
+        notes = "2%",
+        dueDateTime = JavaLocalDateTime.of(2026, 8, 5, 10, 0),
+      )
+
+    assertEquals("Buy oat milk", result?.title)
+    assertEquals(GoogleTask.TASKS_COMPLETE, result?.status)
+    coVerify { googleTaskRepository.save(expectedUpdate) }
+  }
+
+  @Test
+  fun `invoke returns null and never calls the api when no local task exists`() = runTest {
+    coEvery { googleTaskRepository.getById("missing") } returns null
+
+    val result = useCase(id = "missing", title = "Title", notes = null, dueDateTime = null)
+
+    assertNull(result)
+    coVerify(exactly = 0) { googleTasksApi.updateTask(any()) }
+    coVerify(exactly = 0) { googleTaskRepository.save(any()) }
+  }
+
+  @Test
+  fun `invoke returns null and does not save when the api update fails`() = runTest {
+    val existing = GoogleTask(taskId = "task-1", listId = "list-1", title = "Buy milk")
+    coEvery { googleTaskRepository.getById("task-1") } returns existing
+    coEvery { googleTasksApi.updateTask(any()) } returns null
+
+    val result = useCase(id = "task-1", title = "Buy oat milk", notes = null, dueDateTime = null)
+
+    assertNull(result)
+    coVerify(exactly = 0) { googleTaskRepository.save(any()) }
+  }
+}

--- a/extensions/appfunctions/src/test/kotlin/com/github/naz013/appfunctions/note/DeleteNoteUseCaseTest.kt
+++ b/extensions/appfunctions/src/test/kotlin/com/github/naz013/appfunctions/note/DeleteNoteUseCaseTest.kt
@@ -1,0 +1,40 @@
+package com.github.naz013.appfunctions.note
+
+import com.github.naz013.domain.note.Note
+import com.github.naz013.domain.note.NoteWithImages
+import com.github.naz013.domain.sync.SyncState
+import com.github.naz013.repository.NoteRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class DeleteNoteUseCaseTest {
+
+  private val noteRepository = mockk<NoteRepository>(relaxUnitFun = true)
+  private val useCase = DeleteNoteUseCase(noteRepository)
+
+  @Test
+  fun `invoke deletes and returns the note when it exists`() = runTest {
+    val note = Note(key = "note-1", syncState = SyncState.Synced)
+    coEvery { noteRepository.getById("note-1") } returns NoteWithImages(note = note)
+
+    val result = useCase("note-1")
+
+    assertEquals(note, result)
+    coVerify { noteRepository.delete("note-1") }
+  }
+
+  @Test
+  fun `invoke returns null and does not delete when no note exists`() = runTest {
+    coEvery { noteRepository.getById("missing") } returns null
+
+    val result = useCase("missing")
+
+    assertNull(result)
+    coVerify(exactly = 0) { noteRepository.delete(any()) }
+  }
+}

--- a/extensions/appfunctions/src/test/kotlin/com/github/naz013/appfunctions/note/UpdateNoteUseCaseTest.kt
+++ b/extensions/appfunctions/src/test/kotlin/com/github/naz013/appfunctions/note/UpdateNoteUseCaseTest.kt
@@ -1,0 +1,43 @@
+package com.github.naz013.appfunctions.note
+
+import com.github.naz013.domain.note.Note
+import com.github.naz013.domain.note.NoteWithImages
+import com.github.naz013.domain.sync.SyncState
+import com.github.naz013.repository.NoteRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class UpdateNoteUseCaseTest {
+
+  private val noteRepository = mockk<NoteRepository>(relaxUnitFun = true)
+  private val useCase = UpdateNoteUseCase(noteRepository)
+
+  @Test
+  fun `invoke updates content, bumps version and marks for upload when the note exists`() = runTest {
+    val existing = Note(key = "note-1", syncState = SyncState.Synced, version = 4L)
+    coEvery { noteRepository.getById("note-1") } returns NoteWithImages(note = existing)
+
+    val result = useCase(id = "note-1", title = "Wi-Fi password", content = "hunter2")
+
+    assertEquals("Wi-Fi password\nhunter2", result?.content?.text)
+    assertEquals(5L, result?.version)
+    coVerify { noteRepository.save(result!!) }
+    coVerify { noteRepository.updateSyncState("note-1", SyncState.WaitingForUpload) }
+  }
+
+  @Test
+  fun `invoke returns null and does not save when no note exists`() = runTest {
+    coEvery { noteRepository.getById("missing") } returns null
+
+    val result = useCase(id = "missing", title = "Title", content = "Content")
+
+    assertNull(result)
+    coVerify(exactly = 0) { noteRepository.save(any<Note>()) }
+    coVerify(exactly = 0) { noteRepository.updateSyncState(any(), any()) }
+  }
+}

--- a/extensions/appfunctions/src/test/kotlin/com/github/naz013/appfunctions/reminder/SearchRemindersUseCaseTest.kt
+++ b/extensions/appfunctions/src/test/kotlin/com/github/naz013/appfunctions/reminder/SearchRemindersUseCaseTest.kt
@@ -1,0 +1,34 @@
+package com.github.naz013.appfunctions.reminder
+
+import com.github.naz013.domain.reminder.v2.ReminderSchedule
+import com.github.naz013.domain.reminder.v2.ReminderV2
+import com.github.naz013.repository.ReminderV2Repository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.threeten.bp.LocalDateTime
+
+class SearchRemindersUseCaseTest {
+
+  private val reminderV2Repository = mockk<ReminderV2Repository>()
+  private val useCase = SearchRemindersUseCase(reminderV2Repository)
+
+  @Test
+  fun `invoke returns matches from the repository`() = runTest {
+    val matches =
+      listOf(
+        ReminderV2(
+          uuId = "reminder-1",
+          summary = "Pay rent",
+          schedule = ReminderSchedule(startDateTime = LocalDateTime.of(2026, 8, 1, 9, 0)),
+        ),
+      )
+    coEvery { reminderV2Repository.search("rent") } returns matches
+
+    val result = useCase("rent")
+
+    assertEquals(matches, result)
+  }
+}

--- a/extensions/appfunctions/src/test/kotlin/com/github/naz013/appfunctions/reminder/UpdateReminderUseCaseTest.kt
+++ b/extensions/appfunctions/src/test/kotlin/com/github/naz013/appfunctions/reminder/UpdateReminderUseCaseTest.kt
@@ -1,0 +1,67 @@
+package com.github.naz013.appfunctions.reminder
+
+import com.github.naz013.datecalc.DateTimeManager
+import com.github.naz013.domain.reminder.v2.ReminderSchedule
+import com.github.naz013.domain.reminder.v2.ReminderV2
+import com.github.naz013.repository.ReminderV2Repository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.time.LocalDateTime as JavaLocalDateTime
+import org.threeten.bp.LocalDateTime as ThreeTenLocalDateTime
+
+class UpdateReminderUseCaseTest {
+
+  private val reminderV2Repository = mockk<ReminderV2Repository>(relaxUnitFun = true)
+  private val dateTimeManager = mockk<DateTimeManager>()
+  private val useCase = UpdateReminderUseCase(reminderV2Repository, dateTimeManager)
+
+  @Test
+  fun `invoke updates title, notes and schedule when the reminder exists`() = runTest {
+    val existing =
+      ReminderV2(
+        uuId = "reminder-1",
+        summary = "Pay rent",
+        schedule = ReminderSchedule(startDateTime = ThreeTenLocalDateTime.of(2026, 8, 1, 9, 0)),
+      )
+    coEvery { reminderV2Repository.getById("reminder-1") } returns existing
+    every {
+      dateTimeManager.localToUtc(ThreeTenLocalDateTime.of(2026, 8, 5, 10, 0))
+    } returns ThreeTenLocalDateTime.of(2026, 8, 5, 10, 0)
+
+    val result =
+      useCase(
+        id = "reminder-1",
+        title = "Pay rent - updated",
+        dueDateTime = JavaLocalDateTime.of(2026, 8, 5, 10, 0),
+        notes = "before 5pm",
+      )
+
+    assertEquals("Pay rent - updated", result?.summary)
+    assertEquals("before 5pm", result?.description)
+    assertEquals(ThreeTenLocalDateTime.of(2026, 8, 5, 10, 0), result?.schedule?.startDateTime)
+    assertEquals(ThreeTenLocalDateTime.of(2026, 8, 5, 10, 0), result?.schedule?.eventDateTime)
+    coVerify { reminderV2Repository.save(result!!) }
+  }
+
+  @Test
+  fun `invoke returns null and does not save when no reminder exists`() = runTest {
+    coEvery { reminderV2Repository.getById("missing") } returns null
+
+    val result =
+      useCase(
+        id = "missing",
+        title = "Title",
+        dueDateTime = JavaLocalDateTime.of(2026, 8, 5, 10, 0),
+        notes = null,
+      )
+
+    assertNull(result)
+    coVerify(exactly = 0) { reminderV2Repository.save(any()) }
+  }
+}


### PR DESCRIPTION
Brings reminders, notes, birthdays, and Google Tasks to full CRUD+search parity in the appfunctions module - previously only create/list/complete were exposed, with no way to edit anything once created.