### PR TITLE
Add undo-delete snackbar for reminders, notes, and birthdays

### DIFF
--- a/core/feature-common/src/main/kotlin/com/github/naz013/feature/common/viewmodel/PendingDeleteTracker.kt
+++ b/core/feature-common/src/main/kotlin/com/github/naz013/feature/common/viewmodel/PendingDeleteTracker.kt
@@ -1,0 +1,48 @@
+package com.github.naz013.feature.common.viewmodel
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * Backs an "undo delete" Snackbar for a list screen. [markPending] hides [ids] from the UI
+ * immediately via [pendingIds] - combine it into the screen's reactively-observed list so deleted
+ * items disappear right away without actually touching the repository. The caller must follow up
+ * with exactly one of [undo] (the item reappears, [onCommit] never runs) or [commit] (runs
+ * [onCommit], e.g. the real repository delete) once the Snackbar's undo window closes - typically
+ * driven by the result of Compose's `SnackbarHostState.showSnackbar`, not a timer owned here.
+ *
+ * Batches are keyed by [markPending]'s `batchKey` so a single-item delete and a bulk delete can be
+ * pending at the same time without clobbering each other.
+ */
+class PendingDeleteTracker {
+  private val _pendingIds = MutableStateFlow<Set<String>>(emptySet())
+  val pendingIds: StateFlow<Set<String>> = _pendingIds
+
+  private val pendingBatches = mutableMapOf<String, PendingBatch>()
+
+  fun markPending(
+    batchKey: String,
+    ids: Set<String>,
+    onCommit: suspend () -> Unit,
+  ) {
+    val previous = pendingBatches.put(batchKey, PendingBatch(ids, onCommit))
+    _pendingIds.update { (it - (previous?.ids ?: emptySet())) + ids }
+  }
+
+  fun undo(batchKey: String) {
+    val batch = pendingBatches.remove(batchKey) ?: return
+    _pendingIds.update { it - batch.ids }
+  }
+
+  suspend fun commit(batchKey: String) {
+    val batch = pendingBatches.remove(batchKey) ?: return
+    _pendingIds.update { it - batch.ids }
+    batch.onCommit()
+  }
+
+  private class PendingBatch(
+    val ids: Set<String>,
+    val onCommit: suspend () -> Unit,
+  )
+}

--- a/core/feature-common/src/test/kotlin/com/github/naz013/feature/common/viewmodel/PendingDeleteTrackerTest.kt
+++ b/core/feature-common/src/test/kotlin/com/github/naz013/feature/common/viewmodel/PendingDeleteTrackerTest.kt
@@ -1,0 +1,112 @@
+package com.github.naz013.feature.common.viewmodel
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PendingDeleteTrackerTest {
+
+  @Test
+  fun `markPending hides the given ids immediately`() {
+    val tracker = PendingDeleteTracker()
+
+    tracker.markPending(batchKey = "1", ids = setOf("1")) { }
+
+    assertEquals(setOf("1"), tracker.pendingIds.value)
+  }
+
+  @Test
+  fun `markPending keeps ids from different batches independent`() {
+    val tracker = PendingDeleteTracker()
+
+    tracker.markPending(batchKey = "a", ids = setOf("1")) { }
+    tracker.markPending(batchKey = "b", ids = setOf("2", "3")) { }
+
+    assertEquals(setOf("1", "2", "3"), tracker.pendingIds.value)
+  }
+
+  @Test
+  fun `undo un-hides the ids and never runs the commit action`() =
+    runBlocking {
+      val tracker = PendingDeleteTracker()
+      var committed = false
+      tracker.markPending(batchKey = "1", ids = setOf("1")) { committed = true }
+
+      tracker.undo("1")
+
+      assertEquals(emptySet<String>(), tracker.pendingIds.value)
+      assertTrue(!committed)
+    }
+
+  @Test
+  fun `undo only affects its own batch`() {
+    val tracker = PendingDeleteTracker()
+    tracker.markPending(batchKey = "a", ids = setOf("1")) { }
+    tracker.markPending(batchKey = "b", ids = setOf("2")) { }
+
+    tracker.undo("a")
+
+    assertEquals(setOf("2"), tracker.pendingIds.value)
+  }
+
+  @Test
+  fun `undo on an unknown batch key does nothing`() {
+    val tracker = PendingDeleteTracker()
+    tracker.markPending(batchKey = "1", ids = setOf("1")) { }
+
+    tracker.undo("unknown")
+
+    assertEquals(setOf("1"), tracker.pendingIds.value)
+  }
+
+  @Test
+  fun `commit runs the commit action and un-hides the ids`() =
+    runBlocking {
+      val tracker = PendingDeleteTracker()
+      var committed = false
+      tracker.markPending(batchKey = "1", ids = setOf("1")) { committed = true }
+
+      tracker.commit("1")
+
+      assertTrue(committed)
+      assertEquals(emptySet<String>(), tracker.pendingIds.value)
+    }
+
+  @Test
+  fun `commit on an unknown batch key does nothing`() =
+    runBlocking {
+      val tracker = PendingDeleteTracker()
+
+      tracker.commit("unknown")
+    }
+
+  @Test
+  fun `commit after undo does not run the commit action again`() =
+    runBlocking {
+      val tracker = PendingDeleteTracker()
+      var committed = false
+      tracker.markPending(batchKey = "1", ids = setOf("1")) { committed = true }
+      tracker.undo("1")
+
+      tracker.commit("1")
+
+      assertTrue(!committed)
+    }
+
+  @Test
+  fun `re-marking the same batch key replaces its ids and commit action`() =
+    runBlocking {
+      val tracker = PendingDeleteTracker()
+      var firstCommitted = false
+      var secondCommitted = false
+      tracker.markPending(batchKey = "1", ids = setOf("1")) { firstCommitted = true }
+
+      tracker.markPending(batchKey = "1", ids = setOf("2")) { secondCommitted = true }
+      tracker.commit("1")
+
+      assertTrue(!firstCommitted)
+      assertTrue(secondCommitted)
+      assertEquals(emptySet<String>(), tracker.pendingIds.value)
+    }
+}

--- a/feature/feature-birthday/src/main/kotlin/com/github/naz013/feature/birthday/BirthdaysNavGraph.kt
+++ b/feature/feature-birthday/src/main/kotlin/com/github/naz013/feature/birthday/BirthdaysNavGraph.kt
@@ -1,5 +1,6 @@
 package com.github.naz013.feature.birthday
 
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.compose.material3.adaptive.navigation3.ListDetailSceneStrategy
 import androidx.compose.runtime.Composable
@@ -27,6 +28,7 @@ import com.github.naz013.ui.common.compose.AppIcons
 import com.github.naz013.ui.common.compose.foundation.dialog.rememberDialogDispatcher
 import com.github.naz013.ui.common.compose.foundation.navigation.DetailPanePlaceholder
 import com.github.naz013.ui.common.compose.foundation.navigation.sidePanelSupporting
+import com.github.naz013.ui.common.compose.foundation.snackbar.rememberUndoSnackbarDispatcher
 import com.github.naz013.ui.common.livedata.ObserveEvent
 import com.github.naz013.ui.common.permission.rememberPermissionRequesterRationale
 import com.github.naz013.common.Permissions
@@ -77,6 +79,9 @@ private fun ListEntry(
 ) {
   val viewModel = koinViewModel<BirthdaysViewModel>()
   val dialogDispatcher = rememberDialogDispatcher()
+  val snackbarHostState = remember { SnackbarHostState() }
+  val undoSnackbarDispatcher = rememberUndoSnackbarDispatcher(snackbarHostState)
+  val undoActionLabel = stringResource(R.string.undo)
 
   val selectedItemId =
     backStack.lastOrNull()?.let { key ->
@@ -112,12 +117,22 @@ private fun ListEntry(
           onPositive = { viewModel.deleteSelectedBirthdays(event.ids) },
         )
       }
+
+      is BirthdaysViewModel.NavigationEvent.ShowUndoDelete -> {
+        undoSnackbarDispatcher.showUndoSnackbar(
+          message = event.message,
+          actionLabel = undoActionLabel,
+          onUndo = { viewModel.undoDelete(event.batchKey) },
+          onTimeout = { viewModel.commitDelete(event.batchKey) },
+        )
+      }
     }
   }
 
   val state by viewModel.state.collectAsState(BirthdaysScreenState())
   BirthdaysScreen(
     state = state,
+    snackbarHostState = snackbarHostState,
     onBackClick = { if (backStack.size > 1) backStack.removeLastOrNull() },
     onSearchQueryChange = viewModel::onSearchQueryChange,
     onSmartListSelected = viewModel::onSmartListSelected,

--- a/feature/feature-birthday/src/main/kotlin/com/github/naz013/feature/birthday/BirthdaysNavGraph.kt
+++ b/feature/feature-birthday/src/main/kotlin/com/github/naz013/feature/birthday/BirthdaysNavGraph.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
+import com.github.naz013.common.Permissions
 import com.github.naz013.feature.birthday.create.EditBirthdayScreen
 import com.github.naz013.feature.birthday.create.EditBirthdayState
 import com.github.naz013.feature.birthday.create.EditBirthdayViewModel
@@ -29,10 +30,9 @@ import com.github.naz013.ui.common.compose.foundation.dialog.rememberDialogDispa
 import com.github.naz013.ui.common.compose.foundation.navigation.DetailPanePlaceholder
 import com.github.naz013.ui.common.compose.foundation.navigation.sidePanelSupporting
 import com.github.naz013.ui.common.compose.foundation.snackbar.rememberUndoSnackbarDispatcher
+import com.github.naz013.ui.common.datetime.rememberDateTimePicker
 import com.github.naz013.ui.common.livedata.ObserveEvent
 import com.github.naz013.ui.common.permission.rememberPermissionRequesterRationale
-import com.github.naz013.common.Permissions
-import com.github.naz013.ui.common.datetime.rememberDateTimePicker
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 

--- a/feature/feature-birthday/src/main/kotlin/com/github/naz013/feature/birthday/list/BirthdaysScreen.kt
+++ b/feature/feature-birthday/src/main/kotlin/com/github/naz013/feature/birthday/list/BirthdaysScreen.kt
@@ -29,6 +29,8 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -70,6 +72,7 @@ private val BIRTHDAY_SMART_LIST_FILTERS = listOf(SmartListFilter.TODAY, SmartLis
 @Composable
 internal fun BirthdaysScreen(
   state: BirthdaysScreenState,
+  snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
   onBackClick: () -> Unit,
   onSearchQueryChange: (String) -> Unit,
   onSmartListSelected: (SmartListFilter?) -> Unit,
@@ -98,6 +101,7 @@ internal fun BirthdaysScreen(
 
   Scaffold(
     modifier = modifier,
+    snackbarHost = { SnackbarHost(snackbarHostState) },
     topBar = {
       if (isSelectionMode) {
         BirthdaysSelectionTopBar(

--- a/feature/feature-birthday/src/main/kotlin/com/github/naz013/feature/birthday/list/BirthdaysViewModel.kt
+++ b/feature/feature-birthday/src/main/kotlin/com/github/naz013/feature/birthday/list/BirthdaysViewModel.kt
@@ -9,6 +9,7 @@ import com.github.naz013.domain.TaggedItemType
 import com.github.naz013.feature.common.coroutine.DispatcherProvider
 import com.github.naz013.feature.common.livedata.Event
 import com.github.naz013.feature.common.livedata.emit
+import com.github.naz013.feature.common.viewmodel.PendingDeleteTracker
 import com.github.naz013.feature.common.viewmodel.mutableLiveEventOf
 import com.github.naz013.feature.common.viewmodel.stateInWhileSubscribed
 import com.github.naz013.logic.birthday.BirthdayQueryFilter
@@ -39,6 +40,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.threeten.bp.LocalDate
+import java.util.UUID
 
 @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
 internal class BirthdaysViewModel(
@@ -63,6 +65,7 @@ internal class BirthdaysViewModel(
   private val searchQuery = MutableStateFlow("")
   private val selectedSmartList = MutableStateFlow<SmartListFilter?>(null)
   private val selectedTagId = MutableStateFlow<String?>(null)
+  private val pendingDeleteTracker = PendingDeleteTracker()
 
   init {
     viewModelScope.launch(dispatcherProvider.default()) {
@@ -86,6 +89,9 @@ internal class BirthdaysViewModel(
             val ids = tagAssignmentRepository.getItemIdsForTag(tagId, TaggedItemType.BIRTHDAY).toSet()
             birthdays.filter { it.uuId in ids }
           }
+        }
+        .combine(pendingDeleteTracker.pendingIds) { birthdays, pendingIds ->
+          birthdays.filterNot { it.uuId in pendingIds }
         }
         .collect { applyList(it) }
     }
@@ -176,13 +182,18 @@ internal class BirthdaysViewModel(
   }
 
   fun deleteSelectedBirthdays(ids: Set<String>) {
-    viewModelScope.launch(dispatcherProvider.default()) {
+    if (ids.isEmpty()) return
+    val batchKey = UUID.randomUUID().toString()
+    pendingDeleteTracker.markPending(batchKey = batchKey, ids = ids) {
       ids.forEach { deleteBirthdayUseCase(it) }
-
-      withContext(dispatcherProvider.main()) {
-        onSelectionCancel()
-      }
     }
+    onSelectionCancel()
+    navigationEvent.emit(
+      NavigationEvent.ShowUndoDelete(
+        batchKey = batchKey,
+        message = textProvider.getText(R.string.birthdays_deleted_count, ids.size),
+      )
+    )
   }
 
   fun onMenuAction(
@@ -210,8 +221,21 @@ internal class BirthdaysViewModel(
   fun onDeleteConfirmed() {
     val id = _state.value.confirmDeleteId ?: return
     _state.update { it.copy(confirmDeleteId = null) }
-    viewModelScope.launch(dispatcherProvider.default()) {
+    pendingDeleteTracker.markPending(batchKey = id, ids = setOf(id)) {
       deleteBirthdayUseCase(id)
+    }
+    navigationEvent.emit(
+      NavigationEvent.ShowUndoDelete(batchKey = id, message = textProvider.getText(R.string.birthday_deleted))
+    )
+  }
+
+  fun undoDelete(batchKey: String) {
+    pendingDeleteTracker.undo(batchKey)
+  }
+
+  fun commitDelete(batchKey: String) {
+    viewModelScope.launch(dispatcherProvider.default()) {
+      pendingDeleteTracker.commit(batchKey)
     }
   }
 
@@ -220,6 +244,7 @@ internal class BirthdaysViewModel(
     data class OpenEdit(val id: String) : NavigationEvent
     data object OpenNewBirthday : NavigationEvent
     data class ConfirmDeleteSelected(val ids: Set<String>, val title: String) : NavigationEvent
+    data class ShowUndoDelete(val batchKey: String, val message: String) : NavigationEvent
   }
 
   companion object {

--- a/feature/feature-birthday/src/main/kotlin/com/github/naz013/feature/birthday/list/BirthdaysViewModel.kt
+++ b/feature/feature-birthday/src/main/kotlin/com/github/naz013/feature/birthday/list/BirthdaysViewModel.kt
@@ -184,10 +184,13 @@ internal class BirthdaysViewModel(
   fun deleteSelectedBirthdays(ids: Set<String>) {
     if (ids.isEmpty()) return
     val batchKey = UUID.randomUUID().toString()
+    // Clear selection before marking pending: markPending's pendingIds update can synchronously
+    // empty listState (via the reactive pipeline above), and updateSelection is a no-op once
+    // listState is no longer Ready - clearing first avoids a stuck selectedCount.
+    onSelectionCancel()
     pendingDeleteTracker.markPending(batchKey = batchKey, ids = ids) {
       ids.forEach { deleteBirthdayUseCase(it) }
     }
-    onSelectionCancel()
     navigationEvent.emit(
       NavigationEvent.ShowUndoDelete(
         batchKey = batchKey,

--- a/feature/feature-birthday/src/test/kotlin/com/github/naz013/feature/birthday/list/BirthdaysViewModelTest.kt
+++ b/feature/feature-birthday/src/test/kotlin/com/github/naz013/feature/birthday/list/BirthdaysViewModelTest.kt
@@ -197,14 +197,41 @@ class BirthdaysViewModelTest : BaseTest() {
     }
 
   @Test
-  fun `onDeleteConfirmed deletes the birthday and hides the confirmation`() =
+  fun `onDeleteConfirmed hides the confirmation without deleting yet and posts ShowUndoDelete`() =
     runTest {
+      every { textProvider.getText(R.string.birthday_deleted) } returns "Birthday deleted"
       viewModel.onMenuAction(uiBirthday(id = "7"), AgendaMenuAction.DELETE)
 
       viewModel.onDeleteConfirmed()
 
-      coVerify(exactly = 1) { deleteBirthdayUseCase("7") }
+      coVerify(exactly = 0) { deleteBirthdayUseCase(any()) }
       assertEquals(null, viewModel.state.first().confirmDeleteId)
+      assertEquals(
+        BirthdaysViewModel.NavigationEvent.ShowUndoDelete(batchKey = "7", message = "Birthday deleted"),
+        viewModel.navigationEvent.value?.peekContent(),
+      )
+    }
+
+  @Test
+  fun `undoDelete cancels the pending delete`() =
+    runTest {
+      viewModel.onMenuAction(uiBirthday(id = "7"), AgendaMenuAction.DELETE)
+      viewModel.onDeleteConfirmed()
+
+      viewModel.undoDelete("7")
+
+      coVerify(exactly = 0) { deleteBirthdayUseCase(any()) }
+    }
+
+  @Test
+  fun `commitDelete deletes the birthday after the undo window`() =
+    runTest {
+      viewModel.onMenuAction(uiBirthday(id = "7"), AgendaMenuAction.DELETE)
+      viewModel.onDeleteConfirmed()
+
+      viewModel.commitDelete("7")
+
+      coVerify(exactly = 1) { deleteBirthdayUseCase("7") }
     }
 
   @Test
@@ -314,16 +341,33 @@ class BirthdaysViewModelTest : BaseTest() {
     }
 
   @Test
-  fun `deleteSelectedBirthdays deletes each birthday and clears selection`() =
+  fun `deleteSelectedBirthdays clears selection and posts ShowUndoDelete without deleting yet`() =
     runTest {
+      every { textProvider.getText(R.string.birthdays_deleted_count, 2) } returns "2 birthdays deleted"
       val vm = readyViewModelWithTwoBirthdays()
       vm.onItemLongClick("1")
       vm.onItemClick(uiBirthday(id = "2"))
 
       vm.deleteSelectedBirthdays(setOf("1", "2"))
 
+      coVerify(exactly = 0) { deleteBirthdayUseCase(any()) }
+      assertEquals(0, vm.state.first().selectedCount)
+      val event = vm.navigationEvent.value?.peekContent() as BirthdaysViewModel.NavigationEvent.ShowUndoDelete
+      assertEquals("2 birthdays deleted", event.message)
+    }
+
+  @Test
+  fun `commitDelete after a bulk delete deletes each birthday`() =
+    runTest {
+      val vm = readyViewModelWithTwoBirthdays()
+      vm.onItemLongClick("1")
+      vm.onItemClick(uiBirthday(id = "2"))
+      vm.deleteSelectedBirthdays(setOf("1", "2"))
+      val batchKey = (vm.navigationEvent.value?.peekContent() as BirthdaysViewModel.NavigationEvent.ShowUndoDelete).batchKey
+
+      vm.commitDelete(batchKey)
+
       coVerify(exactly = 1) { deleteBirthdayUseCase("1") }
       coVerify(exactly = 1) { deleteBirthdayUseCase("2") }
-      assertEquals(0, vm.state.first().selectedCount)
     }
 }

--- a/feature/feature-birthday/src/test/kotlin/com/github/naz013/feature/birthday/list/BirthdaysViewModelTest.kt
+++ b/feature/feature-birthday/src/test/kotlin/com/github/naz013/feature/birthday/list/BirthdaysViewModelTest.kt
@@ -363,7 +363,8 @@ class BirthdaysViewModelTest : BaseTest() {
       vm.onItemLongClick("1")
       vm.onItemClick(uiBirthday(id = "2"))
       vm.deleteSelectedBirthdays(setOf("1", "2"))
-      val batchKey = (vm.navigationEvent.value?.peekContent() as BirthdaysViewModel.NavigationEvent.ShowUndoDelete).batchKey
+      val batchKey =
+        (vm.navigationEvent.value?.peekContent() as BirthdaysViewModel.NavigationEvent.ShowUndoDelete).batchKey
 
       vm.commitDelete(batchKey)
 

--- a/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/NotesNavGraph.kt
+++ b/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/NotesNavGraph.kt
@@ -1,6 +1,7 @@
 package com.github.naz013.feature.note
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
@@ -39,7 +40,9 @@ import com.github.naz013.ui.common.compose.foundation.dialog.DialogDispatcher
 import com.github.naz013.ui.common.compose.foundation.dialog.rememberColorPickerDialogDispatcher
 import com.github.naz013.ui.common.compose.foundation.dialog.rememberDialogDispatcher
 import com.github.naz013.ui.common.compose.foundation.snackbar.ToastDispatcher
+import com.github.naz013.ui.common.compose.foundation.snackbar.UndoSnackbarDispatcher
 import com.github.naz013.ui.common.compose.foundation.snackbar.rememberToastDispatcher
+import com.github.naz013.ui.common.compose.foundation.snackbar.rememberUndoSnackbarDispatcher
 import com.github.naz013.ui.common.datetime.rememberDateTimePicker
 import com.github.naz013.ui.common.livedata.ObserveEvent
 import com.github.naz013.ui.common.permission.PermissionRequester
@@ -71,6 +74,8 @@ private class NotesNavHandlers(
   val backStack: MutableList<NavKey>,
   val dialogDispatcher: DialogDispatcher,
   val toastDispatcher: ToastDispatcher,
+  val undoSnackbarDispatcher: UndoSnackbarDispatcher,
+  val undoActionLabel: String,
   val noteIntentSender: NoteIntentSender,
   val permissionRequester: PermissionRequester,
   val onOpenNoteSettings: (String) -> Unit,
@@ -141,6 +146,15 @@ private fun handleNotesNavigationEvent(
       )
     }
 
+    is NotesViewModel.NavigationEvent.ShowUndoDelete -> {
+      handlers.undoSnackbarDispatcher.showUndoSnackbar(
+        message = event.message,
+        actionLabel = handlers.undoActionLabel,
+        onUndo = { handlers.viewModel.undoDeleteNote(event.batchKey) },
+        onTimeout = { handlers.viewModel.commitDeleteNote(event.batchKey) },
+      )
+    }
+
     is NotesViewModel.NavigationEvent.Error -> {
       handlers.toastDispatcher.showToast(message = event.message)
     }
@@ -158,6 +172,8 @@ private fun NotesListEntry(
   val permissionRequester = rememberPermissionRequesterRationale()
   val dialogDispatcher = rememberDialogDispatcher()
   val toastDispatcher = rememberToastDispatcher()
+  val snackbarHostState = remember { SnackbarHostState() }
+  val undoSnackbarDispatcher = rememberUndoSnackbarDispatcher(snackbarHostState)
   val noteIntentSender = rememberNoteIntentSender(applicationId)
   val colorPickerDialogDispatcher = rememberColorPickerDialogDispatcher()
   val noteColorEngine = koinInject<NoteColorEngine>()
@@ -167,6 +183,8 @@ private fun NotesListEntry(
     backStack = backStack,
     dialogDispatcher = dialogDispatcher,
     toastDispatcher = toastDispatcher,
+    undoSnackbarDispatcher = undoSnackbarDispatcher,
+    undoActionLabel = stringResource(R.string.undo),
     noteIntentSender = noteIntentSender,
     permissionRequester = permissionRequester,
     onOpenNoteSettings = onOpenNoteSettings,
@@ -177,6 +195,7 @@ private fun NotesListEntry(
   NotesScreen(
     modifier = Modifier.fillMaxSize(),
     state = state,
+    snackbarHostState = snackbarHostState,
     onBackClick = { if (backStack.size > 1) backStack.removeLastOrNull() },
     onSearchQueryChange = viewModel::onSearchQueryChange,
     onSortOrderSelected = viewModel::onSortOrderSelected,
@@ -211,6 +230,8 @@ private fun NotesArchiveEntry(backStack: MutableList<NavKey>, applicationId: Str
   val permissionRequester = rememberPermissionRequesterRationale()
   val dialogDispatcher = rememberDialogDispatcher()
   val toastDispatcher = rememberToastDispatcher()
+  val snackbarHostState = remember { SnackbarHostState() }
+  val undoSnackbarDispatcher = rememberUndoSnackbarDispatcher(snackbarHostState)
   val noteIntentSender = rememberNoteIntentSender(applicationId)
   val colorPickerDialogDispatcher = rememberColorPickerDialogDispatcher()
   val noteColorEngine = koinInject<NoteColorEngine>()
@@ -220,6 +241,8 @@ private fun NotesArchiveEntry(backStack: MutableList<NavKey>, applicationId: Str
     backStack = backStack,
     dialogDispatcher = dialogDispatcher,
     toastDispatcher = toastDispatcher,
+    undoSnackbarDispatcher = undoSnackbarDispatcher,
+    undoActionLabel = stringResource(R.string.undo),
     noteIntentSender = noteIntentSender,
     permissionRequester = permissionRequester,
     onOpenNoteSettings = {},
@@ -230,6 +253,7 @@ private fun NotesArchiveEntry(backStack: MutableList<NavKey>, applicationId: Str
   NotesScreen(
     modifier = Modifier.fillMaxSize(),
     state = state,
+    snackbarHostState = snackbarHostState,
     onBackClick = { if (backStack.size > 1) backStack.removeLastOrNull() },
     onSearchQueryChange = viewModel::onSearchQueryChange,
     onSortOrderSelected = viewModel::onSortOrderSelected,

--- a/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/list/NotesScreen.kt
+++ b/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/list/NotesScreen.kt
@@ -28,6 +28,8 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -71,6 +73,7 @@ private val GRID_CARD_HEIGHT = 180.dp
 internal fun NotesScreen(
   modifier: Modifier = Modifier,
   state: NotesScreenState,
+  snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
   onBackClick: (() -> Unit)?,
   onSearchQueryChange: (String) -> Unit,
   onSortOrderSelected: (String) -> Unit,
@@ -95,6 +98,7 @@ internal fun NotesScreen(
 
   Scaffold(
     modifier = modifier,
+    snackbarHost = { SnackbarHost(snackbarHostState) },
     topBar = {
       if (isSelectionMode) {
         NotesSelectionTopBar(

--- a/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/list/NotesViewModel.kt
+++ b/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/list/NotesViewModel.kt
@@ -234,6 +234,10 @@ internal class NotesViewModel(
   fun deleteSelectedNotes(ids: Set<String>) {
     if (ids.isEmpty()) return
     val batchKey = UUID.randomUUID().toString()
+    // Clear selection before marking pending: markPending's pendingIds update can synchronously
+    // empty listState (via the reactive pipeline above), and updateSelection is a no-op once
+    // listState is no longer Ready - clearing first avoids a stuck selectedCount.
+    onSelectionCancel()
     pendingDeleteTracker.markPending(batchKey = batchKey, ids = ids) {
       ids.forEach { deleteNoteUseCase(it) }
       if (!isArchived) {
@@ -242,7 +246,6 @@ internal class NotesViewModel(
         }
       }
     }
-    onSelectionCancel()
     navigationEvent.emit(
       NavigationEvent.ShowUndoDelete(
         batchKey = batchKey,

--- a/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/list/NotesViewModel.kt
+++ b/feature/feature-note/src/main/kotlin/com/github/naz013/feature/note/list/NotesViewModel.kt
@@ -14,6 +14,7 @@ import com.github.naz013.domain.note.NoteWithImages
 import com.github.naz013.feature.common.coroutine.DispatcherProvider
 import com.github.naz013.feature.common.livedata.Event
 import com.github.naz013.feature.common.livedata.emit
+import com.github.naz013.feature.common.viewmodel.PendingDeleteTracker
 import com.github.naz013.feature.common.viewmodel.mutableLiveEventOf
 import com.github.naz013.feature.common.viewmodel.stateInWhileSubscribed
 import com.github.naz013.feature.note.R
@@ -51,6 +52,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.util.UUID
 
 @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
 internal class NotesViewModel(
@@ -97,6 +99,7 @@ internal class NotesViewModel(
   private val searchQuery = MutableStateFlow("")
   private val sortOrder = MutableStateFlow(notePreferences.noteOrder)
   private val selectedTagId = MutableStateFlow<String?>(null)
+  private val pendingDeleteTracker = PendingDeleteTracker()
 
   init {
     analyticsEventSender.send(ScreenUsedEvent(Screen.NOTES_LIST))
@@ -123,6 +126,9 @@ internal class NotesViewModel(
             val ids = tagAssignmentRepository.getItemIdsForTag(tagId, TaggedItemType.NOTE).toSet()
             notes.filter { it.note?.key in ids }
           }
+        }
+        .combine(pendingDeleteTracker.pendingIds) { notes, pendingIds ->
+          notes.filterNot { it.note?.key in pendingIds }
         }
         .collect { applyList(it) }
     }
@@ -226,19 +232,23 @@ internal class NotesViewModel(
   }
 
   fun deleteSelectedNotes(ids: Set<String>) {
-    viewModelScope.launch(dispatcherProvider.default()) {
+    if (ids.isEmpty()) return
+    val batchKey = UUID.randomUUID().toString()
+    pendingDeleteTracker.markPending(batchKey = batchKey, ids = ids) {
       ids.forEach { deleteNoteUseCase(it) }
-
-      withContext(dispatcherProvider.main()) {
-        onSelectionCancel()
-      }
-
       if (!isArchived) {
         withContext(dispatcherProvider.main()) {
           appWidgetUpdater.updateNotesWidget()
         }
       }
     }
+    onSelectionCancel()
+    navigationEvent.emit(
+      NavigationEvent.ShowUndoDelete(
+        batchKey = batchKey,
+        message = textProvider.getText(R.string.notes_deleted_count, ids.size),
+      )
+    )
   }
 
   fun onArchiveSelectedClick() {
@@ -386,14 +396,26 @@ internal class NotesViewModel(
   }
 
   fun deleteNote(id: String) {
-    viewModelScope.launch(dispatcherProvider.default()) {
+    pendingDeleteTracker.markPending(batchKey = id, ids = setOf(id)) {
       deleteNoteUseCase(id)
-
       if (!isArchived) {
         withContext(dispatcherProvider.main()) {
           appWidgetUpdater.updateNotesWidget()
         }
       }
+    }
+    navigationEvent.emit(
+      NavigationEvent.ShowUndoDelete(batchKey = id, message = textProvider.getString(R.string.note_deleted))
+    )
+  }
+
+  fun undoDeleteNote(batchKey: String) {
+    pendingDeleteTracker.undo(batchKey)
+  }
+
+  fun commitDeleteNote(batchKey: String) {
+    viewModelScope.launch(dispatcherProvider.default()) {
+      pendingDeleteTracker.commit(batchKey)
     }
   }
 
@@ -468,6 +490,11 @@ internal class NotesViewModel(
     data class ConfirmMergeSelected(
       val ids: List<String>,
       val title: String,
+    ) : NavigationEvent
+
+    data class ShowUndoDelete(
+      val batchKey: String,
+      val message: String,
     ) : NavigationEvent
 
     data class Error(val message: String) : NavigationEvent

--- a/feature/feature-note/src/test/kotlin/com/github/naz013/feature/note/list/NotesViewModelTest.kt
+++ b/feature/feature-note/src/test/kotlin/com/github/naz013/feature/note/list/NotesViewModelTest.kt
@@ -433,25 +433,77 @@ class NotesViewModelTest : BaseTest() {
   }
 
   @Test
-  fun `deleteNote deletes, refreshes and updates the widget when not archived`() =
+  fun `deleteNote hides the note immediately without deleting it yet`() =
     runTest {
-      val viewModel = createViewModel(isArchived = false)
+      val (viewModel, state) = readyViewModel(listOf("7"))
 
       viewModel.deleteNote("7")
+
+      assertEquals(ListState.Empty, state().listState)
+      coVerify(exactly = 0) { deleteNoteUseCase(any()) }
+    }
+
+  @Test
+  fun `deleteNote posts a ShowUndoDelete navigation event keyed by the note id`() =
+    runTest {
+      every { textProvider.getString(R.string.note_deleted) } returns "Note deleted"
+      val viewModel = createViewModel()
+
+      viewModel.deleteNote("7")
+
+      assertEquals(
+        NotesViewModel.NavigationEvent.ShowUndoDelete(batchKey = "7", message = "Note deleted"),
+        viewModel.navigationEvent.value?.peekContent(),
+      )
+    }
+
+  @Test
+  fun `undoDeleteNote cancels the pending delete and the note reappears`() =
+    runTest {
+      val (viewModel, state) = readyViewModel(listOf("7"))
+      viewModel.deleteNote("7")
+
+      viewModel.undoDeleteNote("7")
+
+      val ready = state().listState as ListState.Ready
+      assertEquals(listOf("7"), ready.notes.map { it.id })
+      coVerify(exactly = 0) { deleteNoteUseCase(any()) }
+    }
+
+  @Test
+  fun `commitDeleteNote deletes, refreshes and updates the widget when not archived`() =
+    runTest {
+      val viewModel = createViewModel(isArchived = false)
+      viewModel.deleteNote("7")
+
+      viewModel.commitDeleteNote("7")
 
       coVerify(exactly = 1) { deleteNoteUseCase("7") }
       verify(exactly = 1) { appWidgetUpdater.updateNotesWidget() }
     }
 
   @Test
-  fun `deleteNote does not update the widget on the archive screen`() =
+  fun `commitDeleteNote does not update the widget on the archive screen`() =
     runTest {
       val viewModel = createViewModel(isArchived = true)
-
       viewModel.deleteNote("7")
+
+      viewModel.commitDeleteNote("7")
 
       coVerify(exactly = 1) { deleteNoteUseCase("7") }
       verify(exactly = 0) { appWidgetUpdater.updateNotesWidget() }
+    }
+
+  @Test
+  fun `commitDeleteNote does nothing for a batch key that was already undone`() =
+    runTest {
+      val viewModel = createViewModel()
+      viewModel.deleteNote("7")
+      viewModel.undoDeleteNote("7")
+
+      viewModel.commitDeleteNote("7")
+
+      coVerify(exactly = 0) { deleteNoteUseCase(any()) }
     }
 
   @Test
@@ -683,7 +735,7 @@ class NotesViewModelTest : BaseTest() {
     }
 
   @Test
-  fun `deleteSelectedNotes deletes each note, clears selection, refreshes and updates the widget`() =
+  fun `deleteSelectedNotes hides the notes immediately, clears selection, without deleting yet`() =
     runTest {
       val (viewModel, state) = readyViewModel(listOf("1", "2"), isArchived = false)
       viewModel.onNoteLongClick("1")
@@ -691,9 +743,39 @@ class NotesViewModelTest : BaseTest() {
 
       viewModel.deleteSelectedNotes(setOf("1", "2"))
 
+      assertEquals(ListState.Empty, state().listState)
+      assertEquals(0, state().selectedCount)
+      coVerify(exactly = 0) { deleteNoteUseCase(any()) }
+    }
+
+  @Test
+  fun `deleteSelectedNotes posts a ShowUndoDelete navigation event with a formatted message`() =
+    runTest {
+      every { textProvider.getText(R.string.notes_deleted_count, 2) } returns "2 notes deleted"
+      val (viewModel, _) = readyViewModel(listOf("1", "2"))
+      viewModel.onNoteLongClick("1")
+      viewModel.onNoteClick("2")
+
+      viewModel.deleteSelectedNotes(setOf("1", "2"))
+
+      val event = viewModel.navigationEvent.value?.peekContent() as NotesViewModel.NavigationEvent.ShowUndoDelete
+      assertEquals("2 notes deleted", event.message)
+    }
+
+  @Test
+  fun `commitDeleteNote after a bulk delete deletes each note, refreshes and updates the widget`() =
+    runTest {
+      val (viewModel, _) = readyViewModel(listOf("1", "2"), isArchived = false)
+      viewModel.onNoteLongClick("1")
+      viewModel.onNoteClick("2")
+      viewModel.deleteSelectedNotes(setOf("1", "2"))
+      val batchKey =
+        (viewModel.navigationEvent.value?.peekContent() as NotesViewModel.NavigationEvent.ShowUndoDelete).batchKey
+
+      viewModel.commitDeleteNote(batchKey)
+
       coVerify(exactly = 1) { deleteNoteUseCase("1") }
       coVerify(exactly = 1) { deleteNoteUseCase("2") }
-      assertEquals(0, state().selectedCount)
       verify(exactly = 1) { appWidgetUpdater.updateNotesWidget() }
     }
 
@@ -704,6 +786,9 @@ class NotesViewModelTest : BaseTest() {
       viewModel.onNoteLongClick("1")
 
       viewModel.deleteSelectedNotes(setOf("1"))
+      val batchKey =
+        (viewModel.navigationEvent.value?.peekContent() as NotesViewModel.NavigationEvent.ShowUndoDelete).batchKey
+      viewModel.commitDeleteNote(batchKey)
 
       coVerify(exactly = 1) { deleteNoteUseCase("1") }
       verify(exactly = 0) { appWidgetUpdater.updateNotesWidget() }

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/lists/removed/RemindersArchiveNavGraph.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/lists/removed/RemindersArchiveNavGraph.kt
@@ -13,11 +13,11 @@ import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
 import com.github.naz013.ui.common.R
 import com.github.naz013.ui.common.compose.AppIcons
-import com.github.naz013.ui.common.compose.foundation.navigation.DetailPanePlaceholder
-import com.github.naz013.ui.common.livedata.ObserveEvent
 import com.github.naz013.ui.common.compose.foundation.dialog.rememberDialogDispatcher
+import com.github.naz013.ui.common.compose.foundation.navigation.DetailPanePlaceholder
 import com.github.naz013.ui.common.compose.foundation.snackbar.rememberToastDispatcher
 import com.github.naz013.ui.common.compose.foundation.snackbar.rememberUndoSnackbarDispatcher
+import com.github.naz013.ui.common.livedata.ObserveEvent
 import org.koin.compose.viewmodel.koinViewModel
 
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/lists/removed/RemindersArchiveNavGraph.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/lists/removed/RemindersArchiveNavGraph.kt
@@ -1,11 +1,13 @@
 package com.github.naz013.feature.reminder.lists.removed
 
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.compose.material3.adaptive.navigation3.ListDetailSceneStrategy
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.res.stringResource
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
@@ -15,6 +17,7 @@ import com.github.naz013.ui.common.compose.foundation.navigation.DetailPanePlace
 import com.github.naz013.ui.common.livedata.ObserveEvent
 import com.github.naz013.ui.common.compose.foundation.dialog.rememberDialogDispatcher
 import com.github.naz013.ui.common.compose.foundation.snackbar.rememberToastDispatcher
+import com.github.naz013.ui.common.compose.foundation.snackbar.rememberUndoSnackbarDispatcher
 import org.koin.compose.viewmodel.koinViewModel
 
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)
@@ -47,6 +50,9 @@ private fun ListEntry(
 
   val dialogDispatcher = rememberDialogDispatcher()
   val toastDispatcher = rememberToastDispatcher()
+  val snackbarHostState = remember { SnackbarHostState() }
+  val undoSnackbarDispatcher = rememberUndoSnackbarDispatcher(snackbarHostState)
+  val undoActionLabel = stringResource(R.string.undo)
 
   viewModel.event.ObserveEvent { event ->
     when (event) {
@@ -76,12 +82,22 @@ private fun ListEntry(
       RemindersArchiveViewModel.NavigationEvent.ArchiveEmptied -> {
         toastDispatcher.showToast(messageRes = R.string.archive_was_emptied)
       }
+
+      is RemindersArchiveViewModel.NavigationEvent.ShowUndoDelete -> {
+        undoSnackbarDispatcher.showUndoSnackbar(
+          message = event.message,
+          actionLabel = undoActionLabel,
+          onUndo = { viewModel.undoDelete(event.batchKey) },
+          onTimeout = { viewModel.commitDelete(event.batchKey) },
+        )
+      }
     }
   }
 
   val state by viewModel.state.collectAsState(RemindersArchiveScreenState())
   RemindersArchiveScreen(
     state = state,
+    snackbarHostState = snackbarHostState,
     onBackClick = { if (backStack.size > 1) backStack.removeLastOrNull() },
     onSearchQueryChange = viewModel::onSearchQueryChange,
     onDeleteAllClick = viewModel::onDeleteAllClick,

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/lists/removed/RemindersArchiveScreen.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/lists/removed/RemindersArchiveScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -45,6 +47,7 @@ private val HEADER_ELEVATION = 3.dp
 @Composable
 fun RemindersArchiveScreen(
   state: RemindersArchiveScreenState,
+  snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
   onBackClick: () -> Unit,
   onSearchQueryChange: (String) -> Unit,
   onDeleteAllClick: () -> Unit,
@@ -61,6 +64,7 @@ fun RemindersArchiveScreen(
 
   Scaffold(
     modifier = modifier,
+    snackbarHost = { SnackbarHost(snackbarHostState) },
     topBar = {
       Surface(color = MaterialTheme.colorScheme.background, shadowElevation = headerElevation) {
         Column {

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/lists/removed/RemindersArchiveViewModel.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/lists/removed/RemindersArchiveViewModel.kt
@@ -7,9 +7,11 @@ import com.github.naz013.ui.reminder.UiReminderList
 import com.github.naz013.ui.reminder.UiReminderListAdapter
 import com.github.naz013.logic.reminder.filter.ReminderV2QueryFilterInstance
 import com.github.naz013.domain.reminder.v2.ReminderV2
+import com.github.naz013.common.TextProvider
 import com.github.naz013.feature.common.coroutine.DispatcherProvider
 import com.github.naz013.feature.common.livedata.Event
 import com.github.naz013.feature.common.livedata.emit
+import com.github.naz013.feature.common.viewmodel.PendingDeleteTracker
 import com.github.naz013.feature.common.viewmodel.mutableLiveEventOf
 import com.github.naz013.feature.common.viewmodel.stateInWhileSubscribed
 import com.github.naz013.logging.Logger
@@ -17,6 +19,7 @@ import com.github.naz013.logic.reminder.usecase.DeleteAllReminderUseCase
 import com.github.naz013.logic.reminder.usecase.DeleteReminderUseCase
 import com.github.naz013.repository.GroupV2Repository
 import com.github.naz013.repository.ReminderV2Repository
+import com.github.naz013.ui.common.R
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -27,12 +30,14 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.UUID
 
 @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
 class RemindersArchiveViewModel(
   private val reminderV2Repository: ReminderV2Repository,
   private val groupV2Repository: GroupV2Repository,
   private val dispatcherProvider: DispatcherProvider,
+  private val textProvider: TextProvider,
   private val uiReminderListAdapter: UiReminderListAdapter,
   private val deleteReminderUseCase: DeleteReminderUseCase,
   private val deleteAllReminderUseCase: DeleteAllReminderUseCase,
@@ -46,6 +51,7 @@ class RemindersArchiveViewModel(
   val event: LiveData<Event<NavigationEvent>> field = mutableLiveEventOf()
 
   private val searchQueryFlow = MutableStateFlow("")
+  private val pendingDeleteTracker = PendingDeleteTracker()
 
   init {
     viewModelScope.launch(dispatcherProvider.default()) {
@@ -55,6 +61,9 @@ class RemindersArchiveViewModel(
         .debounce { if (it.isEmpty()) 0L else SEARCH_DEBOUNCE_MS }
         .flatMapLatest { query ->
           reminderV2Repository.observeByRemovedStatus(removed = true).map { it to query }
+        }
+        .combine(pendingDeleteTracker.pendingIds) { (reminders, query), pendingIds ->
+          reminders.filterNot { it.uuId in pendingIds } to query
         }
         .collect { (reminders, query) -> applyReminders(reminders, query) }
     }
@@ -88,28 +97,44 @@ class RemindersArchiveViewModel(
   }
 
   fun deleteReminder(id: String) {
-    Logger.i(TAG, "Deleting reminder: $id")
-    viewModelScope.launch(dispatcherProvider.main()) {
-      withContext(dispatcherProvider.io()) {
-        reminderV2Repository.getById(id)?.also {
-          deleteReminderUseCase(it)
-        }
-      } ?: run {
-        Logger.e(TAG, "Cannot delete reminder with id = $id. Not found.")
-      }
+    pendingDeleteTracker.markPending(batchKey = id, ids = setOf(id)) {
+      reminderV2Repository.getById(id)?.also {
+        deleteReminderUseCase(it)
+        Logger.i(TAG, "Deleted reminder: $id")
+      } ?: Logger.e(TAG, "Cannot delete reminder with id = $id. Not found.")
     }
+    event.emit(
+      NavigationEvent.ShowUndoDelete(batchKey = id, message = textProvider.getText(R.string.reminder_deleted))
+    )
   }
 
   fun deleteAll() {
-    viewModelScope.launch(dispatcherProvider.main()) {
-      val toDeleteIds = _state.value.filteredReminders.map { it.uuId }
-      if (toDeleteIds.isEmpty()) return@launch
+    val toDeleteIds = _state.value.filteredReminders.map { it.uuId }.toSet()
+    if (toDeleteIds.isEmpty()) return
+    val batchKey = UUID.randomUUID().toString()
+    pendingDeleteTracker.markPending(batchKey = batchKey, ids = toDeleteIds) {
       Logger.i(TAG, "Deleting all reminders: ${toDeleteIds.size}")
-      withContext(dispatcherProvider.io()) {
-        val toDelete = toDeleteIds.mapNotNull { reminderV2Repository.getById(it) }
-        deleteAllReminderUseCase(toDelete)
+      val toDelete = toDeleteIds.mapNotNull { reminderV2Repository.getById(it) }
+      deleteAllReminderUseCase(toDelete)
+      withContext(dispatcherProvider.main()) {
+        event.emit(NavigationEvent.ArchiveEmptied)
       }
-      event.emit(NavigationEvent.ArchiveEmptied)
+    }
+    event.emit(
+      NavigationEvent.ShowUndoDelete(
+        batchKey = batchKey,
+        message = textProvider.getText(R.string.reminders_deleted_count, toDeleteIds.size),
+      )
+    )
+  }
+
+  fun undoDelete(batchKey: String) {
+    pendingDeleteTracker.undo(batchKey)
+  }
+
+  fun commitDelete(batchKey: String) {
+    viewModelScope.launch(dispatcherProvider.default()) {
+      pendingDeleteTracker.commit(batchKey)
     }
   }
 
@@ -158,6 +183,11 @@ class RemindersArchiveViewModel(
     data object ConfirmDeleteAll : NavigationEvent
 
     data object ArchiveEmptied : NavigationEvent
+
+    data class ShowUndoDelete(
+      val batchKey: String,
+      val message: String,
+    ) : NavigationEvent
   }
 
   companion object {

--- a/feature/feature-reminder/src/test/kotlin/com/github/naz013/feature/reminder/lists/removed/RemindersArchiveViewModelTest.kt
+++ b/feature/feature-reminder/src/test/kotlin/com/github/naz013/feature/reminder/lists/removed/RemindersArchiveViewModelTest.kt
@@ -1,7 +1,9 @@
 package com.github.naz013.feature.reminder.lists.removed
 
+import com.github.naz013.common.TextProvider
 import com.github.naz013.testing.BaseTest
 import com.github.naz013.testing.mockDispatcherProvider
+import com.github.naz013.ui.common.R
 import com.github.naz013.ui.reminder.UiReminderList
 import com.github.naz013.ui.reminder.UiReminderListActions
 import com.github.naz013.ui.reminder.UiReminderListAdapter
@@ -31,6 +33,7 @@ class RemindersArchiveViewModelTest : BaseTest() {
   private val uiReminderListAdapter = mockk<UiReminderListAdapter>()
   private val deleteReminderUseCase = mockk<DeleteReminderUseCase>(relaxed = true)
   private val deleteAllReminderUseCase = mockk<DeleteAllReminderUseCase>(relaxed = true)
+  private val textProvider = mockk<TextProvider>(relaxed = true)
 
   private lateinit var viewModel: RemindersArchiveViewModel
 
@@ -49,6 +52,7 @@ class RemindersArchiveViewModelTest : BaseTest() {
       reminderV2Repository = reminderV2Repository,
       groupV2Repository = groupV2Repository,
       dispatcherProvider = mockDispatcherProvider(),
+      textProvider = textProvider,
       uiReminderListAdapter = uiReminderListAdapter,
       deleteReminderUseCase = deleteReminderUseCase,
       deleteAllReminderUseCase = deleteAllReminderUseCase,
@@ -159,36 +163,84 @@ class RemindersArchiveViewModelTest : BaseTest() {
   }
 
   @Test
-  fun `deleteReminder deletes the found reminder`() =
+  fun `deleteReminder hides the reminder immediately and posts ShowUndoDelete without deleting yet`() =
     runTest {
+      every { textProvider.getText(R.string.reminder_deleted) } returns "Reminder deleted"
       val target = reminderV2("1")
       coEvery { reminderV2Repository.getById("1") } returns target
 
       viewModel.deleteReminder("1")
 
+      coVerify(exactly = 0) { deleteReminderUseCase(any()) }
+      assertEquals(
+        RemindersArchiveViewModel.NavigationEvent.ShowUndoDelete(batchKey = "1", message = "Reminder deleted"),
+        viewModel.event.value?.peekContent(),
+      )
+    }
+
+  @Test
+  fun `commitDelete deletes the found reminder after the undo window`() =
+    runTest {
+      val target = reminderV2("1")
+      coEvery { reminderV2Repository.getById("1") } returns target
+      viewModel.deleteReminder("1")
+
+      viewModel.commitDelete("1")
+
       coVerify(exactly = 1) { deleteReminderUseCase(target) }
     }
 
   @Test
-  fun `deleteReminder does nothing when the reminder is not found`() =
+  fun `commitDelete does nothing when the reminder is not found`() =
     runTest {
       coEvery { reminderV2Repository.getById("missing") } returns null
-
       viewModel.deleteReminder("missing")
+
+      viewModel.commitDelete("missing")
 
       coVerify(exactly = 0) { deleteReminderUseCase(any()) }
     }
 
   @Test
-  fun `deleteAll re-fetches the reminders by id, deletes them and emits ArchiveEmptied`() =
+  fun `undoDelete cancels a pending single delete`() =
+    runTest {
+      val target = reminderV2("1")
+      coEvery { reminderV2Repository.getById("1") } returns target
+      viewModel.deleteReminder("1")
+
+      viewModel.undoDelete("1")
+      viewModel.commitDelete("1")
+
+      coVerify(exactly = 0) { deleteReminderUseCase(any()) }
+    }
+
+  @Test
+  fun `deleteAll hides the reminders immediately and posts ShowUndoDelete without deleting yet`() =
+    runTest {
+      every { textProvider.getText(R.string.reminders_deleted_count, 2) } returns "2 reminders deleted"
+      val remindersV2 = listOf(reminderV2("1"), reminderV2("2"))
+      every { reminderV2Repository.observeByRemovedStatus(removed = true) } returns flowOf(remindersV2)
+      val vm = createViewModel()
+
+      vm.deleteAll()
+
+      coVerify(exactly = 0) { deleteAllReminderUseCase(any()) }
+      val event = vm.event.value?.peekContent() as RemindersArchiveViewModel.NavigationEvent.ShowUndoDelete
+      assertEquals("2 reminders deleted", event.message)
+    }
+
+  @Test
+  fun `commitDelete after deleteAll re-fetches the reminders by id, deletes them and emits ArchiveEmptied`() =
     runTest {
       val remindersV2 = listOf(reminderV2("1"), reminderV2("2"))
       every { reminderV2Repository.observeByRemovedStatus(removed = true) } returns flowOf(remindersV2)
       coEvery { reminderV2Repository.getById("1") } returns remindersV2[0]
       coEvery { reminderV2Repository.getById("2") } returns remindersV2[1]
       val vm = createViewModel()
-
       vm.deleteAll()
+      val batchKey = (vm.event.value?.peekContent() as RemindersArchiveViewModel.NavigationEvent.ShowUndoDelete).batchKey
+
+      vm.commitDelete(batchKey)
 
       coVerify(exactly = 1) { deleteAllReminderUseCase(remindersV2) }
       val event = vm.event.value?.peekContent()

--- a/feature/feature-reminder/src/test/kotlin/com/github/naz013/feature/reminder/lists/removed/RemindersArchiveViewModelTest.kt
+++ b/feature/feature-reminder/src/test/kotlin/com/github/naz013/feature/reminder/lists/removed/RemindersArchiveViewModelTest.kt
@@ -1,6 +1,12 @@
 package com.github.naz013.feature.reminder.lists.removed
 
 import com.github.naz013.common.TextProvider
+import com.github.naz013.domain.reminder.v2.ReminderSchedule
+import com.github.naz013.domain.reminder.v2.ReminderV2
+import com.github.naz013.logic.reminder.usecase.DeleteAllReminderUseCase
+import com.github.naz013.logic.reminder.usecase.DeleteReminderUseCase
+import com.github.naz013.repository.GroupV2Repository
+import com.github.naz013.repository.ReminderV2Repository
 import com.github.naz013.testing.BaseTest
 import com.github.naz013.testing.mockDispatcherProvider
 import com.github.naz013.ui.common.R
@@ -8,12 +14,6 @@ import com.github.naz013.ui.reminder.UiReminderList
 import com.github.naz013.ui.reminder.UiReminderListActions
 import com.github.naz013.ui.reminder.UiReminderListAdapter
 import com.github.naz013.ui.reminder.UiReminderListState
-import com.github.naz013.domain.reminder.v2.ReminderSchedule
-import com.github.naz013.domain.reminder.v2.ReminderV2
-import com.github.naz013.logic.reminder.usecase.DeleteAllReminderUseCase
-import com.github.naz013.logic.reminder.usecase.DeleteReminderUseCase
-import com.github.naz013.repository.GroupV2Repository
-import com.github.naz013.repository.ReminderV2Repository
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -238,7 +238,8 @@ class RemindersArchiveViewModelTest : BaseTest() {
       coEvery { reminderV2Repository.getById("2") } returns remindersV2[1]
       val vm = createViewModel()
       vm.deleteAll()
-      val batchKey = (vm.event.value?.peekContent() as RemindersArchiveViewModel.NavigationEvent.ShowUndoDelete).batchKey
+      val batchKey =
+        (vm.event.value?.peekContent() as RemindersArchiveViewModel.NavigationEvent.ShowUndoDelete).batchKey
 
       vm.commitDelete(batchKey)
 

--- a/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/snackbar/UndoSnackbar.kt
+++ b/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/snackbar/UndoSnackbar.kt
@@ -1,0 +1,54 @@
+package com.github.naz013.ui.common.compose.foundation.snackbar
+
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.launch
+
+interface UndoSnackbarDispatcher {
+  fun showUndoSnackbar(
+    message: String,
+    actionLabel: String,
+    onUndo: () -> Unit,
+    onTimeout: () -> Unit,
+  )
+}
+
+/**
+ * Shows a Snackbar carrying an action button (labelled [UndoSnackbarDispatcher.showUndoSnackbar]'s
+ * `actionLabel`) and reports back whether it was tapped ([UndoSnackbarDispatcher.showUndoSnackbar]'s
+ * `onUndo`) or the Snackbar's own duration elapsed first (`onTimeout`) - the Snackbar's
+ * [SnackbarDuration.Short] window is the single source of truth for how long "undo" stays
+ * available, there is no separate timer on the caller's side.
+ *
+ * A newly shown Snackbar dismisses whatever is currently displayed rather than queuing behind it,
+ * so back-to-back deletes only ever show (and only ever grant an undo window for) the most recent
+ * one - the same behavior most list apps use for delete-undo Snackbars.
+ */
+@Composable
+fun rememberUndoSnackbarDispatcher(snackbarHostState: SnackbarHostState): UndoSnackbarDispatcher {
+  val scope = rememberCoroutineScope()
+  return remember(snackbarHostState) {
+    object : UndoSnackbarDispatcher {
+      override fun showUndoSnackbar(
+        message: String,
+        actionLabel: String,
+        onUndo: () -> Unit,
+        onTimeout: () -> Unit,
+      ) {
+        scope.launch {
+          snackbarHostState.currentSnackbarData?.dismiss()
+          val result = snackbarHostState.showSnackbar(
+            message = message,
+            actionLabel = actionLabel,
+            duration = SnackbarDuration.Short,
+          )
+          if (result == SnackbarResult.ActionPerformed) onUndo() else onTimeout()
+        }
+      }
+    }
+  }
+}

--- a/ui/ui-common/src/main/res/values-ar/strings.xml
+++ b/ui/ui-common/src/main/res/values-ar/strings.xml
@@ -1357,4 +1357,11 @@
     <string name="birthdays_delete_selected_permanently">حذف %1$d أعياد الميلاد نهائيًا؟</string>
     <string name="agenda_delete_selected_permanently">حذف %1$d عناصر نهائيًا؟</string>
     <string name="selected_count">تم تحديد %1$d</string>
+    <string name="undo">تراجع</string>
+    <string name="note_deleted">تم حذف الملاحظة</string>
+    <string name="notes_deleted_count">تم حذف %1$d ملاحظات</string>
+    <string name="birthday_deleted">تم حذف عيد الميلاد</string>
+    <string name="birthdays_deleted_count">تم حذف %1$d أعياد ميلاد</string>
+    <string name="reminder_deleted">تم حذف التذكير</string>
+    <string name="reminders_deleted_count">تم حذف %1$d تذكيرات</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-bg/strings.xml
+++ b/ui/ui-common/src/main/res/values-bg/strings.xml
@@ -1360,4 +1360,11 @@
     <string name="birthdays_delete_selected_permanently">Изтриване на %1$d рождени дни окончателно?</string>
     <string name="agenda_delete_selected_permanently">Изтриване на %1$d елемента окончателно?</string>
     <string name="selected_count">Избрани %1$d</string>
+    <string name="undo">Отмяна</string>
+    <string name="note_deleted">Бележката е изтрита</string>
+    <string name="notes_deleted_count">%1$d бележки са изтрити</string>
+    <string name="birthday_deleted">Рожденият ден е изтрит</string>
+    <string name="birthdays_deleted_count">%1$d рождени дни са изтрити</string>
+    <string name="reminder_deleted">Напомнянето е изтрито</string>
+    <string name="reminders_deleted_count">%1$d напомняния са изтрити</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-cs/strings.xml
+++ b/ui/ui-common/src/main/res/values-cs/strings.xml
@@ -1359,4 +1359,11 @@
     <string name="birthdays_delete_selected_permanently">Trvale smazat %1$d narozenin?</string>
     <string name="agenda_delete_selected_permanently">Trvale smazat %1$d položek?</string>
     <string name="selected_count">Vybráno %1$d</string>
+    <string name="undo">Zpět</string>
+    <string name="note_deleted">Poznámka smazána</string>
+    <string name="notes_deleted_count">Smazáno poznámek: %1$d</string>
+    <string name="birthday_deleted">Narozeniny smazány</string>
+    <string name="birthdays_deleted_count">Smazáno narozenin: %1$d</string>
+    <string name="reminder_deleted">Připomenutí smazáno</string>
+    <string name="reminders_deleted_count">Smazáno připomenutí: %1$d</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-da/strings.xml
+++ b/ui/ui-common/src/main/res/values-da/strings.xml
@@ -1357,4 +1357,11 @@
     <string name="birthdays_delete_selected_permanently">Slet %1$d fødselsdage permanent?</string>
     <string name="agenda_delete_selected_permanently">Slet %1$d emner permanent?</string>
     <string name="selected_count">%1$d valgt</string>
+    <string name="undo">Fortryd</string>
+    <string name="note_deleted">Note slettet</string>
+    <string name="notes_deleted_count">%1$d noter slettet</string>
+    <string name="birthday_deleted">Fødselsdag slettet</string>
+    <string name="birthdays_deleted_count">%1$d fødselsdage slettet</string>
+    <string name="reminder_deleted">Påmindelse slettet</string>
+    <string name="reminders_deleted_count">%1$d påmindelser slettet</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-de/strings.xml
+++ b/ui/ui-common/src/main/res/values-de/strings.xml
@@ -1355,4 +1355,11 @@
     <string name="birthdays_delete_selected_permanently">%1$d Geburtstage dauerhaft löschen?</string>
     <string name="agenda_delete_selected_permanently">%1$d Elemente dauerhaft löschen?</string>
     <string name="selected_count">%1$d ausgewählt</string>
+    <string name="undo">Rückgängig</string>
+    <string name="note_deleted">Notiz gelöscht</string>
+    <string name="notes_deleted_count">%1$d Notizen gelöscht</string>
+    <string name="birthday_deleted">Geburtstag gelöscht</string>
+    <string name="birthdays_deleted_count">%1$d Geburtstage gelöscht</string>
+    <string name="reminder_deleted">Erinnerung gelöscht</string>
+    <string name="reminders_deleted_count">%1$d Erinnerungen gelöscht</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-es/strings.xml
+++ b/ui/ui-common/src/main/res/values-es/strings.xml
@@ -1359,4 +1359,11 @@
     <string name="birthdays_delete_selected_permanently">¿Eliminar %1$d cumpleaños permanentemente?</string>
     <string name="agenda_delete_selected_permanently">¿Eliminar %1$d elementos permanentemente?</string>
     <string name="selected_count">%1$d seleccionados</string>
+    <string name="undo">Deshacer</string>
+    <string name="note_deleted">Nota eliminada</string>
+    <string name="notes_deleted_count">%1$d notas eliminadas</string>
+    <string name="birthday_deleted">Cumpleaños eliminado</string>
+    <string name="birthdays_deleted_count">%1$d cumpleaños eliminados</string>
+    <string name="reminder_deleted">Recordatorio eliminado</string>
+    <string name="reminders_deleted_count">%1$d recordatorios eliminados</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-fr/strings.xml
+++ b/ui/ui-common/src/main/res/values-fr/strings.xml
@@ -1359,4 +1359,11 @@
     <string name="birthdays_delete_selected_permanently">Supprimer %1$d anniversaires définitivement ?</string>
     <string name="agenda_delete_selected_permanently">Supprimer %1$d éléments définitivement ?</string>
     <string name="selected_count">%1$d sélectionné(s)</string>
+    <string name="undo">Annuler</string>
+    <string name="note_deleted">Note supprimée</string>
+    <string name="notes_deleted_count">%1$d notes supprimées</string>
+    <string name="birthday_deleted">Anniversaire supprimé</string>
+    <string name="birthdays_deleted_count">%1$d anniversaires supprimés</string>
+    <string name="reminder_deleted">Rappel supprimé</string>
+    <string name="reminders_deleted_count">%1$d rappels supprimés</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-hi/strings.xml
+++ b/ui/ui-common/src/main/res/values-hi/strings.xml
@@ -1361,4 +1361,11 @@
     <string name="birthdays_delete_selected_permanently">%1$d जन्मदिन को स्थायी रूप से हटाएं?</string>
     <string name="agenda_delete_selected_permanently">%1$d आइटम को स्थायी रूप से हटाएं?</string>
     <string name="selected_count">%1$d चयनित</string>
+    <string name="undo">पूर्ववत करें</string>
+    <string name="note_deleted">नोट हटा दिया गया</string>
+    <string name="notes_deleted_count">%1$d नोट हटाए गए</string>
+    <string name="birthday_deleted">जन्मदिन हटा दिया गया</string>
+    <string name="birthdays_deleted_count">%1$d जन्मदिन हटाए गए</string>
+    <string name="reminder_deleted">रिमाइंडर हटा दिया गया</string>
+    <string name="reminders_deleted_count">%1$d रिमाइंडर हटाए गए</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-id/strings.xml
+++ b/ui/ui-common/src/main/res/values-id/strings.xml
@@ -1357,4 +1357,11 @@
     <string name="birthdays_delete_selected_permanently">Hapus %1$d ulang tahun secara permanen?</string>
     <string name="agenda_delete_selected_permanently">Hapus %1$d item secara permanen?</string>
     <string name="selected_count">%1$d dipilih</string>
+    <string name="undo">Urungkan</string>
+    <string name="note_deleted">Catatan dihapus</string>
+    <string name="notes_deleted_count">%1$d catatan dihapus</string>
+    <string name="birthday_deleted">Ulang tahun dihapus</string>
+    <string name="birthdays_deleted_count">%1$d ulang tahun dihapus</string>
+    <string name="reminder_deleted">Pengingat dihapus</string>
+    <string name="reminders_deleted_count">%1$d pengingat dihapus</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-it/strings.xml
+++ b/ui/ui-common/src/main/res/values-it/strings.xml
@@ -1359,4 +1359,11 @@
     <string name="birthdays_delete_selected_permanently">Eliminare %1$d compleanni definitivamente?</string>
     <string name="agenda_delete_selected_permanently">Eliminare %1$d elementi definitivamente?</string>
     <string name="selected_count">%1$d selezionati</string>
+    <string name="undo">Annulla</string>
+    <string name="note_deleted">Nota eliminata</string>
+    <string name="notes_deleted_count">%1$d note eliminate</string>
+    <string name="birthday_deleted">Compleanno eliminato</string>
+    <string name="birthdays_deleted_count">%1$d compleanni eliminati</string>
+    <string name="reminder_deleted">Promemoria eliminato</string>
+    <string name="reminders_deleted_count">%1$d promemoria eliminati</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-ja/strings.xml
+++ b/ui/ui-common/src/main/res/values-ja/strings.xml
@@ -1359,4 +1359,11 @@
     <string name="birthdays_delete_selected_permanently">%1$d件の誕生日を完全に削除しますか?</string>
     <string name="agenda_delete_selected_permanently">%1$d件のアイテムを完全に削除しますか?</string>
     <string name="selected_count">%1$d件選択中</string>
+    <string name="undo">元に戻す</string>
+    <string name="note_deleted">メモを削除しました</string>
+    <string name="notes_deleted_count">%1$d 件のメモを削除しました</string>
+    <string name="birthday_deleted">誕生日を削除しました</string>
+    <string name="birthdays_deleted_count">%1$d 件の誕生日を削除しました</string>
+    <string name="reminder_deleted">リマインダーを削除しました</string>
+    <string name="reminders_deleted_count">%1$d 件のリマインダーを削除しました</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-ko/strings.xml
+++ b/ui/ui-common/src/main/res/values-ko/strings.xml
@@ -1359,4 +1359,11 @@
     <string name="birthdays_delete_selected_permanently">%1$d개의 생일을 영구 삭제하시겠습니까?</string>
     <string name="agenda_delete_selected_permanently">%1$d개의 항목을 영구 삭제하시겠습니까?</string>
     <string name="selected_count">%1$d개 선택됨</string>
+    <string name="undo">실행 취소</string>
+    <string name="note_deleted">메모가 삭제되었습니다</string>
+    <string name="notes_deleted_count">메모 %1$d개가 삭제되었습니다</string>
+    <string name="birthday_deleted">생일이 삭제되었습니다</string>
+    <string name="birthdays_deleted_count">생일 %1$d개가 삭제되었습니다</string>
+    <string name="reminder_deleted">리마인더가 삭제되었습니다</string>
+    <string name="reminders_deleted_count">리마인더 %1$d개가 삭제되었습니다</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-nb/strings.xml
+++ b/ui/ui-common/src/main/res/values-nb/strings.xml
@@ -1357,4 +1357,11 @@
     <string name="birthdays_delete_selected_permanently">Slette %1$d bursdager permanent?</string>
     <string name="agenda_delete_selected_permanently">Slette %1$d elementer permanent?</string>
     <string name="selected_count">%1$d valgt</string>
+    <string name="undo">Angre</string>
+    <string name="note_deleted">Notat slettet</string>
+    <string name="notes_deleted_count">%1$d notater slettet</string>
+    <string name="birthday_deleted">Bursdag slettet</string>
+    <string name="birthdays_deleted_count">%1$d bursdager slettet</string>
+    <string name="reminder_deleted">Påminnelse slettet</string>
+    <string name="reminders_deleted_count">%1$d påminnelser slettet</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-nl/strings.xml
+++ b/ui/ui-common/src/main/res/values-nl/strings.xml
@@ -1357,4 +1357,11 @@
     <string name="birthdays_delete_selected_permanently">%1$d verjaardagen permanent verwijderen?</string>
     <string name="agenda_delete_selected_permanently">%1$d items permanent verwijderen?</string>
     <string name="selected_count">%1$d geselecteerd</string>
+    <string name="undo">Ongedaan maken</string>
+    <string name="note_deleted">Notitie verwijderd</string>
+    <string name="notes_deleted_count">%1$d notities verwijderd</string>
+    <string name="birthday_deleted">Verjaardag verwijderd</string>
+    <string name="birthdays_deleted_count">%1$d verjaardagen verwijderd</string>
+    <string name="reminder_deleted">Herinnering verwijderd</string>
+    <string name="reminders_deleted_count">%1$d herinneringen verwijderd</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-pl/strings.xml
+++ b/ui/ui-common/src/main/res/values-pl/strings.xml
@@ -1359,4 +1359,11 @@
     <string name="birthdays_delete_selected_permanently">Usunąć %1$d urodzin na stałe?</string>
     <string name="agenda_delete_selected_permanently">Usunąć %1$d elementów na stałe?</string>
     <string name="selected_count">Zaznaczono %1$d</string>
+    <string name="undo">Cofnij</string>
+    <string name="note_deleted">Notatka usunięta</string>
+    <string name="notes_deleted_count">Usunięto %1$d notatek</string>
+    <string name="birthday_deleted">Urodziny usunięte</string>
+    <string name="birthdays_deleted_count">Usunięto %1$d urodzin</string>
+    <string name="reminder_deleted">Przypomnienie usunięte</string>
+    <string name="reminders_deleted_count">Usunięto %1$d przypomnień</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-pt/strings.xml
+++ b/ui/ui-common/src/main/res/values-pt/strings.xml
@@ -1359,4 +1359,11 @@
     <string name="birthdays_delete_selected_permanently">Excluir %1$d aniversários permanentemente?</string>
     <string name="agenda_delete_selected_permanently">Excluir %1$d itens permanentemente?</string>
     <string name="selected_count">%1$d selecionados</string>
+    <string name="undo">Desfazer</string>
+    <string name="note_deleted">Nota excluída</string>
+    <string name="notes_deleted_count">%1$d notas excluídas</string>
+    <string name="birthday_deleted">Aniversário excluído</string>
+    <string name="birthdays_deleted_count">%1$d aniversários excluídos</string>
+    <string name="reminder_deleted">Lembrete excluído</string>
+    <string name="reminders_deleted_count">%1$d lembretes excluídos</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-ro/strings.xml
+++ b/ui/ui-common/src/main/res/values-ro/strings.xml
@@ -1359,4 +1359,11 @@
     <string name="birthdays_delete_selected_permanently">Ștergere %1$d zile de naștere permanent?</string>
     <string name="agenda_delete_selected_permanently">Ștergere %1$d elemente permanent?</string>
     <string name="selected_count">%1$d selectate</string>
+    <string name="undo">Anulează</string>
+    <string name="note_deleted">Notă ștearsă</string>
+    <string name="notes_deleted_count">%1$d notițe șterse</string>
+    <string name="birthday_deleted">Zi de naștere ștearsă</string>
+    <string name="birthdays_deleted_count">%1$d zile de naștere șterse</string>
+    <string name="reminder_deleted">Memento șters</string>
+    <string name="reminders_deleted_count">%1$d mementouri șterse</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-ru/strings.xml
+++ b/ui/ui-common/src/main/res/values-ru/strings.xml
@@ -1358,4 +1358,11 @@
     <string name="birthdays_delete_selected_permanently">Удалить %1$d дней рождения навсегда?</string>
     <string name="agenda_delete_selected_permanently">Удалить %1$d элементов навсегда?</string>
     <string name="selected_count">Выбрано %1$d</string>
+    <string name="undo">Отменить</string>
+    <string name="note_deleted">Заметка удалена</string>
+    <string name="notes_deleted_count">Удалено заметок: %1$d</string>
+    <string name="birthday_deleted">День рождения удалён</string>
+    <string name="birthdays_deleted_count">Удалено дней рождения: %1$d</string>
+    <string name="reminder_deleted">Напоминание удалено</string>
+    <string name="reminders_deleted_count">Удалено напоминаний: %1$d</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-sv/strings.xml
+++ b/ui/ui-common/src/main/res/values-sv/strings.xml
@@ -1357,4 +1357,11 @@
     <string name="birthdays_delete_selected_permanently">Ta bort %1$d födelsedagar permanent?</string>
     <string name="agenda_delete_selected_permanently">Ta bort %1$d objekt permanent?</string>
     <string name="selected_count">%1$d valda</string>
+    <string name="undo">Ångra</string>
+    <string name="note_deleted">Anteckning raderad</string>
+    <string name="notes_deleted_count">%1$d anteckningar raderade</string>
+    <string name="birthday_deleted">Födelsedag raderad</string>
+    <string name="birthdays_deleted_count">%1$d födelsedagar raderade</string>
+    <string name="reminder_deleted">Påminnelse raderad</string>
+    <string name="reminders_deleted_count">%1$d påminnelser raderade</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-th/strings.xml
+++ b/ui/ui-common/src/main/res/values-th/strings.xml
@@ -1357,4 +1357,11 @@
     <string name="birthdays_delete_selected_permanently">ลบ %1$d วันเกิดอย่างถาวร?</string>
     <string name="agenda_delete_selected_permanently">ลบ %1$d รายการอย่างถาวร?</string>
     <string name="selected_count">เลือก %1$d รายการแล้ว</string>
+    <string name="undo">เลิกทำ</string>
+    <string name="note_deleted">ลบโน้ตแล้ว</string>
+    <string name="notes_deleted_count">ลบโน้ตแล้ว %1$d รายการ</string>
+    <string name="birthday_deleted">ลบวันเกิดแล้ว</string>
+    <string name="birthdays_deleted_count">ลบวันเกิดแล้ว %1$d รายการ</string>
+    <string name="reminder_deleted">ลบการแจ้งเตือนแล้ว</string>
+    <string name="reminders_deleted_count">ลบการแจ้งเตือนแล้ว %1$d รายการ</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-tr/strings.xml
+++ b/ui/ui-common/src/main/res/values-tr/strings.xml
@@ -1360,4 +1360,11 @@
     <string name="birthdays_delete_selected_permanently">%1$d doğum günü kalıcı olarak silinsin mi?</string>
     <string name="agenda_delete_selected_permanently">%1$d öğe kalıcı olarak silinsin mi?</string>
     <string name="selected_count">%1$d seçildi</string>
+    <string name="undo">Geri al</string>
+    <string name="note_deleted">Not silindi</string>
+    <string name="notes_deleted_count">%1$d not silindi</string>
+    <string name="birthday_deleted">Doğum günü silindi</string>
+    <string name="birthdays_deleted_count">%1$d doğum günü silindi</string>
+    <string name="reminder_deleted">Hatırlatıcı silindi</string>
+    <string name="reminders_deleted_count">%1$d hatırlatıcı silindi</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-uk/strings.xml
+++ b/ui/ui-common/src/main/res/values-uk/strings.xml
@@ -1360,4 +1360,11 @@
     <string name="birthdays_delete_selected_permanently">Видалити %1$d днів народження назавжди?</string>
     <string name="agenda_delete_selected_permanently">Видалити %1$d елементів назавжди?</string>
     <string name="selected_count">Вибрано %1$d</string>
+    <string name="undo">Скасувати</string>
+    <string name="note_deleted">Нотатку видалено</string>
+    <string name="notes_deleted_count">Видалено нотаток: %1$d</string>
+    <string name="birthday_deleted">День народження видалено</string>
+    <string name="birthdays_deleted_count">Видалено днів народження: %1$d</string>
+    <string name="reminder_deleted">Нагадування видалено</string>
+    <string name="reminders_deleted_count">Видалено нагадувань: %1$d</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-vi/strings.xml
+++ b/ui/ui-common/src/main/res/values-vi/strings.xml
@@ -1357,4 +1357,11 @@
     <string name="birthdays_delete_selected_permanently">Xóa vĩnh viễn %1$d sinh nhật?</string>
     <string name="agenda_delete_selected_permanently">Xóa vĩnh viễn %1$d mục?</string>
     <string name="selected_count">Đã chọn %1$d</string>
+    <string name="undo">Hoàn tác</string>
+    <string name="note_deleted">Đã xóa ghi chú</string>
+    <string name="notes_deleted_count">Đã xóa %1$d ghi chú</string>
+    <string name="birthday_deleted">Đã xóa ngày sinh nhật</string>
+    <string name="birthdays_deleted_count">Đã xóa %1$d ngày sinh nhật</string>
+    <string name="reminder_deleted">Đã xóa lời nhắc</string>
+    <string name="reminders_deleted_count">Đã xóa %1$d lời nhắc</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-zh/strings.xml
+++ b/ui/ui-common/src/main/res/values-zh/strings.xml
@@ -1360,4 +1360,11 @@
     <string name="birthdays_delete_selected_permanently">永久删除 %1$d 个生日?</string>
     <string name="agenda_delete_selected_permanently">永久删除 %1$d 项?</string>
     <string name="selected_count">已选择 %1$d 项</string>
+    <string name="undo">撤销</string>
+    <string name="note_deleted">笔记已删除</string>
+    <string name="notes_deleted_count">已删除 %1$d 条笔记</string>
+    <string name="birthday_deleted">生日已删除</string>
+    <string name="birthdays_deleted_count">已删除 %1$d 个生日</string>
+    <string name="reminder_deleted">提醒已删除</string>
+    <string name="reminders_deleted_count">已删除 %1$d 条提醒</string>
 </resources>

--- a/ui/ui-common/src/main/res/values/strings.xml
+++ b/ui/ui-common/src/main/res/values/strings.xml
@@ -1363,4 +1363,11 @@
     <string name="birthdays_delete_selected_permanently">Delete %1$d birthdays permanently?</string>
     <string name="agenda_delete_selected_permanently">Delete %1$d items permanently?</string>
     <string name="selected_count">%1$d selected</string>
+    <string name="undo">Undo</string>
+    <string name="note_deleted">Note deleted</string>
+    <string name="notes_deleted_count">%1$d notes deleted</string>
+    <string name="birthday_deleted">Birthday deleted</string>
+    <string name="birthdays_deleted_count">%1$d birthdays deleted</string>
+    <string name="reminder_deleted">Reminder deleted</string>
+    <string name="reminders_deleted_count">%1$d reminders deleted</string>
 </resources>


### PR DESCRIPTION
## Summary

Implements the Trello card ["Undo on delete (reminders, notes, birthdays)"](https://trello.com/c/xfKfNOLG): deletes on the Notes list, Birthdays list, and the Reminders archive screen now show a **"Deleted — Undo"** Snackbar instead of deleting immediately.

- Tapping delete (single or bulk) hides the item(s) from the list right away and shows a Snackbar with an **Undo** action.
- Tapping **Undo** cancels the pending delete — nothing was ever removed from the database.
- Letting the Snackbar's ~4s window elapse (Material 3's `SnackbarDuration.Short`) commits the delete for real.
- A newly-shown Snackbar dismisses whatever is currently displayed (so back-to-back deletes only ever grant an undo window for the most recent one — the same behavior most list apps use).

**Scope note:** reminders' normal "delete" already routes through the existing non-destructive archive/trash flow (`MoveReminderToArchiveUseCase`) for most screens, which is itself a form of undo (nothing is destroyed until a later, separate action). This PR adds the Snackbar+Undo treatment to the genuinely permanent, no-safety-net delete paths: the **Notes** list (no trash concept at all), the **Birthdays** list (same), and the **Reminders Archive screen**'s own delete/"delete all" (the one place a reminder is actually, permanently removed). Preview/Edit-screen deletes and the Agenda screen's mixed bulk delete are left as-is for this PR, since correctly hoisting a Snackbar across a delete-then-navigate-away flow is a separate, larger design problem (the Snackbar needs a host that outlives the screen that triggered it) — noted here as a natural follow-up rather than folded into this change.

## What changed

- **`core:feature-common`** — new `PendingDeleteTracker`: tracks which ids are optimistically hidden per delete "batch" (keyed so a single delete and a bulk delete can be pending independently), and runs a caller-supplied commit action only when told to (never on its own timer).
- **`ui:ui-common`** — new `UndoSnackbarDispatcher` / `rememberUndoSnackbarDispatcher`, mirroring the existing `ToastDispatcher`/`DialogDispatcher` pattern already used in this codebase. The Snackbar's own duration is the single source of truth for the undo window — there's no separate timer to keep in sync.
- **`feature-note`**, **`feature-birthday`**, **`feature-reminder`** — wired the tracker + dispatcher into `NotesViewModel`/`BirthdaysViewModel`/`RemindersArchiveViewModel` (combine the tracker's pending-ids into each screen's reactively-observed list) and their Compose screens/nav graphs (added a `SnackbarHost` to each `Scaffold`).
- **`ui-common` strings** — added `undo`, `note_deleted`/`notes_deleted_count`, `birthday_deleted`/`birthdays_deleted_count`, `reminder_deleted`/`reminders_deleted_count`, translated into all 25 shipped locales.
- Updated existing unit tests for the three touched ViewModels to match the new deferred-delete contract (delete now optimistically hides + defers instead of deleting synchronously), and added tests for `PendingDeleteTracker` and the new undo/commit/ShowUndoDelete behavior.

## Test plan

- [x] Reviewed every touched file end-to-end for correctness (imports, exhaustive `when` blocks, Koin DI wiring for the new `TextProvider` dependency on `RemindersArchiveViewModel`).
- [x] Updated/added unit tests for `NotesViewModel`, `BirthdaysViewModel`, `RemindersArchiveViewModel`, and the new `PendingDeleteTracker` covering: optimistic hide without deleting, `ShowUndoDelete` event content, undo cancels the pending delete, commit performs the real delete (single + bulk), and commit after undo is a no-op.
- [ ] Could not run `./gradlew testProDebugUnitTest` / `assembleProDebug` in this sandbox — the project's Gradle toolchain resolution requires downloading a JetBrains-vendor JDK from `api.foojay.io`, which this session's egress policy blocks with a 403 (a deliberate org policy denial, not something to route around). Please run the test suite before merging.
- [ ] Manual on-device verification (delete a note/birthday/archived reminder, confirm the Snackbar shows, tap Undo and confirm the item reappears, let it time out and confirm it's actually gone) not done — no device/emulator available in this sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eNCF8R8txCM65KqB4THqc

---
_Generated by [Claude Code](https://claude.ai/code/session_013eNCF8R8txCM65KqB4THqc)_