### PR TITLE
REM-1206 - Fix cloud sync metadata mismatch, legacy group data loss, and conflict handling

### DIFF
--- a/app/src/main/java/com/elementary/tasks/core/cloud/IsProUserUseCaseImpl.kt
+++ b/app/src/main/java/com/elementary/tasks/core/cloud/IsProUserUseCaseImpl.kt
@@ -1,0 +1,10 @@
+package com.elementary.tasks.core.cloud
+
+import com.github.naz013.common.system.BuildInfo
+import com.github.naz013.sync.IsProUserUseCase
+
+class IsProUserUseCaseImpl(
+  private val buildInfo: BuildInfo,
+) : IsProUserUseCase {
+  override fun invoke(): Boolean = buildInfo.isPro
+}

--- a/app/src/main/java/com/elementary/tasks/core/cloud/KoinModule.kt
+++ b/app/src/main/java/com/elementary/tasks/core/cloud/KoinModule.kt
@@ -4,6 +4,7 @@ import com.github.naz013.repository.TagSyncTrigger
 import com.github.naz013.sync.CloudApiProvider
 import com.github.naz013.sync.DataPostProcessor
 import com.github.naz013.sync.FileCacheProvider
+import com.github.naz013.sync.IsProUserUseCase
 import com.github.naz013.sync.SyncSettings
 import org.koin.dsl.module
 
@@ -13,4 +14,5 @@ val cloudModule = module {
   factory { DataPostProcessorImpl(get(), get(), get(), get()) as DataPostProcessor }
   factory { FileCacheProviderImpl(get()) as FileCacheProvider }
   single { TagSyncTriggerImpl(get()) as TagSyncTrigger }
+  factory { IsProUserUseCaseImpl(get()) as IsProUserUseCase }
 }

--- a/data/files-api/src/main/kotlin/com/github/naz013/files/DataType.kt
+++ b/data/files-api/src/main/kotlin/com/github/naz013/files/DataType.kt
@@ -2,7 +2,8 @@ package com.github.naz013.files
 
 enum class DataType(
   val fileExtension: String,
-  val isLegacy: Boolean = false
+  val isLegacy: Boolean = false,
+  val isProOnly: Boolean = false
 ) {
   Reminders(".ta2", isLegacy = true),
   RemindersV2(".ta3"),
@@ -18,6 +19,6 @@ enum class DataType(
   Tags(".tg1"),
   TagAssignments(".tga1"),
   Routines(".rt1"),
-  WorkflowRules(".wr1"),
-  WorkflowTemplates(".wt1")
+  WorkflowRules(".wr1", isProOnly = true),
+  WorkflowTemplates(".wt1", isProOnly = true)
 }

--- a/data/sync/src/main/kotlin/com/github/naz013/sync/IsProUserUseCase.kt
+++ b/data/sync/src/main/kotlin/com/github/naz013/sync/IsProUserUseCase.kt
@@ -1,0 +1,11 @@
+package com.github.naz013.sync
+
+/**
+ * Answers whether the current user has an active Pro subscription/purchase - the seam
+ * [SyncApiImpl] uses to gate upload/download of [com.github.naz013.files.DataType.isProOnly]
+ * data types. Implemented in `app` against `BuildInfo.isPro`; `data:sync` stays free of any
+ * Android/platform dependency, same as the [SyncSettings] seam.
+ */
+fun interface IsProUserUseCase {
+  operator fun invoke(): Boolean
+}

--- a/data/sync/src/main/kotlin/com/github/naz013/sync/KoinModule.kt
+++ b/data/sync/src/main/kotlin/com/github/naz013/sync/KoinModule.kt
@@ -34,7 +34,7 @@ import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.module
 
 val syncApiModule = module {
-  factory { SyncApiImpl(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) as SyncApi }
+  factory { SyncApiImpl(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) as SyncApi }
 
   factoryOf(::DataTypeRepositoryCallerFactory)
 

--- a/data/sync/src/main/kotlin/com/github/naz013/sync/SyncApiImpl.kt
+++ b/data/sync/src/main/kotlin/com/github/naz013/sync/SyncApiImpl.kt
@@ -26,15 +26,25 @@ internal class SyncApiImpl(
   private val uploadDataTypeUseCase: UploadDataTypeUseCase,
   private val hasAnyCloudApiUseCase: HasAnyCloudApiUseCase,
   private val syncApiSessionCache: SyncApiSessionCache,
-  private val downloadLegacyFilesUseCase: DownloadLegacyFilesUseCase
+  private val downloadLegacyFilesUseCase: DownloadLegacyFilesUseCase,
+  private val isProUserUseCase: IsProUserUseCase
 ) : SyncApi {
+
+  /**
+   * Deletion is deliberately never gated here: a user whose Pro subscription lapses must still
+   * be able to remove their own already-synced Pro-only data (e.g. workflow rules) from the
+   * cloud - otherwise it's stranded forever, the same class of bug fixed for legacy files.
+   */
+  private fun isDataTypeAllowed(dataType: DataType): Boolean {
+    return !dataType.isProOnly || isProUserUseCase()
+  }
 
   override suspend fun sync(forceUpload: Boolean): SyncResult = measure("Total sync") {
     if (!hasAnyCloudApiUseCase()) {
       Logger.i(TAG, "No cloud API configured for sync.")
       return@measure SyncResult.Skipped
     }
-    val allowedDataTypes = getAllowedDataTypesUseCase()
+    val allowedDataTypes = getAllowedDataTypesUseCase().filter(::isDataTypeAllowed)
     if (allowedDataTypes.isEmpty()) {
       Logger.i(TAG, "No allowed data types for sync.")
       return@measure SyncResult.Skipped
@@ -55,6 +65,10 @@ internal class SyncApiImpl(
   override suspend fun sync(dataType: DataType, forceUpload: Boolean): SyncResult = measure("Sync for data type: $dataType") {
     if (!hasAnyCloudApiUseCase()) {
       Logger.i(TAG, "No cloud API configured for sync.")
+      return@measure SyncResult.Skipped
+    }
+    if (!isDataTypeAllowed(dataType)) {
+      Logger.i(TAG, "Data type $dataType requires a Pro subscription. Skipping sync.")
       return@measure SyncResult.Skipped
     }
     syncInternal(dataType, forceUpload).also {
@@ -79,6 +93,10 @@ internal class SyncApiImpl(
       Logger.i(TAG, "No cloud API configured for sync.")
       return@measure SyncResult.Skipped
     }
+    if (!isDataTypeAllowed(dataType)) {
+      Logger.i(TAG, "Data type $dataType requires a Pro subscription. Skipping sync.")
+      return@measure SyncResult.Skipped
+    }
     if (dataType == DataType.Settings) {
       throw IllegalArgumentException("Cannot sync single settings item.")
     }
@@ -97,7 +115,7 @@ internal class SyncApiImpl(
       Logger.i(TAG, "No cloud API configured for upload.")
       return@measure
     }
-    val allowedDataTypes = getAllowedDataTypesUseCase()
+    val allowedDataTypes = getAllowedDataTypesUseCase().filter(::isDataTypeAllowed)
     for (dataType in allowedDataTypes) {
       Logger.i(TAG, "Uploading items for data type: $dataType")
       uploadInternal(dataType)
@@ -108,6 +126,10 @@ internal class SyncApiImpl(
   override suspend fun upload(dataType: DataType) = measure("Upload for data type: $dataType") {
     if (!hasAnyCloudApiUseCase()) {
       Logger.i(TAG, "No cloud API configured for upload.")
+      return@measure
+    }
+    if (!isDataTypeAllowed(dataType)) {
+      Logger.i(TAG, "Data type $dataType requires a Pro subscription. Skipping upload.")
       return@measure
     }
     uploadInternal(dataType)
@@ -122,6 +144,10 @@ internal class SyncApiImpl(
     require(id.isNotBlank()) { "Id cannot be blank" }
     if (!hasAnyCloudApiUseCase()) {
       Logger.i(TAG, "No cloud API configured for upload.")
+      return@measure
+    }
+    if (!isDataTypeAllowed(dataType)) {
+      Logger.i(TAG, "Data type $dataType requires a Pro subscription. Skipping upload.")
       return@measure
     }
     if (dataType == DataType.Settings) {
@@ -140,7 +166,7 @@ internal class SyncApiImpl(
       Logger.i(TAG, "No cloud API configured for upload.")
       return
     }
-    val allowedDataTypes = getAllowedDataTypesUseCase()
+    val allowedDataTypes = getAllowedDataTypesUseCase().filter(::isDataTypeAllowed)
     for (dataType in allowedDataTypes) {
       forceUploadInternal(dataType)
     }
@@ -150,6 +176,10 @@ internal class SyncApiImpl(
   override suspend fun forceUpload(dataType: DataType) {
     if (!hasAnyCloudApiUseCase()) {
       Logger.i(TAG, "No cloud API configured for upload.")
+      return
+    }
+    if (!isDataTypeAllowed(dataType)) {
+      Logger.i(TAG, "Data type $dataType requires a Pro subscription. Skipping force upload.")
       return
     }
     forceUploadInternal(dataType)
@@ -177,6 +207,10 @@ internal class SyncApiImpl(
     require(id.isNotBlank()) { "Id cannot be blank" }
     if (!hasAnyCloudApiUseCase()) {
       Logger.i(TAG, "No cloud API configured for upload.")
+      return
+    }
+    if (!isDataTypeAllowed(dataType)) {
+      Logger.i(TAG, "Data type $dataType requires a Pro subscription. Skipping force upload.")
       return
     }
     Logger.i(TAG, "Force uploading single item. dataType: $dataType, id: $id")

--- a/data/sync/src/main/kotlin/com/github/naz013/sync/SyncApiImpl.kt
+++ b/data/sync/src/main/kotlin/com/github/naz013/sync/SyncApiImpl.kt
@@ -158,6 +158,13 @@ internal class SyncApiImpl(
 
   private suspend fun forceUploadInternal(dataType: DataType) {
     Logger.i(TAG, "Force uploading items for data type: $dataType")
+    if (dataType == DataType.Settings || dataType == DataType.TagAssignments) {
+      // Whole-collection snapshot types have no per-id sync state to ignore, so forcing
+      // them is identical to a normal upload - delegate to the same always-upload path
+      // instead of falling through to getAllIds(), which is a no-op for these types.
+      uploadDataTypeUseCase(dataType)
+      return
+    }
     val repositoryCaller = dataTypeRepositoryCallerFactory.getCaller(dataType)
     val ids = repositoryCaller.getAllIds()
     Logger.i(TAG, "Found ${ids.size} items to force upload for data type: $dataType")

--- a/data/sync/src/main/kotlin/com/github/naz013/sync/local/DataTypeRepositoryCallerFactory.kt
+++ b/data/sync/src/main/kotlin/com/github/naz013/sync/local/DataTypeRepositoryCallerFactory.kt
@@ -31,7 +31,7 @@ internal class DataTypeRepositoryCallerFactory(
       DataType.RemindersV2 -> ReminderV2RepositoryCaller(reminderV2Repository)
       DataType.Notes, DataType.NotesV2 -> NoteRepositoryCaller(noteRepository)
       DataType.Birthdays -> BirthdayRepositoryCaller(birthdayRepository)
-      DataType.Groups -> NoopRepositoryCaller()
+      DataType.Groups -> GroupV2RepositoryCaller(groupV2Repository)
       DataType.GroupsV2 -> GroupV2RepositoryCaller(groupV2Repository)
       DataType.Places -> PlaceRepositoryCaller(placeRepository)
       DataType.Settings -> NoopRepositoryCaller()

--- a/data/sync/src/main/kotlin/com/github/naz013/sync/usecase/FindAllFilesToDownloadUseCase.kt
+++ b/data/sync/src/main/kotlin/com/github/naz013/sync/usecase/FindAllFilesToDownloadUseCase.kt
@@ -43,7 +43,7 @@ internal class FindAllFilesToDownloadUseCase(
     dataType: DataType,
   ): List<CloudFile> {
     val cloudFiles = cloudFileApi.findFiles(dataType.fileExtension)
-    val remoteMetadataMap = remoteFileMetadataRepository.getBySource(cloudFileApi.source.name)
+    val remoteMetadataMap = remoteFileMetadataRepository.getBySource(cloudFileApi.source.value)
       .associateBy { it.name }
     return cloudFiles.filter { cloudFile ->
       val remoteMetadata = remoteMetadataMap[cloudFile.name]

--- a/data/sync/src/main/kotlin/com/github/naz013/sync/usecase/FindNewestCloudApiSourceUseCase.kt
+++ b/data/sync/src/main/kotlin/com/github/naz013/sync/usecase/FindNewestCloudApiSourceUseCase.kt
@@ -49,7 +49,7 @@ internal class FindNewestCloudApiSourceUseCase(
         fileExtension = dataType.fileExtension
       )
     )
-    val remoteMetadata = remoteFileMetadataRepository.getByLocalUuIdAndSource(id, cloudFileApi.source.name)
+    val remoteMetadata = remoteFileMetadataRepository.getByLocalUuIdAndSource(id, cloudFileApi.source.value)
     return cloudFile?.takeIf { decideIfCanUseFile(cloudFileApi.source, it, remoteMetadata) }
   }
 

--- a/data/sync/src/main/kotlin/com/github/naz013/sync/usecase/download/DownloadLegacyFilesUseCase.kt
+++ b/data/sync/src/main/kotlin/com/github/naz013/sync/usecase/download/DownloadLegacyFilesUseCase.kt
@@ -36,17 +36,18 @@ internal class DownloadLegacyFilesUseCase(
 
             val id = getLocalUuIdUseCase(data)
 
-            // Check for conflicts before updating
+            // Legacy migration is one-shot: whether or not the item already exists locally,
+            // the legacy cloud file is stale afterwards and must be removed so it isn't
+            // redownloaded and reprocessed on every subsequent sync.
             val existingData = caller.getById(id)
-            if (existingData != null) {
+            if (existingData == null) {
+              caller.insertOrUpdate(data)
+              dataPostProcessor.process(dataType, data)
+              caller.updateSyncState(id, SyncState.Synced)
+              Logger.i(TAG, "Downloaded and saved file: ${cloudFile.name} from source: ${cloudFileApi.source}")
+            } else {
               Logger.d(TAG, "Existing data found for id: $id, skipping update.")
-              continue
             }
-
-            caller.insertOrUpdate(data)
-            dataPostProcessor.process(dataType, data)
-            caller.updateSyncState(id, SyncState.Synced)
-            Logger.i(TAG, "Downloaded and saved file: ${cloudFile.name} from source: ${cloudFileApi.source}")
 
             cloudFileApi.deleteFile(cloudFile.name)
           }

--- a/data/sync/src/main/kotlin/com/github/naz013/sync/usecase/download/DownloadSingleUseCase.kt
+++ b/data/sync/src/main/kotlin/com/github/naz013/sync/usecase/download/DownloadSingleUseCase.kt
@@ -40,14 +40,15 @@ internal class DownloadSingleUseCase(
       return SyncResult.Skipped
     }
     val cloudFile = newestResult.cloudFile
-    val existingMetadata = remoteFileMetadataRepository.getBySource(
-      source = newestResult.cloudFileApi.source.value
-    ).firstOrNull { it.name == cloudFile.name }
-    if (existingMetadata != null) {
-      if (cloudFile.lastModified <= existingMetadata.lastModified) {
-        Logger.d(TAG, "Local file is up to date for dataType: $dataType, id: $id, skipping download.")
-        return SyncResult.Skipped
-      }
+
+    // Local changes not yet uploaded must not be clobbered by an older-relative-to-them cloud
+    // copy - skip and let the next sync re-evaluate once they've been uploaded.
+    val pendingUploadIds = caller.getIdsByState(
+      listOf(SyncState.WaitingForUpload, SyncState.FailedToUpload)
+    )
+    if (id in pendingUploadIds) {
+      Logger.w(TAG, "Skipping download for dataType: $dataType, id: $id, local changes are still pending upload.")
+      return SyncResult.Skipped
     }
 
     val data = downloadCloudFileUseCase(
@@ -55,14 +56,6 @@ internal class DownloadSingleUseCase(
       cloudFile = cloudFile,
       dataType = dataType
     )
-
-    // Check for conflicts before updating
-    val existingData = caller.getById(id)
-    if (existingData != null) {
-      Logger.d(TAG, "Existing data found for id: $id, overwriting with cloud version")
-      // Cloud version takes precedence for now
-      // Future: Implement proper conflict resolution strategy
-    }
 
     caller.insertOrUpdate(data)
     dataPostProcessor.process(dataType, data)

--- a/data/sync/src/main/kotlin/com/github/naz013/sync/usecase/download/DownloadUseCase.kt
+++ b/data/sync/src/main/kotlin/com/github/naz013/sync/usecase/download/DownloadUseCase.kt
@@ -37,20 +37,15 @@ internal class DownloadUseCase(
       Logger.i(TAG, "No files to download for dataType: $dataType")
       return SyncResult.Skipped
     }
+    // Items with local changes not yet uploaded must not be clobbered by an older-relative-to-them
+    // cloud copy - skip them here and let the next sync re-evaluate once they've been uploaded.
+    val pendingUploadIds = caller.getIdsByState(
+      listOf(SyncState.WaitingForUpload, SyncState.FailedToUpload)
+    ).toSet()
     val downloadedFiles = mutableListOf<Downloaded>()
     for (cloudFilesWithSource in newestResult.sources) {
       val cloudFileApi = cloudFilesWithSource.source
       for (cloudFile in cloudFilesWithSource.cloudFiles) {
-        val existingMetadata = remoteFileMetadataRepository.getBySource(
-          source = cloudFileApi.source.value
-        ).firstOrNull { it.name == cloudFile.name }
-        if (existingMetadata != null) {
-          if (cloudFile.lastModified <= existingMetadata.lastModified) {
-            Logger.d(TAG, "Local file is up to date for file: ${cloudFile.name}, skipping download.")
-            continue
-          }
-        }
-
         Logger.i(TAG, "Downloading file: ${cloudFile.name} from source: ${cloudFileApi.source}")
         val data = try {
           downloadCloudFileUseCase(
@@ -64,12 +59,9 @@ internal class DownloadUseCase(
         }
         val id = getLocalUuIdUseCase(data)
 
-        // Check for conflicts before updating
-        val existingData = caller.getById(id)
-        if (existingData != null) {
-          Logger.d(TAG, "Existing data found for id: $id, overwriting with cloud version")
-          // Cloud version takes precedence for now
-          // Future: Implement proper conflict resolution strategy
+        if (id in pendingUploadIds) {
+          Logger.w(TAG, "Skipping download for id: $id, local changes are still pending upload.")
+          continue
         }
 
         caller.insertOrUpdate(data)

--- a/data/sync/src/test/kotlin/com/github/naz013/sync/SyncApiImplTest.kt
+++ b/data/sync/src/test/kotlin/com/github/naz013/sync/SyncApiImplTest.kt
@@ -583,6 +583,63 @@ class SyncApiImplTest {
     }
   }
 
+  @Test
+  fun `force upload with Settings data type should delegate to upload data type use case`() {
+    runBlocking {
+      // Arrange - Settings has no per-id sync state, so forcing it must still upload it
+      every { hasAnyCloudApiUseCase() } returns true
+      coEvery { uploadDataTypeUseCase(DataType.Settings) } returns Unit
+
+      // Act
+      syncApi.forceUpload(DataType.Settings)
+
+      // Assert
+      coVerify(exactly = 1) { uploadDataTypeUseCase(DataType.Settings) }
+      coVerify(exactly = 0) { dataTypeRepositoryCallerFactory.getCaller(any()) }
+      coVerify(exactly = 0) { uploadSingleUseCase(any(), any()) }
+      coVerify(exactly = 1) { syncApiSessionCache.clearCache() }
+    }
+  }
+
+  @Test
+  fun `force upload with TagAssignments data type should delegate to upload data type use case`() {
+    runBlocking {
+      // Arrange - TagAssignments has no per-id sync state, so forcing it must still upload it
+      every { hasAnyCloudApiUseCase() } returns true
+      coEvery { uploadDataTypeUseCase(DataType.TagAssignments) } returns Unit
+
+      // Act
+      syncApi.forceUpload(DataType.TagAssignments)
+
+      // Assert
+      coVerify(exactly = 1) { uploadDataTypeUseCase(DataType.TagAssignments) }
+      coVerify(exactly = 0) { dataTypeRepositoryCallerFactory.getCaller(any()) }
+      coVerify(exactly = 0) { uploadSingleUseCase(any(), any()) }
+      coVerify(exactly = 1) { syncApiSessionCache.clearCache() }
+    }
+  }
+
+  @Test
+  fun `force upload without parameters should also force upload Settings and TagAssignments`() {
+    runBlocking {
+      // Arrange
+      val allowedTypes = listOf(DataType.Settings, DataType.TagAssignments)
+
+      every { hasAnyCloudApiUseCase() } returns true
+      every { getAllowedDataTypesUseCase() } returns allowedTypes
+      coEvery { uploadDataTypeUseCase(any()) } returns Unit
+
+      // Act
+      syncApi.forceUpload()
+
+      // Assert - Both snapshot types were force-uploaded via the always-upload path
+      coVerify(exactly = 1) { uploadDataTypeUseCase(DataType.Settings) }
+      coVerify(exactly = 1) { uploadDataTypeUseCase(DataType.TagAssignments) }
+      coVerify(exactly = 0) { dataTypeRepositoryCallerFactory.getCaller(any()) }
+      coVerify(exactly = 1) { syncApiSessionCache.clearCache() }
+    }
+  }
+
   // ==================== delete() Tests ====================
 
   @Test

--- a/data/sync/src/test/kotlin/com/github/naz013/sync/SyncApiImplTest.kt
+++ b/data/sync/src/test/kotlin/com/github/naz013/sync/SyncApiImplTest.kt
@@ -45,6 +45,7 @@ class SyncApiImplTest {
   private lateinit var syncApi: SyncApiImpl
   private lateinit var syncApiSessionCache: SyncApiSessionCache
   private lateinit var downloadLegacyFilesUseCase: DownloadLegacyFilesUseCase
+  private lateinit var isProUserUseCase: IsProUserUseCase
 
   private lateinit var mockRepositoryCaller: DataTypeRepositoryCaller<Any>
 
@@ -62,6 +63,7 @@ class SyncApiImplTest {
     mockRepositoryCaller = mockk(relaxed = true)
     syncApiSessionCache = mockk(relaxed = true)
     downloadLegacyFilesUseCase = mockk(relaxed = true)
+    isProUserUseCase = mockk()
 
     syncApi = SyncApiImpl(
       dataTypeRepositoryCallerFactory = dataTypeRepositoryCallerFactory,
@@ -74,7 +76,8 @@ class SyncApiImplTest {
       uploadDataTypeUseCase = uploadDataTypeUseCase,
       hasAnyCloudApiUseCase = hasAnyCloudApiUseCase,
       syncApiSessionCache = syncApiSessionCache,
-      downloadLegacyFilesUseCase = downloadLegacyFilesUseCase
+      downloadLegacyFilesUseCase = downloadLegacyFilesUseCase,
+      isProUserUseCase = isProUserUseCase
     )
   }
 
@@ -637,6 +640,143 @@ class SyncApiImplTest {
       coVerify(exactly = 1) { uploadDataTypeUseCase(DataType.TagAssignments) }
       coVerify(exactly = 0) { dataTypeRepositoryCallerFactory.getCaller(any()) }
       coVerify(exactly = 1) { syncApiSessionCache.clearCache() }
+    }
+  }
+
+  // ==================== Pro-only data type gating Tests ====================
+
+  @Test
+  fun `sync with a Pro-only data type should be skipped for a free user`() {
+    runBlocking {
+      every { hasAnyCloudApiUseCase() } returns true
+      every { isProUserUseCase() } returns false
+
+      val result = syncApi.sync(DataType.WorkflowRules)
+
+      assertEquals(SyncResult.Skipped, result)
+      coVerify(exactly = 0) { uploadDataTypeUseCase(any()) }
+      coVerify(exactly = 0) { downloadUseCase(any()) }
+    }
+  }
+
+  @Test
+  fun `sync with a Pro-only data type should proceed for a Pro user`() {
+    runBlocking {
+      val dataType = DataType.WorkflowRules
+      val downloadResult = SyncResult.Success(downloaded = listOf(Downloaded(dataType, "w1")), success = true)
+
+      every { hasAnyCloudApiUseCase() } returns true
+      every { isProUserUseCase() } returns true
+      coEvery { uploadDataTypeUseCase(dataType) } returns Unit
+      coEvery { downloadUseCase(dataType) } returns downloadResult
+
+      val result = syncApi.sync(dataType)
+
+      assertEquals(downloadResult, result)
+      coVerify(exactly = 1) { uploadDataTypeUseCase(dataType) }
+      coVerify(exactly = 1) { downloadUseCase(dataType) }
+    }
+  }
+
+  @Test
+  fun `sync single item with a Pro-only data type should be skipped for a free user`() {
+    runBlocking {
+      every { hasAnyCloudApiUseCase() } returns true
+      every { isProUserUseCase() } returns false
+
+      val result = syncApi.sync(DataType.WorkflowTemplates, "template-1")
+
+      assertEquals(SyncResult.Skipped, result)
+      coVerify(exactly = 0) { uploadSingleUseCase(any(), any()) }
+      coVerify(exactly = 0) { downloadSingleUseCase(any(), any()) }
+    }
+  }
+
+  @Test
+  fun `upload with a Pro-only data type should be skipped for a free user`() {
+    runBlocking {
+      every { hasAnyCloudApiUseCase() } returns true
+      every { isProUserUseCase() } returns false
+
+      syncApi.upload(DataType.WorkflowRules)
+
+      coVerify(exactly = 0) { uploadDataTypeUseCase(any()) }
+    }
+  }
+
+  @Test
+  fun `upload single item with a Pro-only data type should be skipped for a free user`() {
+    runBlocking {
+      every { hasAnyCloudApiUseCase() } returns true
+      every { isProUserUseCase() } returns false
+
+      syncApi.upload(DataType.WorkflowTemplates, "template-1")
+
+      coVerify(exactly = 0) { uploadSingleUseCase(any(), any()) }
+    }
+  }
+
+  @Test
+  fun `force upload with a Pro-only data type should be skipped for a free user`() {
+    runBlocking {
+      every { hasAnyCloudApiUseCase() } returns true
+      every { isProUserUseCase() } returns false
+
+      syncApi.forceUpload(DataType.WorkflowRules)
+
+      coVerify(exactly = 0) { dataTypeRepositoryCallerFactory.getCaller(any()) }
+      coVerify(exactly = 0) { uploadSingleUseCase(any(), any()) }
+    }
+  }
+
+  @Test
+  fun `force upload single item with a Pro-only data type should be skipped for a free user`() {
+    runBlocking {
+      every { hasAnyCloudApiUseCase() } returns true
+      every { isProUserUseCase() } returns false
+
+      syncApi.forceUpload(DataType.WorkflowTemplates, "template-1")
+
+      coVerify(exactly = 0) { uploadSingleUseCase(any(), any()) }
+    }
+  }
+
+  @Test
+  fun `bulk sync should exclude Pro-only data types for a free user but keep the rest`() {
+    runBlocking {
+      val allowedTypes = listOf(DataType.Reminders, DataType.WorkflowRules, DataType.WorkflowTemplates)
+      val downloadResult = SyncResult.Success(downloaded = listOf(Downloaded(DataType.Reminders, "r1")), success = true)
+
+      every { hasAnyCloudApiUseCase() } returns true
+      every { getAllowedDataTypesUseCase() } returns allowedTypes
+      every { isProUserUseCase() } returns false
+      coEvery { uploadDataTypeUseCase(any()) } returns Unit
+      coEvery { downloadUseCase(DataType.Reminders) } returns downloadResult
+
+      syncApi.sync()
+
+      coVerify(exactly = 1) { uploadDataTypeUseCase(DataType.Reminders) }
+      coVerify(exactly = 1) { downloadUseCase(DataType.Reminders) }
+      coVerify(exactly = 0) { uploadDataTypeUseCase(DataType.WorkflowRules) }
+      coVerify(exactly = 0) { uploadDataTypeUseCase(DataType.WorkflowTemplates) }
+      coVerify(exactly = 0) { downloadUseCase(DataType.WorkflowRules) }
+      coVerify(exactly = 0) { downloadUseCase(DataType.WorkflowTemplates) }
+    }
+  }
+
+  @Test
+  fun `delete of a Pro-only data type is never gated so a downgraded user can still clean up the cloud`() {
+    runBlocking {
+      val dataType = DataType.WorkflowRules
+      val itemId = "workflow-rule-1"
+
+      every { hasAnyCloudApiUseCase() } returns true
+      coEvery { deleteSingleUseCase(dataType, itemId) } returns Unit
+
+      // Note: isProUserUseCase is never stubbed here - delete must not even query it.
+      syncApi.delete(dataType, itemId)
+
+      coVerify(exactly = 1) { deleteSingleUseCase(dataType, itemId) }
     }
   }
 

--- a/data/sync/src/test/kotlin/com/github/naz013/sync/local/DataTypeRepositoryCallerFactoryTest.kt
+++ b/data/sync/src/test/kotlin/com/github/naz013/sync/local/DataTypeRepositoryCallerFactoryTest.kt
@@ -1,0 +1,68 @@
+package com.github.naz013.sync.local
+
+import com.github.naz013.files.DataType
+import com.github.naz013.repository.BirthdayRepository
+import com.github.naz013.repository.GroupV2Repository
+import com.github.naz013.repository.NoteRepository
+import com.github.naz013.repository.PlaceRepository
+import com.github.naz013.repository.RecurPresetRepository
+import com.github.naz013.repository.ReminderV2Repository
+import com.github.naz013.repository.RoutineRepository
+import com.github.naz013.repository.TagRepository
+import com.github.naz013.repository.WorkflowRuleRepository
+import com.github.naz013.repository.WorkflowTemplateRepository
+import io.mockk.mockk
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class DataTypeRepositoryCallerFactoryTest {
+
+  private lateinit var factory: DataTypeRepositoryCallerFactory
+
+  @Before
+  fun setUp() {
+    factory = DataTypeRepositoryCallerFactory(
+      noteRepository = mockk<NoteRepository>(),
+      birthdayRepository = mockk<BirthdayRepository>(),
+      placeRepository = mockk<PlaceRepository>(),
+      recurPresetRepository = mockk<RecurPresetRepository>(),
+      reminderV2Repository = mockk<ReminderV2Repository>(),
+      groupV2Repository = mockk<GroupV2Repository>(),
+      tagRepository = mockk<TagRepository>(),
+      routineRepository = mockk<RoutineRepository>(),
+      workflowRuleRepository = mockk<WorkflowRuleRepository>(),
+      workflowTemplateRepository = mockk<WorkflowTemplateRepository>()
+    )
+  }
+
+  @Test
+  fun `getCaller for legacy Groups returns a real caller so migrated groups are actually persisted`() {
+    // Legacy .gr2 files are converted to GroupV2 by the data converter (ReminderGroup.toGroupV2()),
+    // so the caller for DataType.Groups must be able to persist a GroupV2 - a NoopRepositoryCaller
+    // here would silently discard every migrated group after its cloud backup is deleted.
+    val caller = factory.getCaller(DataType.Groups)
+
+    assertTrue(caller is GroupV2RepositoryCaller)
+  }
+
+  @Test
+  fun `getCaller for GroupsV2 returns the same caller type as legacy Groups`() {
+    val caller = factory.getCaller(DataType.GroupsV2)
+
+    assertTrue(caller is GroupV2RepositoryCaller)
+  }
+
+  @Test
+  fun `getCaller for NotesV2 legacy type returns a real caller`() {
+    val caller = factory.getCaller(DataType.NotesV2)
+
+    assertTrue(caller is NoteRepositoryCaller)
+  }
+
+  @Test
+  fun `getCaller for Settings and TagAssignments returns a noop caller`() {
+    assertTrue(factory.getCaller(DataType.Settings) is NoopRepositoryCaller)
+    assertTrue(factory.getCaller(DataType.TagAssignments) is NoopRepositoryCaller)
+  }
+}

--- a/data/sync/src/test/kotlin/com/github/naz013/sync/usecase/DownloadSingleUseCaseTest.kt
+++ b/data/sync/src/test/kotlin/com/github/naz013/sync/usecase/DownloadSingleUseCaseTest.kt
@@ -442,6 +442,39 @@ class DownloadSingleUseCaseTest {
   }
 
   @Test
+  fun `invoke should skip download when local item has pending upload`() {
+    runBlocking {
+      // Arrange - id has local edits still waiting to be uploaded
+      val dataType = DataType.Reminders
+      val reminderId = "reminder-pending-upload"
+      val cloudFile = CloudFile(
+        id = "gdrive-file-id",
+        name = "$reminderId.ta2",
+        fileExtension = ".ta2",
+        lastModified = 1698765432000L,
+        size = 2048,
+        version = 3L,
+        rev = "rev3"
+      )
+
+      every { dataTypeRepositoryCallerFactory.getCaller(dataType) } returns mockRepositoryCaller
+      coEvery { findNewestCloudApiSourceUseCase(dataType, reminderId) } returns
+        FindNewestCloudApiSourceUseCase.SearchResult(mockCloudFileApi, cloudFile)
+      coEvery {
+        mockRepositoryCaller.getIdsByState(listOf(SyncState.WaitingForUpload, SyncState.FailedToUpload))
+      } returns listOf(reminderId)
+
+      // Act
+      val result = downloadSingleUseCase(dataType, reminderId)
+
+      // Assert - Should skip without ever downloading or overwriting the pending local edit
+      assertTrue(result is SyncResult.Skipped)
+      coVerify(exactly = 0) { downloadCloudFileUseCase(any(), any(), any()) }
+      coVerify(exactly = 0) { mockRepositoryCaller.insertOrUpdate(any()) }
+    }
+  }
+
+  @Test
   fun `invoke should return success result with correct downloaded information`() {
     runBlocking {
       // Arrange - Verify result structure

--- a/data/sync/src/test/kotlin/com/github/naz013/sync/usecase/DownloadUseCaseTest.kt
+++ b/data/sync/src/test/kotlin/com/github/naz013/sync/usecase/DownloadUseCaseTest.kt
@@ -479,6 +479,43 @@ class DownloadUseCaseTest {
   }
 
   @Test
+  fun `invoke should skip item with pending local upload to avoid overwriting unsynced changes`() {
+    runBlocking {
+      // Arrange - Cloud has an update for r1, but r1 has local edits still waiting to be uploaded
+      val dataType = DataType.Reminders
+      val pendingReminder = Reminder(summary = "Local edit", uuId = "r1")
+      val cloudFile = CloudFile(id = "cf1", name = "r1.ta2", fileExtension = ".ta2", lastModified = 1000L, size = 100, version = 1L, rev = "r1")
+
+      val searchResult = FindAllFilesToDownloadUseCase.SearchResult(
+        sources = listOf(
+          FindAllFilesToDownloadUseCase.CloudFilesWithSource(
+            source = mockCloudFileApi,
+            cloudFiles = listOf(cloudFile)
+          )
+        )
+      )
+
+      every { dataTypeRepositoryCallerFactory.getCaller(dataType) } returns mockRepositoryCaller
+      coEvery { findAllFilesToDownloadUseCase(dataType) } returns searchResult
+      every { mockCloudFileApi.source } returns Source.GoogleDrive
+      coEvery { downloadCloudFileUseCase(mockCloudFileApi, cloudFile, dataType) } returns pendingReminder
+      every { getLocalUuIdUseCase(pendingReminder) } returns "r1"
+      coEvery {
+        mockRepositoryCaller.getIdsByState(listOf(SyncState.WaitingForUpload, SyncState.FailedToUpload))
+      } returns listOf("r1")
+
+      // Act
+      val result = downloadUseCase(dataType)
+
+      // Assert - Should skip the item entirely rather than overwrite the pending local edit
+      assertTrue(result is SyncResult.Skipped)
+      coVerify(exactly = 0) { mockRepositoryCaller.insertOrUpdate(any()) }
+      coVerify(exactly = 0) { dataPostProcessor.process(any(), any()) }
+      coVerify(exactly = 0) { mockRepositoryCaller.updateSyncState(any(), any()) }
+    }
+  }
+
+  @Test
   fun `invoke with large number of files should process all sequentially`() {
     runBlocking {
       // Arrange - 10 birthday files

--- a/data/sync/src/test/kotlin/com/github/naz013/sync/usecase/FindAllFilesToDownloadUseCaseTest.kt
+++ b/data/sync/src/test/kotlin/com/github/naz013/sync/usecase/FindAllFilesToDownloadUseCaseTest.kt
@@ -81,7 +81,7 @@ class FindAllFilesToDownloadUseCaseTest {
       every { getAllowedCloudApisUseCase.invoke() } returns listOf(mockCloudFileApi)
       every { mockCloudFileApi.source } returns Source.GoogleDrive
       coEvery { mockCloudFileApi.findFiles(".ta2") } returns listOf(cloudFile1, cloudFile2, cloudFile3)
-      coEvery { remoteFileMetadataRepository.getBySource("GoogleDrive") } returns emptyList()
+      coEvery { remoteFileMetadataRepository.getBySource("google_drive") } returns emptyList()
 
       // Act
       val result = findAllFilesToDownloadUseCase(dataType)
@@ -95,7 +95,7 @@ class FindAllFilesToDownloadUseCaseTest {
       assertTrue(result.sources[0].cloudFiles.contains(cloudFile3))
 
       coVerify(exactly = 1) { mockCloudFileApi.findFiles(".ta2") }
-      coVerify(exactly = 1) { remoteFileMetadataRepository.getBySource("GoogleDrive") }
+      coVerify(exactly = 1) { remoteFileMetadataRepository.getBySource("google_drive") }
     }
   }
 
@@ -107,7 +107,7 @@ class FindAllFilesToDownloadUseCaseTest {
 
       every { mockCloudFileApi.source } returns Source.GoogleDrive
       coEvery { mockCloudFileApi.findFiles(".bi2") } returns emptyList()
-      coEvery { remoteFileMetadataRepository.getBySource("GoogleDrive") } returns emptyList()
+      coEvery { remoteFileMetadataRepository.getBySource("google_drive") } returns emptyList()
       every { getAllowedCloudApisUseCase.invoke() } returns listOf(mockCloudFileApi)
 
       // Act
@@ -137,7 +137,7 @@ class FindAllFilesToDownloadUseCaseTest {
         name = "note-key-1.no3",
         lastModified = 1698799000000L,
         size = 512,
-        source = "GoogleDrive",
+        source = "google_drive",
         localUuId = "note-1",
         fileExtension = ".no3",
         version = 3L,  // Older version
@@ -147,7 +147,7 @@ class FindAllFilesToDownloadUseCaseTest {
       every { getAllowedCloudApisUseCase.invoke() } returns listOf(mockCloudFileApi)
       every { mockCloudFileApi.source } returns Source.GoogleDrive
       coEvery { mockCloudFileApi.findFiles(".no3") } returns listOf(cloudFile)
-      coEvery { remoteFileMetadataRepository.getBySource("GoogleDrive") } returns listOf(localMetadata)
+      coEvery { remoteFileMetadataRepository.getBySource("google_drive") } returns listOf(localMetadata)
 
       // Act
       val result = findAllFilesToDownloadUseCase(dataType)
@@ -179,7 +179,7 @@ class FindAllFilesToDownloadUseCaseTest {
         name = "reminder-uuid-1.ta2",
         lastModified = 1698800000000L,  // Older timestamp
         size = 2048,
-        source = "GoogleDrive",
+        source = "google_drive",
         localUuId = "reminder-1",
         fileExtension = ".ta2",
         version = 3L,  // Same version
@@ -189,7 +189,7 @@ class FindAllFilesToDownloadUseCaseTest {
       every { getAllowedCloudApisUseCase.invoke() } returns listOf(mockCloudFileApi)
       every { mockCloudFileApi.source } returns Source.GoogleDrive
       coEvery { mockCloudFileApi.findFiles(".ta2") } returns listOf(cloudFile)
-      coEvery { remoteFileMetadataRepository.getBySource("GoogleDrive") } returns listOf(localMetadata)
+      coEvery { remoteFileMetadataRepository.getBySource("google_drive") } returns listOf(localMetadata)
 
       // Act
       val result = findAllFilesToDownloadUseCase(dataType)
@@ -220,7 +220,7 @@ class FindAllFilesToDownloadUseCaseTest {
         name = "birthday-uuid-1.bi2",
         lastModified = 1698850000000L,
         size = 1024,
-        source = "Dropbox",
+        source = "dropbox",
         localUuId = "birthday-1",
         fileExtension = ".bi2",
         version = 1L,
@@ -230,7 +230,7 @@ class FindAllFilesToDownloadUseCaseTest {
       every { getAllowedCloudApisUseCase.invoke() } returns listOf(mockCloudFileApi)
       every { mockCloudFileApi.source } returns Source.Dropbox
       coEvery { mockCloudFileApi.findFiles(".bi2") } returns listOf(cloudFile)
-      coEvery { remoteFileMetadataRepository.getBySource("Dropbox") } returns listOf(localMetadata)
+      coEvery { remoteFileMetadataRepository.getBySource("dropbox") } returns listOf(localMetadata)
 
       // Act
       val result = findAllFilesToDownloadUseCase(dataType)
@@ -279,7 +279,7 @@ class FindAllFilesToDownloadUseCaseTest {
         name = "current-group.gr2",
         lastModified = 3000L,  // Same
         size = 300,
-        source = "GoogleDrive",
+        source = "google_drive",
         localUuId = "current",
         fileExtension = ".gr2",
         version = 3L,  // Same
@@ -290,7 +290,7 @@ class FindAllFilesToDownloadUseCaseTest {
         name = "updated-group.gr2",
         lastModified = 1500L,  // Older
         size = 200,
-        source = "GoogleDrive",
+        source = "google_drive",
         localUuId = "updated",
         fileExtension = ".gr2",
         version = 1L,
@@ -300,7 +300,7 @@ class FindAllFilesToDownloadUseCaseTest {
       every { getAllowedCloudApisUseCase.invoke() } returns listOf(mockCloudFileApi)
       every { mockCloudFileApi.source } returns Source.GoogleDrive
       coEvery { mockCloudFileApi.findFiles(".gr2") } returns listOf(newFile, updatedFile, upToDateFile)
-      coEvery { remoteFileMetadataRepository.getBySource("GoogleDrive") } returns
+      coEvery { remoteFileMetadataRepository.getBySource("google_drive") } returns
         listOf(upToDateMetadata, outdatedMetadata)
 
       // Act
@@ -338,7 +338,7 @@ class FindAllFilesToDownloadUseCaseTest {
         name = "place-1.pl2",
         lastModified = 900L,
         size = 100,
-        source = "GoogleDrive",
+        source = "google_drive",
         localUuId = "place-1",
         fileExtension = ".pl2",
         version = 1L,  // Old version
@@ -359,7 +359,7 @@ class FindAllFilesToDownloadUseCaseTest {
         name = "place-2.pl2",
         lastModified = 2000L,
         size = 200,
-        source = "Dropbox",
+        source = "dropbox",
         localUuId = "place-2",
         fileExtension = ".pl2",
         version = 1L,
@@ -371,8 +371,8 @@ class FindAllFilesToDownloadUseCaseTest {
       every { mockDropboxApi.source } returns Source.Dropbox
       coEvery { mockGDriveApi.findFiles(".pl2") } returns listOf(gdriveFile)
       coEvery { mockDropboxApi.findFiles(".pl2") } returns listOf(dropboxFile)
-      coEvery { remoteFileMetadataRepository.getBySource("GoogleDrive") } returns listOf(gdriveMetadata)
-      coEvery { remoteFileMetadataRepository.getBySource("Dropbox") } returns listOf(dropboxMetadata)
+      coEvery { remoteFileMetadataRepository.getBySource("google_drive") } returns listOf(gdriveMetadata)
+      coEvery { remoteFileMetadataRepository.getBySource("dropbox") } returns listOf(dropboxMetadata)
 
       // Act
       val result = findAllFilesToDownloadUseCase(dataType)
@@ -425,7 +425,7 @@ class FindAllFilesToDownloadUseCaseTest {
         name = "note-2.no3",
         lastModified = 2000L,
         size = 200,
-        source = "Dropbox",
+        source = "dropbox",
         localUuId = "note-2",
         fileExtension = ".no3",
         version = 1L,
@@ -437,8 +437,8 @@ class FindAllFilesToDownloadUseCaseTest {
       every { mockDropboxApi.source } returns Source.Dropbox
       coEvery { mockGDriveApi.findFiles(".no3") } returns listOf(gdriveFile)
       coEvery { mockDropboxApi.findFiles(".no3") } returns listOf(dropboxFile)
-      coEvery { remoteFileMetadataRepository.getBySource("GoogleDrive") } returns emptyList()
-      coEvery { remoteFileMetadataRepository.getBySource("Dropbox") } returns listOf(dropboxMetadata)
+      coEvery { remoteFileMetadataRepository.getBySource("google_drive") } returns emptyList()
+      coEvery { remoteFileMetadataRepository.getBySource("dropbox") } returns listOf(dropboxMetadata)
 
       // Act
       val result = findAllFilesToDownloadUseCase(dataType)
@@ -469,7 +469,7 @@ class FindAllFilesToDownloadUseCaseTest {
         name = "reminder-1.ta2",
         lastModified = 1000L,  // Same
         size = 100,
-        source = "GoogleDrive",
+        source = "google_drive",
         localUuId = "r1",
         fileExtension = ".ta2",
         version = 5L,  // Same
@@ -479,7 +479,7 @@ class FindAllFilesToDownloadUseCaseTest {
       every { getAllowedCloudApisUseCase.invoke() } returns listOf(mockCloudFileApi)
       every { mockCloudFileApi.source } returns Source.GoogleDrive
       coEvery { mockCloudFileApi.findFiles(".ta2") } returns listOf(cloudFile)
-      coEvery { remoteFileMetadataRepository.getBySource("GoogleDrive") } returns listOf(localMetadata)
+      coEvery { remoteFileMetadataRepository.getBySource("google_drive") } returns listOf(localMetadata)
 
       // Act
       val result = findAllFilesToDownloadUseCase(dataType)
@@ -520,12 +520,12 @@ class FindAllFilesToDownloadUseCaseTest {
 
       val metadata1 = RemoteFileMetadata(
         id = "f1", name = "b1.bi2", lastModified = 1000L, size = 100,
-        source = "GoogleDrive", localUuId = "b1", fileExtension = ".bi2",
+        source = "google_drive", localUuId = "b1", fileExtension = ".bi2",
         version = 2L, rev = "r2"  // Same version - up-to-date
       )
       val metadata2 = RemoteFileMetadata(
         id = "f2", name = "b2.bi2", lastModified = 1500L, size = 200,
-        source = "GoogleDrive", localUuId = "b2", fileExtension = ".bi2",
+        source = "google_drive", localUuId = "b2", fileExtension = ".bi2",
         version = 1L, rev = "r0"  // Different version - needs download
       )
       // No metadata for file3 - it's new
@@ -533,7 +533,7 @@ class FindAllFilesToDownloadUseCaseTest {
       every { getAllowedCloudApisUseCase.invoke() } returns listOf(mockCloudFileApi)
       every { mockCloudFileApi.source } returns Source.GoogleDrive
       coEvery { mockCloudFileApi.findFiles(".bi2") } returns listOf(file1, file2, file3)
-      coEvery { remoteFileMetadataRepository.getBySource("GoogleDrive") } returns
+      coEvery { remoteFileMetadataRepository.getBySource("google_drive") } returns
         listOf(metadata1, metadata2)
 
       // Act

--- a/data/sync/src/test/kotlin/com/github/naz013/sync/usecase/FindNewestCloudApiSourceUseCaseTest.kt
+++ b/data/sync/src/test/kotlin/com/github/naz013/sync/usecase/FindNewestCloudApiSourceUseCaseTest.kt
@@ -70,7 +70,7 @@ class FindNewestCloudApiSourceUseCaseTest {
       every {getAllowedCloudApisUseCase.invoke() } returns listOf(mockGDriveApi)
       every { mockGDriveApi.source } returns Source.GoogleDrive
       coEvery { mockGDriveApi.findFile(searchParams) } returns cloudFile
-      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(reminderId, "GoogleDrive") } returns null
+      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(reminderId, "google_drive") } returns null
 
       // Act
       val result = findNewestCloudApiSourceUseCase(dataType, reminderId)
@@ -81,7 +81,7 @@ class FindNewestCloudApiSourceUseCaseTest {
       assertEquals(cloudFile, result.cloudFile)
 
       coVerify(exactly = 1) { mockGDriveApi.findFile(searchParams) }
-      coVerify(exactly = 1) { remoteFileMetadataRepository.getByLocalUuIdAndSource(reminderId, "GoogleDrive") }
+      coVerify(exactly = 1) { remoteFileMetadataRepository.getByLocalUuIdAndSource(reminderId, "google_drive") }
     }
   }
 
@@ -143,8 +143,8 @@ class FindNewestCloudApiSourceUseCaseTest {
       every { mockDropboxApi.source } returns Source.Dropbox
       coEvery { mockGDriveApi.findFile(searchParams) } returns gdriveFile
       coEvery { mockDropboxApi.findFile(searchParams) } returns dropboxFile
-      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(noteId, "GoogleDrive") } returns null
-      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(noteId, "Dropbox") } returns null
+      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(noteId, "google_drive") } returns null
+      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(noteId, "dropbox") } returns null
 
       // Act
       val result = findNewestCloudApiSourceUseCase(dataType, noteId)
@@ -177,7 +177,7 @@ class FindNewestCloudApiSourceUseCaseTest {
         name = "$reminderId.ta2",
         lastModified = 1698850000000L,  // Same timestamp
         size = 1024,
-        source = "GoogleDrive",
+        source = "google_drive",
         localUuId = reminderId,
         fileExtension = ".ta2",
         version = 5L,  // Same version
@@ -191,7 +191,7 @@ class FindNewestCloudApiSourceUseCaseTest {
       every {getAllowedCloudApisUseCase.invoke() } returns listOf(mockGDriveApi)
       every { mockGDriveApi.source } returns Source.GoogleDrive
       coEvery { mockGDriveApi.findFile(searchParams) } returns cloudFile
-      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(reminderId, "GoogleDrive") } returns localMetadata
+      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(reminderId, "google_drive") } returns localMetadata
 
       // Act
       val result = findNewestCloudApiSourceUseCase(dataType, reminderId)
@@ -221,7 +221,7 @@ class FindNewestCloudApiSourceUseCaseTest {
         name = "$groupId.gr2",
         lastModified = 1698900000000L,  // Same timestamp
         size = 256,
-        source = "GoogleDrive",
+        source = "google_drive",
         localUuId = groupId,
         fileExtension = ".gr2",
         version = 5L,  // Older version
@@ -235,7 +235,7 @@ class FindNewestCloudApiSourceUseCaseTest {
       every {getAllowedCloudApisUseCase.invoke() } returns listOf(mockGDriveApi)
       every { mockGDriveApi.source } returns Source.GoogleDrive
       coEvery { mockGDriveApi.findFile(searchParams) } returns cloudFile
-      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(groupId, "GoogleDrive") } returns localMetadata
+      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(groupId, "google_drive") } returns localMetadata
 
       // Act
       val result = findNewestCloudApiSourceUseCase(dataType, groupId)
@@ -266,7 +266,7 @@ class FindNewestCloudApiSourceUseCaseTest {
         name = "$placeId.pl2",
         lastModified = 1698900000000L,  // Older timestamp
         size = 512,
-        source = "GoogleDrive",
+        source = "google_drive",
         localUuId = placeId,
         fileExtension = ".pl2",
         version = 3L,  // Same version
@@ -280,7 +280,7 @@ class FindNewestCloudApiSourceUseCaseTest {
       every {getAllowedCloudApisUseCase.invoke() } returns listOf(mockGDriveApi)
       every { mockGDriveApi.source } returns Source.GoogleDrive
       coEvery { mockGDriveApi.findFile(searchParams) } returns cloudFile
-      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(placeId, "GoogleDrive") } returns localMetadata
+      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(placeId, "google_drive") } returns localMetadata
 
       // Act
       val result = findNewestCloudApiSourceUseCase(dataType, placeId)
@@ -311,7 +311,7 @@ class FindNewestCloudApiSourceUseCaseTest {
         name = "$birthdayId.bi2",
         lastModified = 1698950000000L,
         size = 1024,
-        source = "Dropbox",
+        source = "dropbox",
         localUuId = birthdayId,
         fileExtension = ".bi2",
         version = 2L,
@@ -325,7 +325,7 @@ class FindNewestCloudApiSourceUseCaseTest {
       every {getAllowedCloudApisUseCase.invoke() } returns listOf(mockDropboxApi)
       every { mockDropboxApi.source } returns Source.Dropbox
       coEvery { mockDropboxApi.findFile(searchParams) } returns cloudFile
-      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(birthdayId, "Dropbox") } returns localMetadata
+      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(birthdayId, "dropbox") } returns localMetadata
 
       // Act
       val result = findNewestCloudApiSourceUseCase(dataType, birthdayId)
@@ -355,7 +355,7 @@ class FindNewestCloudApiSourceUseCaseTest {
         name = "$noteId.no3",
         lastModified = 1699000000000L,  // Same timestamp doesn't matter for Dropbox
         size = 768,
-        source = "Dropbox",
+        source = "dropbox",
         localUuId = noteId,
         fileExtension = ".no3",
         version = 1L,
@@ -369,7 +369,7 @@ class FindNewestCloudApiSourceUseCaseTest {
       every {getAllowedCloudApisUseCase.invoke() } returns listOf(mockDropboxApi)
       every { mockDropboxApi.source } returns Source.Dropbox
       coEvery { mockDropboxApi.findFile(searchParams) } returns cloudFile
-      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(noteId, "Dropbox") } returns localMetadata
+      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(noteId, "dropbox") } returns localMetadata
 
       // Act
       val result = findNewestCloudApiSourceUseCase(dataType, noteId)
@@ -422,7 +422,7 @@ class FindNewestCloudApiSourceUseCaseTest {
       every {getAllowedCloudApisUseCase.invoke() } returns listOf(mockGDriveApi)
       every { mockGDriveApi.source } returns Source.GoogleDrive
       coEvery { mockGDriveApi.findFile(searchParams) } returns cloudFile
-      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(reminderId, "GoogleDrive") } returns null
+      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(reminderId, "google_drive") } returns null
 
       // Act
       val result = findNewestCloudApiSourceUseCase(dataType, reminderId)
@@ -462,7 +462,7 @@ class FindNewestCloudApiSourceUseCaseTest {
         name = "$groupId.gr2",
         lastModified = 1699090000000L,  // Older than cloud
         size = 256,
-        source = "GoogleDrive",
+        source = "google_drive",
         localUuId = groupId,
         fileExtension = ".gr2",
         version = 4L,  // Older version
@@ -473,7 +473,7 @@ class FindNewestCloudApiSourceUseCaseTest {
         name = "$groupId.gr2",
         lastModified = 1699000000000L,
         size = 256,
-        source = "Dropbox",
+        source = "dropbox",
         localUuId = groupId,
         fileExtension = ".gr2",
         version = 3L,
@@ -489,8 +489,8 @@ class FindNewestCloudApiSourceUseCaseTest {
       every { mockDropboxApi.source } returns Source.Dropbox
       coEvery { mockGDriveApi.findFile(searchParams) } returns gdriveFile
       coEvery { mockDropboxApi.findFile(searchParams) } returns dropboxFile
-      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(groupId, "GoogleDrive") } returns gdriveMetadata
-      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(groupId, "Dropbox") } returns dropboxMetadata
+      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(groupId, "google_drive") } returns gdriveMetadata
+      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(groupId, "dropbox") } returns dropboxMetadata
 
       // Act
       val result = findNewestCloudApiSourceUseCase(dataType, groupId)
@@ -536,8 +536,8 @@ class FindNewestCloudApiSourceUseCaseTest {
       every { mockDropboxApi.source } returns Source.Dropbox
       coEvery { mockGDriveApi.findFile(searchParams) } returns gdriveFile
       coEvery { mockDropboxApi.findFile(searchParams) } returns dropboxFile
-      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(placeId, "GoogleDrive") } returns null
-      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(placeId, "Dropbox") } returns null
+      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(placeId, "google_drive") } returns null
+      coEvery { remoteFileMetadataRepository.getByLocalUuIdAndSource(placeId, "dropbox") } returns null
 
       // Act
       val result = findNewestCloudApiSourceUseCase(dataType, placeId)

--- a/data/sync/src/test/kotlin/com/github/naz013/sync/usecase/download/DownloadLegacyFilesUseCaseTest.kt
+++ b/data/sync/src/test/kotlin/com/github/naz013/sync/usecase/download/DownloadLegacyFilesUseCaseTest.kt
@@ -1,0 +1,140 @@
+package com.github.naz013.sync.usecase.download
+
+import com.github.naz013.cloudapi.CloudFile
+import com.github.naz013.cloudapi.CloudFileApi
+import com.github.naz013.cloudapi.Source
+import com.github.naz013.domain.reminder.v2.GroupV2
+import com.github.naz013.domain.sync.SyncState
+import com.github.naz013.files.DataType
+import com.github.naz013.sync.DataPostProcessor
+import com.github.naz013.sync.local.DataTypeRepositoryCaller
+import com.github.naz013.sync.local.DataTypeRepositoryCallerFactory
+import com.github.naz013.sync.usecase.FindAllFilesToDeleteUseCase
+import com.github.naz013.sync.usecase.GetLocalUuIdUseCase
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for [DownloadLegacyFilesUseCase].
+ *
+ * Legacy migration is one-shot: whether or not an item already exists locally, the legacy
+ * cloud file must always be deleted afterwards, otherwise it gets redownloaded and
+ * reprocessed on every subsequent sync forever.
+ */
+class DownloadLegacyFilesUseCaseTest {
+
+  private lateinit var getAllFilesToDeleteUseCase: FindAllFilesToDeleteUseCase
+  private lateinit var downloadCloudFileUseCase: DownloadCloudFileUseCase
+  private lateinit var dataTypeRepositoryCallerFactory: DataTypeRepositoryCallerFactory
+  private lateinit var getLocalUuIdUseCase: GetLocalUuIdUseCase
+  private lateinit var dataPostProcessor: DataPostProcessor
+  private lateinit var downloadLegacyFilesUseCase: DownloadLegacyFilesUseCase
+
+  private lateinit var mockRepositoryCaller: DataTypeRepositoryCaller<Any>
+  private lateinit var mockCloudFileApi: CloudFileApi
+
+  @Before
+  fun setUp() {
+    getAllFilesToDeleteUseCase = mockk()
+    downloadCloudFileUseCase = mockk()
+    dataTypeRepositoryCallerFactory = mockk()
+    getLocalUuIdUseCase = mockk()
+    dataPostProcessor = mockk(relaxed = true)
+    mockRepositoryCaller = mockk(relaxed = true)
+    mockCloudFileApi = mockk(relaxUnitFun = true)
+
+    downloadLegacyFilesUseCase = DownloadLegacyFilesUseCase(
+      getAllFilesToDeleteUseCase = getAllFilesToDeleteUseCase,
+      downloadCloudFileUseCase = downloadCloudFileUseCase,
+      dataTypeRepositoryCallerFactory = dataTypeRepositoryCallerFactory,
+      getLocalUuIdUseCase = getLocalUuIdUseCase,
+      dataPostProcessor = dataPostProcessor
+    )
+
+    // Only DataType.Groups is legacy-and-relevant for these tests; stub the rest of the
+    // legacy set to "nothing found" so they don't interfere with verification.
+    DataType.entries.filter { it.isLegacy }.forEach { dataType ->
+      every { dataTypeRepositoryCallerFactory.getCaller(dataType) } returns mockRepositoryCaller
+      coEvery { getAllFilesToDeleteUseCase(dataType) } returns null
+    }
+  }
+
+  @Test
+  fun `invoke deletes the cloud file even when the item already exists locally`() {
+    runBlocking {
+      val group = GroupV2(uuId = "group-1", title = "Existing group")
+      val cloudFile = CloudFile(
+        id = "gdrive-group-1",
+        name = "group-1.gr2",
+        fileExtension = ".gr2",
+        lastModified = 1000L,
+        size = 100,
+        version = 1L,
+        rev = "r1"
+      )
+      val searchResult = FindAllFilesToDeleteUseCase.SearchResult(
+        sources = listOf(
+          FindAllFilesToDeleteUseCase.CloudFilesWithSource(
+            source = mockCloudFileApi,
+            cloudFiles = listOf(cloudFile)
+          )
+        )
+      )
+
+      every { mockCloudFileApi.source } returns Source.GoogleDrive
+      coEvery { getAllFilesToDeleteUseCase(DataType.Groups) } returns searchResult
+      coEvery { downloadCloudFileUseCase(mockCloudFileApi, cloudFile, DataType.Groups) } returns group
+      every { getLocalUuIdUseCase(group) } returns "group-1"
+      coEvery { mockRepositoryCaller.getById("group-1") } returns group
+
+      downloadLegacyFilesUseCase()
+
+      // Already exists locally, so it must not be overwritten again...
+      coVerify(exactly = 0) { mockRepositoryCaller.insertOrUpdate(any()) }
+      // ...but the stale legacy cloud copy must still be cleaned up so it isn't redownloaded forever.
+      coVerify(exactly = 1) { mockCloudFileApi.deleteFile("group-1.gr2") }
+    }
+  }
+
+  @Test
+  fun `invoke persists and deletes the cloud file for a new legacy item`() {
+    runBlocking {
+      val group = GroupV2(uuId = "group-2", title = "New group")
+      val cloudFile = CloudFile(
+        id = "gdrive-group-2",
+        name = "group-2.gr2",
+        fileExtension = ".gr2",
+        lastModified = 1000L,
+        size = 100,
+        version = 1L,
+        rev = "r1"
+      )
+      val searchResult = FindAllFilesToDeleteUseCase.SearchResult(
+        sources = listOf(
+          FindAllFilesToDeleteUseCase.CloudFilesWithSource(
+            source = mockCloudFileApi,
+            cloudFiles = listOf(cloudFile)
+          )
+        )
+      )
+
+      every { mockCloudFileApi.source } returns Source.GoogleDrive
+      coEvery { getAllFilesToDeleteUseCase(DataType.Groups) } returns searchResult
+      coEvery { downloadCloudFileUseCase(mockCloudFileApi, cloudFile, DataType.Groups) } returns group
+      every { getLocalUuIdUseCase(group) } returns "group-2"
+      coEvery { mockRepositoryCaller.getById("group-2") } returns null
+
+      downloadLegacyFilesUseCase()
+
+      coVerify(exactly = 1) { mockRepositoryCaller.insertOrUpdate(group) }
+      coVerify(exactly = 1) { dataPostProcessor.process(DataType.Groups, group) }
+      coVerify(exactly = 1) { mockRepositoryCaller.updateSyncState("group-2", SyncState.Synced) }
+      coVerify(exactly = 1) { mockCloudFileApi.deleteFile("group-2.gr2") }
+    }
+  }
+}

--- a/data/sync/src/test/kotlin/com/github/naz013/sync/usecase/download/DownloadLegacyFilesUseCaseTest.kt
+++ b/data/sync/src/test/kotlin/com/github/naz013/sync/usecase/download/DownloadLegacyFilesUseCaseTest.kt
@@ -46,7 +46,7 @@ class DownloadLegacyFilesUseCaseTest {
     getLocalUuIdUseCase = mockk()
     dataPostProcessor = mockk(relaxed = true)
     mockRepositoryCaller = mockk(relaxed = true)
-    mockCloudFileApi = mockk(relaxUnitFun = true)
+    mockCloudFileApi = mockk(relaxed = true)
 
     downloadLegacyFilesUseCase = DownloadLegacyFilesUseCase(
       getAllFilesToDeleteUseCase = getAllFilesToDeleteUseCase,


### PR DESCRIPTION
## Summary

Follow-up to a review of `data:sync`'s cloud sync implementation (Trello card #1206). Two related changes, both in `data:sync`:

### 1. Bug fixes

- **Source identifier mismatch breaks the "already synced" check.** `FindAllFilesToDownloadUseCase` and `FindNewestCloudApiSourceUseCase` looked up cached `RemoteFileMetadata` by `Source.name` (`"GoogleDrive"`/`"Dropbox"`), while every writer (`UploadSingleUseCase`, `DownloadUseCase`, `DownloadSingleUseCase`) saves it under `Source.value` (`"google_drive"`/`"dropbox"`). The lookup never matched, so every sync re-evaluated every cloud file as if nothing had metadata yet, and the Google Drive version-mismatch trigger was silently dead. The existing unit tests encoded the same bug (stubbed `getBySource("GoogleDrive")`), which is why it went unnoticed.
- **Legacy Group backups (`.gr2`) were silently destroyed on migration.** `DataTypeRepositoryCallerFactory` mapped legacy `DataType.Groups` to `NoopRepositoryCaller`, and the app's `DataPostProcessorImpl` has no case for `GroupV2`. `DownloadLegacyFilesUseCase` parses a legacy file into a real `GroupV2` correctly, but nothing ever persisted it — and the cloud file was deleted anyway. Now routes through the same `GroupV2RepositoryCaller` already used for `GroupsV2`.
- **Legacy files that collide with an existing local item were never cleaned up**, so they got redownloaded and reprocessed on every sync forever. The cloud file is now always deleted once handled, whether or not the item already existed locally.
- **`forceUpload()`/`forceUpload(dataType)` silently did nothing for `Settings`/`TagAssignments`**, contradicting the `SyncApi` interface's own doc comment ("Force upload of all data types"). Their caller's `getAllIds()` is a no-op (`NoopRepositoryCaller`), unlike normal `upload()` which special-cases these two snapshot types. Force upload now delegates to the same always-upload path.
- **No protection against overwriting unsynced local edits.** `DownloadUseCase`/`DownloadSingleUseCase` unconditionally overwrote local data with the cloud copy (flagged in the code itself: `// Cloud version takes precedence for now`). They now skip an item that still has local changes pending upload (`WaitingForUpload`/`FailedToUpload`) instead of clobbering it, and the loop's leftover `lastModified`-only recheck — which had become inconsistent with the version-comparison logic once the source-string bug above is fixed — is removed as redundant.

### 2. Gate workflow rule/template cloud sync to Pro users

`DataType.WorkflowRules`/`WorkflowTemplates` are now marked `isProOnly = true`. Every dataType-specific and per-id `SyncApi` entry point (`sync`/`upload`/`forceUpload`, bulk and single-item) checks this against a new `IsProUserUseCase` seam — `data:sync` stays platform-agnostic; it's implemented in `app` against `BuildInfo.isPro`, mirroring the existing `SyncSettings` seam. This is a single choke point: every write path for workflow data (`SaveWorkflowRuleUseCase`, `DeleteWorkflowRuleUseCase`, `SaveWorkflowTemplateUseCase`, and the background `UploadTask`/`SyncTask`/`ForceUploadTask` jobs they schedule) already funnels through `SyncApi` with an explicit `DataType`, so nothing in `feature-workflow` itself needed to change.

Deletion is deliberately **not** gated: a user whose Pro subscription lapses must still be able to remove their own already-synced workflow data from the cloud, otherwise it's stranded there forever — the same class of bug just fixed for legacy files above.

Note: this only gates *cloud sync* of workflow data. The Workflow automation feature itself (creating/running rules locally) remains available to free users, unchanged — gating that would be a separate, larger product decision.

## Test plan

- [x] Updated `FindAllFilesToDownloadUseCaseTest`/`FindNewestCloudApiSourceUseCaseTest` to stub the real `Source.value` strings instead of the enum name.
- [x] Added `DownloadUseCaseTest`/`DownloadSingleUseCaseTest` cases asserting a pending-upload item is skipped rather than overwritten.
- [x] Added `DataTypeRepositoryCallerFactoryTest` asserting legacy `Groups` (and `NotesV2`) resolve to a real, persisting caller.
- [x] Added `DownloadLegacyFilesUseCaseTest` asserting the cloud file is deleted whether or not the item already exists locally.
- [x] Added `SyncApiImplTest` cases asserting `forceUpload()`/`forceUpload(dataType)` upload `Settings`/`TagAssignments` via the always-upload path.
- [x] Added `SyncApiImplTest` cases asserting `WorkflowRules`/`WorkflowTemplates` sync/upload/forceUpload (bulk and single-item) are skipped for a free user, proceed for a Pro user, and that bulk sync still processes non-Pro-only types; and that `delete(...)` is never gated.
- [ ] `./gradlew :data:sync:test` — **could not be run in this sandbox**: both `api.foojay.io` (Gradle daemon JDK provisioning) and `dl.google.com` (Android Gradle Plugin, required even to configure this pure-Kotlin module because it's resolved at the root project) are blocked by this environment's egress policy. Please let CI validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xtMqYMiFw7cabeHBEHYge