### PR TITLE
fix: exclude ColorSlider from system back-gesture interception

### DIFF
--- a/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/component/ColorSlider.kt
+++ b/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/component/ColorSlider.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.systemGestureExclusion
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.ProgressBarRangeInfo
@@ -53,15 +54,17 @@ fun ColorSlider(
   val currentOnColorSelected by rememberUpdatedState(onColorSelected)
   val currentSelectedIndex by rememberUpdatedState(selectedIndex)
   val gestureModifier = if (enabled && colors.isNotEmpty()) {
-    Modifier.pointerInput(colors.size) {
-      detectColorSliderDrag(
-        colorCount = colors.size,
-        hapticFeedbackEnabled = hapticFeedbackEnabled,
-        hapticFeedback = hapticFeedback,
-        selectedIndex = { currentSelectedIndex },
-        onColorSelected = currentOnColorSelected,
-      )
-    }
+    Modifier
+      .systemGestureExclusion()
+      .pointerInput(colors.size) {
+        detectColorSliderDrag(
+          colorCount = colors.size,
+          hapticFeedbackEnabled = hapticFeedbackEnabled,
+          hapticFeedback = hapticFeedback,
+          selectedIndex = { currentSelectedIndex },
+          onColorSelected = currentOnColorSelected,
+        )
+      }
   } else {
     Modifier
   }

--- a/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/component/ColorSlider.kt
+++ b/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/component/ColorSlider.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.systemGestureExclusion
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -20,7 +21,6 @@ import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.input.pointer.systemGestureExclusion
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.ProgressBarRangeInfo


### PR DESCRIPTION
ColorSlider's drag gesture is a raw pointerInput on a full-width Canvas,
so when the slider sits near a screen edge (color pickers, routine/map
pickers), the OS predictive-back edge-swipe zone can intercept the touch
before it reaches the slider. Add systemGestureExclusion() to the
slider's gesture area so its own drag always wins over the system
back gesture.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AX7Z5vrLbEYBudiDRKjCYh