### PR TITLE
feat: add priority x urgency matrix view to the Agenda screen

### DIFF
--- a/app/src/main/java/com/elementary/tasks/core/utils/params/Prefs.kt
+++ b/app/src/main/java/com/elementary/tasks/core/utils/params/Prefs.kt
@@ -463,6 +463,10 @@ class Prefs(
     get() = getString(PrefsConstants.CALENDAR_VIEW_MODE, def = "")
     set(value) = putString(PrefsConstants.CALENDAR_VIEW_MODE, value)
 
+  var agendaViewMode: String
+    get() = getString(PrefsConstants.AGENDA_VIEW_MODE, def = "")
+    set(value) = putString(PrefsConstants.AGENDA_VIEW_MODE, value)
+
   var isBirthdayReminderEnabled: Boolean
     get() = getBoolean(PrefsConstants.BIRTHDAY_REMINDER, def = true)
     set(value) = putBoolean(PrefsConstants.BIRTHDAY_REMINDER, value)

--- a/app/src/main/java/com/elementary/tasks/core/utils/params/PrefsConstants.kt
+++ b/app/src/main/java/com/elementary/tasks/core/utils/params/PrefsConstants.kt
@@ -137,6 +137,7 @@ object PrefsConstants {
   const val AI_DIGEST_HOUR = "ai_digest_hour"
 
   const val CALENDAR_VIEW_MODE = "calendar_view_mode"
+  const val AGENDA_VIEW_MODE = "agenda_view_mode"
 
   const val HEADER_NAVIGATION_ORDER = "header_navigation_order"
   const val DISABLED_HEADER_NAVIGATION_SECTIONS = "disabled_header_navigation_sections"

--- a/app/src/main/java/com/elementary/tasks/module/logicreminder/ReminderPreferencesImpl.kt
+++ b/app/src/main/java/com/elementary/tasks/module/logicreminder/ReminderPreferencesImpl.kt
@@ -1,6 +1,7 @@
 package com.elementary.tasks.module.logicreminder
 
 import com.elementary.tasks.core.utils.params.Prefs
+import com.github.naz013.logic.reminder.AgendaViewMode
 import com.github.naz013.logic.reminder.ReminderPreferences
 
 class ReminderPreferencesImpl(
@@ -143,4 +144,10 @@ class ReminderPreferencesImpl(
   override var initDefaultPresets: Boolean
     get() = prefs.initDefaultPresets
     set(value) { prefs.initDefaultPresets = value }
+
+  // Stored as the enum name (not ordinal) so reordering AgendaViewMode can't silently remap a
+  // saved preference; an unknown/empty stored value falls back to LIST.
+  override var agendaViewMode: AgendaViewMode
+    get() = runCatching { AgendaViewMode.valueOf(prefs.agendaViewMode) }.getOrDefault(AgendaViewMode.LIST)
+    set(value) { prefs.agendaViewMode = value.name }
 }

--- a/app/src/main/java/com/elementary/tasks/settings/SettingsCrossFeatureEntries.kt
+++ b/app/src/main/java/com/elementary/tasks/settings/SettingsCrossFeatureEntries.kt
@@ -133,6 +133,7 @@ fun RemindersCrossFeatureEntry(
         onLocationClick = viewModel::onLocationClick,
         onWorkflowRulesClick = viewModel::onWorkflowRulesClick,
         onPriorityClick = viewModel::onPriorityClick,
+        onAgendaViewModeToggle = viewModel::onAgendaViewModeToggle,
         onCompletedToggle = viewModel::onCompletedToggle,
         onWearToggle = viewModel::onWearToggle,
         onSnoozeClick = viewModel::onSnoozeClick,

--- a/feature/feature-agenda/src/main/kotlin/com/github/naz013/feature/agenda/AgendaNavGraph.kt
+++ b/feature/feature-agenda/src/main/kotlin/com/github/naz013/feature/agenda/AgendaNavGraph.kt
@@ -204,5 +204,6 @@ private fun AgendaEntry(
     onSelectionCancel = viewModel::onSelectionCancel,
     onDeleteSelectedClick = viewModel::onDeleteSelectedClick,
     onArchiveSelectedClick = viewModel::onArchiveSelectedClick,
+    onViewModeToggle = viewModel::onViewModeToggle,
   )
 }

--- a/feature/feature-agenda/src/main/kotlin/com/github/naz013/feature/agenda/AgendaScreen.kt
+++ b/feature/feature-agenda/src/main/kotlin/com/github/naz013/feature/agenda/AgendaScreen.kt
@@ -2,6 +2,7 @@ package com.github.naz013.feature.agenda
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,7 +16,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
@@ -38,12 +42,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.github.naz013.domain.Tag
 import com.github.naz013.domain.reminder.v2.GroupV2
+import com.github.naz013.logic.reminder.AgendaViewMode
 import com.github.naz013.logic.reminder.smartlist.SmartListFilter
 import com.github.naz013.ui.agenda.AgendaCategory
 import com.github.naz013.ui.agenda.AgendaMenuAction
@@ -91,6 +97,7 @@ internal fun AgendaScreen(
   onSelectionCancel: () -> Unit,
   onDeleteSelectedClick: () -> Unit,
   onArchiveSelectedClick: () -> Unit,
+  onViewModeToggle: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
   val lazyListState = rememberLazyListState()
@@ -158,6 +165,8 @@ internal fun AgendaScreen(
               onTagsClick = onTagsClick,
               onFilterClick = { showFilterSheet = true },
               hasActiveFilters = hasActiveFilters,
+              viewMode = state.viewMode,
+              onViewModeToggle = onViewModeToggle,
             )
 
             if (state.hasAnyItems) {
@@ -203,17 +212,34 @@ internal fun AgendaScreen(
         }
 
         is ListState.Ready -> {
-          AgendaList(
-            items = listState.items,
-            lazyListState = lazyListState,
-            isSelectionMode = isSelectionMode,
-            onItemClick = onItemClick,
-            onItemLongClick = onItemLongClick,
-            onAgendaMenuAction = onAgendaMenuAction,
-            modifier = Modifier
-              .fillMaxSize()
-              .weight(1f),
-          )
+          when (state.viewMode) {
+            AgendaViewMode.LIST -> {
+              AgendaList(
+                items = listState.items,
+                lazyListState = lazyListState,
+                isSelectionMode = isSelectionMode,
+                onItemClick = onItemClick,
+                onItemLongClick = onItemLongClick,
+                onAgendaMenuAction = onAgendaMenuAction,
+                modifier = Modifier
+                  .fillMaxSize()
+                  .weight(1f),
+              )
+            }
+
+            AgendaViewMode.MATRIX -> {
+              AgendaMatrixView(
+                reminders = listState.items.filterIsInstance<UiAgendaReminder>(),
+                isSelectionMode = isSelectionMode,
+                onItemClick = onItemClick,
+                onItemLongClick = onItemLongClick,
+                onAgendaMenuAction = onAgendaMenuAction,
+                modifier = Modifier
+                  .fillMaxSize()
+                  .weight(1f),
+              )
+            }
+          }
         }
       }
     }
@@ -384,6 +410,95 @@ private fun AgendaList(
   }
 }
 
+/**
+ * Alternate, priority x urgency layout for the same filtered reminder set [AgendaList] renders -
+ * birthdays are excluded since they carry no priority concept to classify by. Cells are plain
+ * (non-lazy) columns inside one scrolling [LazyVerticalGrid] rather than each having its own
+ * nested scroll state, which keeps a quadrant with many reminders from fighting the grid for
+ * scroll gestures.
+ */
+@Composable
+private fun AgendaMatrixView(
+  reminders: List<UiAgendaReminder>,
+  isSelectionMode: Boolean,
+  onItemClick: (UiAgendaItem) -> Unit,
+  onItemLongClick: (String) -> Unit,
+  onAgendaMenuAction: (UiAgendaItem, AgendaMenuAction) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val groups = remember(reminders) { classifyIntoQuadrants(reminders) }
+  if (groups.values.all { it.isEmpty() }) {
+    EmptyState(
+      icon = AppIcons.Fluent.CalendarAgenda,
+      message = stringResource(R.string.no_events),
+      modifier = modifier,
+    )
+    return
+  }
+  LazyVerticalGrid(
+    columns = GridCells.Fixed(2),
+    modifier = modifier,
+    contentPadding = PaddingValues(12.dp),
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+    verticalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    EisenhowerQuadrant.entries.forEach { quadrant ->
+      item(key = quadrant.name) {
+        MatrixQuadrantCell(
+          quadrant = quadrant,
+          items = groups[quadrant].orEmpty(),
+          isSelectionMode = isSelectionMode,
+          onItemClick = onItemClick,
+          onItemLongClick = onItemLongClick,
+          onAgendaMenuAction = onAgendaMenuAction,
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun MatrixQuadrantCell(
+  quadrant: EisenhowerQuadrant,
+  items: List<UiAgendaReminder>,
+  isSelectionMode: Boolean,
+  onItemClick: (UiAgendaItem) -> Unit,
+  onItemLongClick: (String) -> Unit,
+  onAgendaMenuAction: (UiAgendaItem, AgendaMenuAction) -> Unit,
+) {
+  Column(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clip(RoundedCornerShape(12.dp))
+      .background(MaterialTheme.colorScheme.surfaceContainerLow)
+      .padding(8.dp),
+    verticalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    Text(
+      text = "${stringResource(quadrant.titleRes())} (${items.size})",
+      style = MaterialTheme.typography.titleSmall,
+    )
+    items.forEach { item ->
+      ReminderAgendaRow(
+        item = item,
+        onClick = { onItemClick(item) },
+        onMenuAction = { action -> onAgendaMenuAction(item, action) },
+        onLongClick = { onItemLongClick(item.id) },
+        isSelectionMode = isSelectionMode,
+        onToggleSelected = { onItemClick(item) },
+      )
+    }
+  }
+}
+
+private fun EisenhowerQuadrant.titleRes(): Int =
+  when (this) {
+    EisenhowerQuadrant.DO_FIRST -> R.string.agenda_matrix_do_first
+    EisenhowerQuadrant.SCHEDULE -> R.string.agenda_matrix_schedule
+    EisenhowerQuadrant.DELEGATE -> R.string.agenda_matrix_delegate
+    EisenhowerQuadrant.SOMEDAY -> R.string.agenda_matrix_someday
+  }
+
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun CategoryChipRow(
@@ -553,6 +668,8 @@ private fun AgendaTopBar(
   onTagsClick: () -> Unit,
   onFilterClick: () -> Unit,
   hasActiveFilters: Boolean,
+  viewMode: AgendaViewMode,
+  onViewModeToggle: () -> Unit,
 ) {
   TopAppBar(
     title = { Text(stringResource(R.string.agenda)) },
@@ -568,6 +685,15 @@ private fun AgendaTopBar(
         onAddReminderClick = onAddReminderClick,
         onAddTodoClick = onAddTodoClick,
         onAddBirthdayClick = onAddBirthdayClick,
+      )
+      MenuIconButton(
+        icon = if (viewMode == AgendaViewMode.LIST) AppIcons.Fluent.Grid else AppIcons.Fluent.List,
+        contentDescription = if (viewMode == AgendaViewMode.LIST) {
+          stringResource(R.string.agenda_matrix_view)
+        } else {
+          stringResource(R.string.agenda_list_view)
+        },
+        onClick = onViewModeToggle,
       )
       BadgedBox(
         badge = { if (hasActiveFilters) Badge() },
@@ -689,6 +815,7 @@ private fun AgendaScreenEmptyPreview() {
       onSelectionCancel = {},
       onDeleteSelectedClick = {},
       onArchiveSelectedClick = {},
+      onViewModeToggle = {},
     )
   }
 }

--- a/feature/feature-agenda/src/main/kotlin/com/github/naz013/feature/agenda/AgendaScreenState.kt
+++ b/feature/feature-agenda/src/main/kotlin/com/github/naz013/feature/agenda/AgendaScreenState.kt
@@ -2,6 +2,7 @@ package com.github.naz013.feature.agenda
 
 import com.github.naz013.domain.Tag
 import com.github.naz013.domain.reminder.v2.GroupV2
+import com.github.naz013.logic.reminder.AgendaViewMode
 import com.github.naz013.logic.reminder.smartlist.SmartListFilter
 import com.github.naz013.ui.agenda.AgendaCategory
 import com.github.naz013.ui.agenda.UiAgendaBirthday
@@ -20,6 +21,7 @@ internal data class AgendaScreenState(
   val availableGroups: List<GroupV2> = emptyList(),
   val todayScrollTargetId: String? = null,
   val selectedCount: Int = 0,
+  val viewMode: AgendaViewMode = AgendaViewMode.LIST,
 )
 
 internal fun AgendaScreenState.withSelectedItem(selectedItemId: String?): AgendaScreenState {

--- a/feature/feature-agenda/src/main/kotlin/com/github/naz013/feature/agenda/AgendaViewModel.kt
+++ b/feature/feature-agenda/src/main/kotlin/com/github/naz013/feature/agenda/AgendaViewModel.kt
@@ -19,6 +19,8 @@ import com.github.naz013.domain.TaggedItemType
 import com.github.naz013.domain.reminder.v2.GroupV2
 import com.github.naz013.domain.reminder.v2.ReminderAction
 import com.github.naz013.domain.reminder.v2.ReminderV2
+import com.github.naz013.logic.reminder.AgendaViewMode
+import com.github.naz013.logic.reminder.ReminderPreferences
 import com.github.naz013.feature.common.coroutine.DispatcherProvider
 import com.github.naz013.feature.common.livedata.Event
 import com.github.naz013.feature.common.viewmodel.mutableLiveEventOf
@@ -72,9 +74,10 @@ internal class AgendaViewModel(
   private val togglePinnedReminderUseCase: TogglePinnedReminderUseCase,
   private val deleteReminderUseCase: DeleteReminderUseCase,
   private val deleteBirthdayUseCase: DeleteBirthdayUseCase,
+  private val reminderPreferences: ReminderPreferences,
 ) : ViewModel() {
 
-  private val _agendaScreenState = MutableStateFlow(AgendaScreenState())
+  private val _agendaScreenState = MutableStateFlow(AgendaScreenState(viewMode = reminderPreferences.agendaViewMode))
   private val _selectedItemId = MutableStateFlow<String?>(null)
   val agendaScreenState = combine(_agendaScreenState, _selectedItemId, AgendaScreenState::withSelectedItem)
     .stateInWhileSubscribed(AgendaScreenState())
@@ -273,6 +276,16 @@ internal class AgendaViewModel(
 
   fun onScrolledToToday() {
     hasScrolledToToday = true
+  }
+
+  fun onViewModeToggle() {
+    val newMode = if (_agendaScreenState.value.viewMode == AgendaViewMode.LIST) {
+      AgendaViewMode.MATRIX
+    } else {
+      AgendaViewMode.LIST
+    }
+    reminderPreferences.agendaViewMode = newMode
+    _agendaScreenState.update { it.copy(viewMode = newMode) }
   }
 
   fun onSelectedItemIdChanged(id: String?) {

--- a/feature/feature-agenda/src/main/kotlin/com/github/naz013/feature/agenda/EisenhowerQuadrant.kt
+++ b/feature/feature-agenda/src/main/kotlin/com/github/naz013/feature/agenda/EisenhowerQuadrant.kt
@@ -1,0 +1,9 @@
+package com.github.naz013.feature.agenda
+
+/** The four cells of the Agenda screen's Matrix view - see [classifyIntoQuadrants]. */
+internal enum class EisenhowerQuadrant {
+  DO_FIRST,
+  SCHEDULE,
+  DELEGATE,
+  SOMEDAY,
+}

--- a/feature/feature-agenda/src/main/kotlin/com/github/naz013/feature/agenda/MatrixClassifier.kt
+++ b/feature/feature-agenda/src/main/kotlin/com/github/naz013/feature/agenda/MatrixClassifier.kt
@@ -1,0 +1,32 @@
+package com.github.naz013.feature.agenda
+
+import com.github.naz013.domain.reminder.v2.ReminderPriority
+import com.github.naz013.ui.agenda.UiAgendaReminder
+import org.threeten.bp.LocalDate
+
+/**
+ * Groups reminders into Eisenhower quadrants using only data [UiAgendaReminder] already carries -
+ * priority as the importance axis, and overdue/due-today as the urgency axis - so the Matrix view
+ * needs no data beyond what the chronological Agenda list already resolves per reminder.
+ */
+internal fun classifyIntoQuadrants(
+  reminders: List<UiAgendaReminder>,
+  today: LocalDate = LocalDate.now(),
+): Map<EisenhowerQuadrant, List<UiAgendaReminder>> =
+  EisenhowerQuadrant.entries.associateWith { quadrant ->
+    reminders.filter { quadrantOf(it, today) == quadrant }.sortedBy { it.dateTime }
+  }
+
+private fun quadrantOf(
+  reminder: UiAgendaReminder,
+  today: LocalDate,
+): EisenhowerQuadrant {
+  val important = reminder.priority == ReminderPriority.HIGH || reminder.priority == ReminderPriority.HIGHEST
+  val urgent = reminder.isOverdue || reminder.dateTime.toLocalDate() == today
+  return when {
+    important && urgent -> EisenhowerQuadrant.DO_FIRST
+    important && !urgent -> EisenhowerQuadrant.SCHEDULE
+    !important && urgent -> EisenhowerQuadrant.DELEGATE
+    else -> EisenhowerQuadrant.SOMEDAY
+  }
+}

--- a/feature/feature-agenda/src/test/kotlin/com/github/naz013/feature/agenda/AgendaViewModelTest.kt
+++ b/feature/feature-agenda/src/test/kotlin/com/github/naz013/feature/agenda/AgendaViewModelTest.kt
@@ -23,6 +23,8 @@ import com.github.naz013.domain.reminder.v2.ReminderAction
 import com.github.naz013.domain.reminder.v2.ReminderSchedule
 import com.github.naz013.domain.reminder.v2.ReminderV2
 import com.github.naz013.domain.sync.SyncState
+import com.github.naz013.logic.reminder.AgendaViewMode
+import com.github.naz013.logic.reminder.ReminderPreferences
 import com.github.naz013.logic.reminder.smartlist.SmartListFilter
 import com.github.naz013.logic.reminder.usecase.DeleteReminderUseCase
 import com.github.naz013.repository.BirthdayRepository
@@ -73,12 +75,14 @@ class AgendaViewModelTest : BaseTest() {
   private val deleteBirthdayUseCase = mockk<DeleteBirthdayUseCase>()
   private val birthdaySmartListPredicate = BirthdaySmartListPredicate(provideBirthdayDateCalculator())
   private val textProvider = mockk<TextProvider>(relaxed = true)
+  private val reminderPreferences = mockk<ReminderPreferences>(relaxed = true)
 
   private lateinit var viewModel: AgendaViewModel
 
   @Before
   override fun setUp() {
     super.setUp()
+    every { reminderPreferences.agendaViewMode } returns AgendaViewMode.LIST
     coEvery { groupV2Repository.getAll() } returns emptyList()
     // AgendaViewModel's init{} eagerly runs the load pipeline once on construction, and
     // mockDispatcherProvider() uses Dispatchers.Unconfined, so that eager call executes
@@ -122,6 +126,7 @@ class AgendaViewModelTest : BaseTest() {
         togglePinnedReminderUseCase = togglePinnedReminderUseCase,
         deleteReminderUseCase = deleteReminderUseCase,
         deleteBirthdayUseCase = deleteBirthdayUseCase,
+        reminderPreferences = reminderPreferences,
       )
 
     // Construction above already triggered one eager load via init{}. Clear recorded
@@ -482,6 +487,7 @@ class AgendaViewModelTest : BaseTest() {
       togglePinnedReminderUseCase = togglePinnedReminderUseCase,
       deleteReminderUseCase = deleteReminderUseCase,
       deleteBirthdayUseCase = deleteBirthdayUseCase,
+      reminderPreferences = reminderPreferences,
     )
   }
 

--- a/feature/feature-agenda/src/test/kotlin/com/github/naz013/feature/agenda/MatrixClassifierTest.kt
+++ b/feature/feature-agenda/src/test/kotlin/com/github/naz013/feature/agenda/MatrixClassifierTest.kt
@@ -1,0 +1,109 @@
+package com.github.naz013.feature.agenda
+
+import com.github.naz013.domain.reminder.v2.ReminderPriority
+import com.github.naz013.ui.agenda.AgendaCategory
+import com.github.naz013.ui.agenda.UiAgendaReminder
+import com.github.naz013.ui.common.text.UiTextElement
+import com.github.naz013.ui.common.text.UiTextFormat
+import com.github.naz013.ui.reminder.UiReminderListActions
+import com.github.naz013.ui.reminder.UiReminderListState
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.threeten.bp.LocalDate
+import org.threeten.bp.LocalDateTime
+
+class MatrixClassifierTest {
+
+  private val today: LocalDate = LocalDate.of(2026, 8, 2)
+
+  @Test
+  fun `high priority reminder due today lands in Do First`() {
+    val reminder = reminder(id = "r1", priority = ReminderPriority.HIGH, dateTime = today.atTime(9, 0))
+
+    val result = classifyIntoQuadrants(listOf(reminder), today)
+
+    assertEquals(listOf("r1"), result[EisenhowerQuadrant.DO_FIRST]?.map { it.id })
+  }
+
+  @Test
+  fun `highest priority overdue reminder lands in Do First even when due date is in the past`() {
+    val reminder = reminder(id = "r1", priority = ReminderPriority.HIGHEST, dateTime = today.minusDays(1).atTime(9, 0), isOverdue = true)
+
+    val result = classifyIntoQuadrants(listOf(reminder), today)
+
+    assertEquals(listOf("r1"), result[EisenhowerQuadrant.DO_FIRST]?.map { it.id })
+  }
+
+  @Test
+  fun `high priority reminder due later lands in Schedule`() {
+    val reminder = reminder(id = "r1", priority = ReminderPriority.HIGH, dateTime = today.plusDays(3).atTime(9, 0))
+
+    val result = classifyIntoQuadrants(listOf(reminder), today)
+
+    assertEquals(listOf("r1"), result[EisenhowerQuadrant.SCHEDULE]?.map { it.id })
+  }
+
+  @Test
+  fun `normal priority reminder due today lands in Delegate`() {
+    val reminder = reminder(id = "r1", priority = ReminderPriority.NORMAL, dateTime = today.atTime(9, 0))
+
+    val result = classifyIntoQuadrants(listOf(reminder), today)
+
+    assertEquals(listOf("r1"), result[EisenhowerQuadrant.DELEGATE]?.map { it.id })
+  }
+
+  @Test
+  fun `low priority reminder due later lands in Someday`() {
+    val reminder = reminder(id = "r1", priority = ReminderPriority.LOW, dateTime = today.plusDays(3).atTime(9, 0))
+
+    val result = classifyIntoQuadrants(listOf(reminder), today)
+
+    assertEquals(listOf("r1"), result[EisenhowerQuadrant.SOMEDAY]?.map { it.id })
+  }
+
+  @Test
+  fun `permanent reminder with no real due date lands in Someday when priority is not high`() {
+    val reminder = reminder(id = "r1", priority = ReminderPriority.NORMAL, dateTime = LocalDateTime.of(9999, 12, 28, 0, 0))
+
+    val result = classifyIntoQuadrants(listOf(reminder), today)
+
+    assertEquals(listOf("r1"), result[EisenhowerQuadrant.SOMEDAY]?.map { it.id })
+  }
+
+  @Test
+  fun `every quadrant key is present even when empty`() {
+    val result = classifyIntoQuadrants(emptyList(), today)
+
+    assertEquals(EisenhowerQuadrant.entries.toSet(), result.keys)
+    assertEquals(true, result.values.all { it.isEmpty() })
+  }
+
+  @Test
+  fun `sorts reminders within a quadrant chronologically`() {
+    val later = reminder(id = "later", priority = ReminderPriority.HIGH, dateTime = today.atTime(18, 0))
+    val earlier = reminder(id = "earlier", priority = ReminderPriority.HIGH, dateTime = today.atTime(8, 0))
+
+    val result = classifyIntoQuadrants(listOf(later, earlier), today)
+
+    assertEquals(listOf("earlier", "later"), result[EisenhowerQuadrant.DO_FIRST]?.map { it.id })
+  }
+
+  private fun reminder(
+    id: String,
+    priority: ReminderPriority,
+    dateTime: LocalDateTime,
+    isOverdue: Boolean = false,
+  ) = UiAgendaReminder(
+    id = id,
+    dateTime = dateTime,
+    category = AgendaCategory.REMINDERS,
+    mainText = UiTextElement(id, UiTextFormat(fontSize = 14f)),
+    secondaryText = null,
+    tertiaryText = null,
+    tags = emptyList(),
+    actions = UiReminderListActions(),
+    state = UiReminderListState(),
+    isOverdue = isOverdue,
+    priority = priority,
+  )
+}

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/settings/RemindersSettingsScreen.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/settings/RemindersSettingsScreen.kt
@@ -29,6 +29,7 @@ fun RemindersSettingsScreen(
   onLocationClick: () -> Unit,
   onWorkflowRulesClick: () -> Unit,
   onPriorityClick: () -> Unit,
+  onAgendaViewModeToggle: () -> Unit,
   onCompletedToggle: () -> Unit,
   onWearToggle: () -> Unit,
   onSnoozeClick: () -> Unit,
@@ -103,6 +104,16 @@ fun RemindersSettingsScreen(
       itemKey = SettingsSearchItemKeys.REMINDERS_PRIORITY,
       dividerBottom = true,
       onClick = onPriorityClick,
+    )
+    SettingsSwitchItem(
+      title = stringResource(R.string.agenda_default_view_title),
+      checked = state.isMatrixViewDefaultChecked,
+      onCheckedChange = { onAgendaViewModeToggle() },
+      subtitleOn = stringResource(R.string.agenda_matrix_view),
+      subtitleOff = stringResource(R.string.agenda_list_view),
+      icon = AppIcons.Fluent.Grid,
+      itemKey = SettingsSearchItemKeys.REMINDERS_AGENDA_VIEW_MODE,
+      dividerBottom = true,
     )
     SettingsSwitchItem(
       title = stringResource(R.string.completed_reminders),

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/settings/RemindersSettingsState.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/settings/RemindersSettingsState.kt
@@ -4,6 +4,7 @@ import org.threeten.bp.LocalTime
 
 data class RemindersSettingsState(
   val priorityName: String = "",
+  val isMatrixViewDefaultChecked: Boolean = false,
   val isCompletedChecked: Boolean = false,
   val isWearChecked: Boolean = false,
   val snoozeText: String = "",

--- a/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/settings/RemindersSettingsViewModel.kt
+++ b/feature/feature-reminder/src/main/kotlin/com/github/naz013/feature/reminder/settings/RemindersSettingsViewModel.kt
@@ -17,6 +17,7 @@ import com.github.naz013.common.system.BuildInfo
 import com.github.naz013.platform.SystemInfo
 import com.github.naz013.domain.reminder.v2.LockScreenVisibility
 import com.github.naz013.domain.reminder.v2.ReminderNotificationCategory
+import com.github.naz013.logic.reminder.AgendaViewMode
 import com.github.naz013.feature.common.livedata.Event
 import com.github.naz013.feature.common.viewmodel.mutableLiveEventOf
 import com.github.naz013.logic.workflow.WorkflowConfig
@@ -70,6 +71,15 @@ class RemindersSettingsViewModel(
 
   fun onCompletedToggle() {
     reminderPreferences.moveCompleted = !reminderPreferences.moveCompleted
+    refreshState()
+  }
+
+  fun onAgendaViewModeToggle() {
+    reminderPreferences.agendaViewMode = if (reminderPreferences.agendaViewMode == AgendaViewMode.MATRIX) {
+      AgendaViewMode.LIST
+    } else {
+      AgendaViewMode.MATRIX
+    }
     refreshState()
   }
 
@@ -380,6 +390,7 @@ class RemindersSettingsViewModel(
     val isPermanentNotificationChecked = reminderPreferences.isSbNotificationEnabled
     return RemindersSettingsState(
       priorityName = priorityOptions()[reminderPreferences.defaultPriority.coerceIn(0, 4)],
+      isMatrixViewDefaultChecked = reminderPreferences.agendaViewMode == AgendaViewMode.MATRIX,
       isCompletedChecked = reminderPreferences.moveCompleted,
       isWearChecked = reminderPreferences.isWearEnabled,
       snoozeText = minutesText(reminderPreferences.snoozeTime),

--- a/feature/feature-reminder/src/test/kotlin/com/github/naz013/feature/reminder/settings/reminders/RemindersSettingsViewModelTest.kt
+++ b/feature/feature-reminder/src/test/kotlin/com/github/naz013/feature/reminder/settings/reminders/RemindersSettingsViewModelTest.kt
@@ -2,6 +2,7 @@ package com.github.naz013.feature.reminder.settings.reminders
 
 import com.github.naz013.testing.BaseTest
 import com.github.naz013.ui.notification.settings.VibrationPlayer
+import com.github.naz013.logic.reminder.AgendaViewMode
 import com.github.naz013.logic.reminder.ReminderPreferences
 import com.github.naz013.analytics.AnalyticsEventSender
 import com.github.naz013.analytics.Feature
@@ -44,6 +45,7 @@ class RemindersSettingsViewModelTest : BaseTest() {
   override fun setUp() {
     super.setUp()
     every { reminderPreferences.defaultPriority } returns 2
+    every { reminderPreferences.agendaViewMode } returns AgendaViewMode.LIST
     every { reminderPreferences.moveCompleted } returns false
     every { reminderPreferences.isWearEnabled } returns false
     every { reminderPreferences.snoozeTime } returns 10

--- a/feature/feature-settings/src/main/kotlin/com/github/naz013/feature/settings/search/SettingsSearchIndex.kt
+++ b/feature/feature-settings/src/main/kotlin/com/github/naz013/feature/settings/search/SettingsSearchIndex.kt
@@ -218,6 +218,13 @@ internal object SettingsSearchIndex {
     )
     add(
       SettingsSearchEntry(
+        titleRes = R.string.agenda_default_view_title,
+        path = remindersPath,
+        highlightItemId = SettingsSearchItemKeys.REMINDERS_AGENDA_VIEW_MODE,
+      ),
+    )
+    add(
+      SettingsSearchEntry(
         titleRes = R.string.completed_reminders,
         path = remindersPath,
         keywordRes = listOf(R.string.settings_search_keyword_archive_completed),

--- a/logic/logic-reminder/src/main/kotlin/com/github/naz013/logic/reminder/AgendaViewMode.kt
+++ b/logic/logic-reminder/src/main/kotlin/com/github/naz013/logic/reminder/AgendaViewMode.kt
@@ -1,0 +1,7 @@
+package com.github.naz013.logic.reminder
+
+/** Which layout the Agenda screen's reminder list renders in - see [ReminderPreferences.agendaViewMode]. */
+enum class AgendaViewMode {
+  LIST,
+  MATRIX,
+}

--- a/logic/logic-reminder/src/main/kotlin/com/github/naz013/logic/reminder/ReminderPreferences.kt
+++ b/logic/logic-reminder/src/main/kotlin/com/github/naz013/logic/reminder/ReminderPreferences.kt
@@ -37,4 +37,5 @@ interface ReminderPreferences {
   var defaultLockScreenVisibility: String
   var initPresets: Boolean
   var initDefaultPresets: Boolean
+  var agendaViewMode: AgendaViewMode
 }

--- a/ui/ui-agenda/build.gradle.kts
+++ b/ui/ui-agenda/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
   implementation(project(":core:logging-api"))
   implementation(project(":core:platform-common"))
   implementation(project(":core:date-calculations"))
+  implementation(project(":data:repository-api"))
   implementation(project(":ui:ui-common"))
   implementation(project(":ui:ui-reminder"))
   implementation(project(":ui:ui-birthday"))

--- a/ui/ui-agenda/src/main/kotlin/com/github/naz013/ui/agenda/UiAgendaItem.kt
+++ b/ui/ui-agenda/src/main/kotlin/com/github/naz013/ui/agenda/UiAgendaItem.kt
@@ -1,5 +1,6 @@
 package com.github.naz013.ui.agenda
 
+import com.github.naz013.domain.reminder.v2.ReminderPriority
 import com.github.naz013.ui.reminder.UiReminderListActions
 import com.github.naz013.ui.reminder.UiReminderListState
 import com.github.naz013.ui.common.selection.Selectable
@@ -49,6 +50,9 @@ data class UiAgendaReminder(
   /** Whether this row is currently open in the two-pane layout's detail pane. */
   val isHighlighted: Boolean = false,
   val isOverdue: Boolean = false,
+  /** Fully resolved (Reminder -> Group -> Settings) notification priority, reused as the
+   * importance axis for the Agenda Matrix view - see `classifyIntoQuadrants` in feature-agenda. */
+  val priority: ReminderPriority = ReminderPriority.NORMAL,
   override val isSelected: Boolean = false,
 ) : UiAgendaItem, Selectable<UiAgendaReminder> {
   override fun withSelected(selected: Boolean) = copy(isSelected = selected)

--- a/ui/ui-agenda/src/main/kotlin/com/github/naz013/ui/agenda/UiAgendaItemAdapter.kt
+++ b/ui/ui-agenda/src/main/kotlin/com/github/naz013/ui/agenda/UiAgendaItemAdapter.kt
@@ -7,8 +7,11 @@ import com.github.naz013.common.TextProvider
 import com.github.naz013.datecalc.DateTimeManager
 import com.github.naz013.domain.Birthday
 import com.github.naz013.domain.reminder.v2.GroupV2
+import com.github.naz013.domain.reminder.v2.NotificationSettings
 import com.github.naz013.domain.reminder.v2.ReminderAction
 import com.github.naz013.domain.reminder.v2.ReminderV2
+import com.github.naz013.domain.reminder.v2.resolve
+import com.github.naz013.repository.ReminderSettingsRepository
 import org.threeten.bp.LocalDate
 import org.threeten.bp.LocalDateTime
 
@@ -23,6 +26,7 @@ class UiAgendaItemAdapter(
   private val uiBirthdayListAdapter: UiBirthdayListAdapter,
   private val dateTimeManager: DateTimeManager,
   private val textProvider: TextProvider,
+  private val reminderSettingsRepository: ReminderSettingsRepository,
 ) {
   fun convertV2(
     reminders: List<ReminderV2>,
@@ -30,8 +34,13 @@ class UiAgendaItemAdapter(
     birthdays: List<Birthday>,
   ): List<UiAgendaItem> {
     val (pinnedReminders, unpinnedReminders) = reminders.partition { it.isPinned }
+    // Read once per conversion rather than per reminder - a cheap SharedPreferences-backed getter,
+    // but there's no reason to re-read it for every row in the list.
+    val notificationDefaults = reminderSettingsRepository.getNotificationDefaults()
 
-    val reminderItems = unpinnedReminders.map { toUiAgendaReminderV2(it, it.groupId?.let { id -> groupsById[id] }) }
+    val reminderItems = unpinnedReminders.map {
+      toUiAgendaReminderV2(it, it.groupId?.let { id -> groupsById[id] }, notificationDefaults)
+    }
     val birthdayItems = birthdays.map { convertBirthday(it) }
     val merged = (reminderItems + birthdayItems).sortedBy { it.dateTime }
     val body = insertHeaders(merged)
@@ -40,7 +49,7 @@ class UiAgendaItemAdapter(
 
     val pinnedItems =
       pinnedReminders
-        .map { toUiAgendaReminderV2(it, it.groupId?.let { id -> groupsById[id] }) }
+        .map { toUiAgendaReminderV2(it, it.groupId?.let { id -> groupsById[id] }, notificationDefaults) }
         .sortedBy { it.dateTime }
     val pinnedHeader =
       UiAgendaHeader(
@@ -78,6 +87,7 @@ class UiAgendaItemAdapter(
   private fun toUiAgendaReminderV2(
     reminder: ReminderV2,
     group: GroupV2?,
+    notificationDefaults: NotificationSettings,
   ): UiAgendaReminder {
     val uiReminderList = uiReminderListAdapter.createV2(reminder, group)
     return UiAgendaReminder(
@@ -97,6 +107,7 @@ class UiAgendaItemAdapter(
       state = uiReminderList.state,
       isOverdue = uiReminderList.state.isActive &&
         uiReminderList.dueDateTime?.isAfter(dateTimeManager.getCurrentDateTime()) == false,
+      priority = reminder.notification.resolve(group = group?.notification, defaults = notificationDefaults).priority,
     )
   }
 

--- a/ui/ui-agenda/src/test/kotlin/com/github/naz013/ui/agenda/UiAgendaItemAdapterTest.kt
+++ b/ui/ui-agenda/src/test/kotlin/com/github/naz013/ui/agenda/UiAgendaItemAdapterTest.kt
@@ -13,11 +13,13 @@ import com.github.naz013.common.TextProvider
 import com.github.naz013.datecalc.DateTimeManager
 import com.github.naz013.domain.Birthday
 import com.github.naz013.domain.reminder.v2.LocationSettings
+import com.github.naz013.domain.reminder.v2.NotificationSettings
 import com.github.naz013.domain.reminder.v2.ReminderAction
 import com.github.naz013.domain.reminder.v2.ReminderSchedule
 import com.github.naz013.domain.reminder.v2.ReminderV2
 import com.github.naz013.domain.reminder.v2.SyncMetadata
 import com.github.naz013.domain.sync.SyncState
+import com.github.naz013.repository.ReminderSettingsRepository
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
@@ -33,6 +35,7 @@ class UiAgendaItemAdapterTest {
   private val uiBirthdayListAdapter = mockk<UiBirthdayListAdapter>()
   private val dateTimeManager = mockk<DateTimeManager>()
   private val textProvider = mockk<TextProvider>()
+  private val reminderSettingsRepository = mockk<ReminderSettingsRepository>()
 
   private lateinit var adapter: UiAgendaItemAdapter
 
@@ -51,8 +54,15 @@ class UiAgendaItemAdapterTest {
     every { textProvider.getText(R.string.location) } returns "Location"
     every { textProvider.getText(R.string.shopping_lists) } returns "Shopping lists"
     every { textProvider.getText(R.string.pinned) } returns "Pinned"
+    every { reminderSettingsRepository.getNotificationDefaults() } returns NotificationSettings()
 
-    adapter = UiAgendaItemAdapter(uiReminderListAdapter, uiBirthdayListAdapter, dateTimeManager, textProvider)
+    adapter = UiAgendaItemAdapter(
+      uiReminderListAdapter,
+      uiBirthdayListAdapter,
+      dateTimeManager,
+      textProvider,
+      reminderSettingsRepository,
+    )
   }
 
   private fun reminderV2(

--- a/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/component/SettingsHighlight.kt
+++ b/ui/ui-common/src/main/kotlin/com/github/naz013/ui/common/compose/foundation/component/SettingsHighlight.kt
@@ -82,6 +82,7 @@ object SettingsSearchItemKeys {
   const val REMINDERS_VIBRATION_PATTERN = "reminders_vibration_pattern"
   const val REMINDERS_INSIGHTS = "reminders_insights"
   const val REMINDERS_PRIORITY = "reminders_priority"
+  const val REMINDERS_AGENDA_VIEW_MODE = "reminders_agenda_view_mode"
   const val REMINDERS_COMPLETED = "reminders_completed"
   const val REMINDERS_WEAR = "reminders_wear"
   const val REMINDERS_REPEAT_INTERVAL = "reminders_repeat_interval"

--- a/ui/ui-common/src/main/res/values-ar/strings.xml
+++ b/ui/ui-common/src/main/res/values-ar/strings.xml
@@ -1372,4 +1372,11 @@
     <string name="critical_reminder">تذكير حرج</string>
     <string name="critical_reminder_description">يتكرر حتى يتم رفضه، ويتجاوز وضع عدم الإزعاج، ويشغّل الشاشة. للتنبيهات التي لا يمكنك تفويتها.</string>
     <string name="critical">حرج</string>
+    <string name="agenda_matrix_view">مصفوفة الأولويات</string>
+    <string name="agenda_list_view">قائمة</string>
+    <string name="agenda_matrix_do_first">افعل أولاً</string>
+    <string name="agenda_matrix_schedule">جدولة</string>
+    <string name="agenda_matrix_delegate">تفويض</string>
+    <string name="agenda_matrix_someday">يومًا ما</string>
+    <string name="agenda_default_view_title">طريقة العرض الافتراضية للتذكيرات</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-bg/strings.xml
+++ b/ui/ui-common/src/main/res/values-bg/strings.xml
@@ -1375,4 +1375,11 @@
     <string name="critical_reminder">Критично напомняне</string>
     <string name="critical_reminder_description">Повтаря се, докато не бъде отхвърлено, заобикаля режим \"Не безпокойте\" и събужда екрана. За известия, които не можете да пропуснете.</string>
     <string name="critical">Критично</string>
+    <string name="agenda_matrix_view">Матрица на приоритетите</string>
+    <string name="agenda_list_view">Списък</string>
+    <string name="agenda_matrix_do_first">Направи първо</string>
+    <string name="agenda_matrix_schedule">Планирай</string>
+    <string name="agenda_matrix_delegate">Делегирай</string>
+    <string name="agenda_matrix_someday">Някой ден</string>
+    <string name="agenda_default_view_title">Изглед по подразбиране за напомняния</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-cs/strings.xml
+++ b/ui/ui-common/src/main/res/values-cs/strings.xml
@@ -1374,4 +1374,11 @@
     <string name="critical_reminder">Kritická připomínka</string>
     <string name="critical_reminder_description">Opakuje se, dokud není zavřena, obchází režim Nerušit a probouzí obrazovku. Pro upozornění, která si nemůžete dovolit zmeškat.</string>
     <string name="critical">Kritické</string>
+    <string name="agenda_matrix_view">Matice priorit</string>
+    <string name="agenda_list_view">Seznam</string>
+    <string name="agenda_matrix_do_first">Udělat nejdřív</string>
+    <string name="agenda_matrix_schedule">Naplánovat</string>
+    <string name="agenda_matrix_delegate">Delegovat</string>
+    <string name="agenda_matrix_someday">Někdy</string>
+    <string name="agenda_default_view_title">Výchozí zobrazení připomenutí</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-da/strings.xml
+++ b/ui/ui-common/src/main/res/values-da/strings.xml
@@ -1372,4 +1372,11 @@
     <string name="critical_reminder">Kritisk påmindelse</string>
     <string name="critical_reminder_description">Gentages, indtil den afvises, omgår Forstyr ikke, og vækker skærmen. Til alarmer, du ikke har råd til at gå glip af.</string>
     <string name="critical">Kritisk</string>
+    <string name="agenda_matrix_view">Prioritetsmatrix</string>
+    <string name="agenda_list_view">Liste</string>
+    <string name="agenda_matrix_do_first">Gør først</string>
+    <string name="agenda_matrix_schedule">Planlæg</string>
+    <string name="agenda_matrix_delegate">Uddeleger</string>
+    <string name="agenda_matrix_someday">En dag</string>
+    <string name="agenda_default_view_title">Standardvisning for påmindelser</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-de/strings.xml
+++ b/ui/ui-common/src/main/res/values-de/strings.xml
@@ -1370,4 +1370,11 @@
     <string name="critical_reminder">Kritische Erinnerung</string>
     <string name="critical_reminder_description">Wiederholt sich, bis sie geschlossen wird, umgeht „Nicht stören“ und weckt den Bildschirm auf. Für Erinnerungen, die Sie nicht verpassen dürfen.</string>
     <string name="critical">Kritisch</string>
+    <string name="agenda_matrix_view">Prioritätenmatrix</string>
+    <string name="agenda_list_view">Liste</string>
+    <string name="agenda_matrix_do_first">Zuerst erledigen</string>
+    <string name="agenda_matrix_schedule">Planen</string>
+    <string name="agenda_matrix_delegate">Delegieren</string>
+    <string name="agenda_matrix_someday">Irgendwann</string>
+    <string name="agenda_default_view_title">Standardansicht für Erinnerungen</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-es/strings.xml
+++ b/ui/ui-common/src/main/res/values-es/strings.xml
@@ -1374,4 +1374,11 @@
     <string name="critical_reminder">Recordatorio crítico</string>
     <string name="critical_reminder_description">Se repite hasta que se descarta, omite el modo No molestar y activa la pantalla. Para alertas que no puedes permitirte perder.</string>
     <string name="critical">Crítico</string>
+    <string name="agenda_matrix_view">Matriz de prioridades</string>
+    <string name="agenda_list_view">Lista</string>
+    <string name="agenda_matrix_do_first">Hacer primero</string>
+    <string name="agenda_matrix_schedule">Programar</string>
+    <string name="agenda_matrix_delegate">Delegar</string>
+    <string name="agenda_matrix_someday">Algún día</string>
+    <string name="agenda_default_view_title">Vista predeterminada de recordatorios</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-fr/strings.xml
+++ b/ui/ui-common/src/main/res/values-fr/strings.xml
@@ -1374,4 +1374,11 @@
     <string name="critical_reminder">Rappel critique</string>
     <string name="critical_reminder_description">Se répète jusqu\'à ce qu\'il soit ignoré, contourne le mode Ne pas déranger et réveille l\'écran. Pour les alertes que vous ne pouvez pas vous permettre de manquer.</string>
     <string name="critical">Critique</string>
+    <string name="agenda_matrix_view">Matrice des priorités</string>
+    <string name="agenda_list_view">Liste</string>
+    <string name="agenda_matrix_do_first">À faire en premier</string>
+    <string name="agenda_matrix_schedule">Planifier</string>
+    <string name="agenda_matrix_delegate">Déléguer</string>
+    <string name="agenda_matrix_someday">Un jour</string>
+    <string name="agenda_default_view_title">Vue par défaut des rappels</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-hi/strings.xml
+++ b/ui/ui-common/src/main/res/values-hi/strings.xml
@@ -1376,4 +1376,11 @@
     <string name="critical_reminder">महत्वपूर्ण रिमाइंडर</string>
     <string name="critical_reminder_description">जब तक खारिज न किया जाए तब तक दोहराता है, परेशान न करें मोड को दरकिनार करता है, और स्क्रीन को जगाता है। उन अलर्ट के लिए जिन्हें आप चूक नहीं सकते।</string>
     <string name="critical">महत्वपूर्ण</string>
+    <string name="agenda_matrix_view">प्राथमिकता मैट्रिक्स</string>
+    <string name="agenda_list_view">सूची</string>
+    <string name="agenda_matrix_do_first">पहले करें</string>
+    <string name="agenda_matrix_schedule">शेड्यूल करें</string>
+    <string name="agenda_matrix_delegate">सौंपें</string>
+    <string name="agenda_matrix_someday">किसी दिन</string>
+    <string name="agenda_default_view_title">डिफ़ॉल्ट रिमाइंडर दृश्य</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-id/strings.xml
+++ b/ui/ui-common/src/main/res/values-id/strings.xml
@@ -1372,4 +1372,11 @@
     <string name="critical_reminder">Pengingat kritis</string>
     <string name="critical_reminder_description">Berulang hingga ditutup, melewati mode Jangan Ganggu, dan membangunkan layar. Untuk peringatan yang tidak boleh Anda lewatkan.</string>
     <string name="critical">Kritis</string>
+    <string name="agenda_matrix_view">Matriks prioritas</string>
+    <string name="agenda_list_view">Daftar</string>
+    <string name="agenda_matrix_do_first">Lakukan dulu</string>
+    <string name="agenda_matrix_schedule">Jadwalkan</string>
+    <string name="agenda_matrix_delegate">Delegasikan</string>
+    <string name="agenda_matrix_someday">Suatu saat</string>
+    <string name="agenda_default_view_title">Tampilan default pengingat</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-it/strings.xml
+++ b/ui/ui-common/src/main/res/values-it/strings.xml
@@ -1374,4 +1374,11 @@
     <string name="critical_reminder">Promemoria critico</string>
     <string name="critical_reminder_description">Si ripete finché non viene ignorato, ignora la modalità Non disturbare e riattiva lo schermo. Per gli avvisi che non puoi permetterti di perdere.</string>
     <string name="critical">Critico</string>
+    <string name="agenda_matrix_view">Matrice delle priorità</string>
+    <string name="agenda_list_view">Elenco</string>
+    <string name="agenda_matrix_do_first">Da fare per prima cosa</string>
+    <string name="agenda_matrix_schedule">Pianifica</string>
+    <string name="agenda_matrix_delegate">Delega</string>
+    <string name="agenda_matrix_someday">Un giorno</string>
+    <string name="agenda_default_view_title">Vista predefinita dei promemoria</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-ja/strings.xml
+++ b/ui/ui-common/src/main/res/values-ja/strings.xml
@@ -1374,4 +1374,11 @@
     <string name="critical_reminder">重要なリマインダー</string>
     <string name="critical_reminder_description">解除するまで繰り返され、おやすみモードを無視して画面をオンにします。見逃せない通知向けです。</string>
     <string name="critical">重要</string>
+    <string name="agenda_matrix_view">優先度マトリクス</string>
+    <string name="agenda_list_view">リスト</string>
+    <string name="agenda_matrix_do_first">最初にやる</string>
+    <string name="agenda_matrix_schedule">スケジュールする</string>
+    <string name="agenda_matrix_delegate">委任する</string>
+    <string name="agenda_matrix_someday">いつか</string>
+    <string name="agenda_default_view_title">デフォルトのリマインダー表示</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-ko/strings.xml
+++ b/ui/ui-common/src/main/res/values-ko/strings.xml
@@ -1374,4 +1374,11 @@
     <string name="critical_reminder">긴급 알림</string>
     <string name="critical_reminder_description">해제할 때까지 반복되며, 방해 금지 모드를 무시하고 화면을 켭니다. 놓쳐서는 안 되는 알림에 사용하세요.</string>
     <string name="critical">긴급</string>
+    <string name="agenda_matrix_view">우선순위 매트릭스</string>
+    <string name="agenda_list_view">목록</string>
+    <string name="agenda_matrix_do_first">먼저 하기</string>
+    <string name="agenda_matrix_schedule">일정 잡기</string>
+    <string name="agenda_matrix_delegate">위임</string>
+    <string name="agenda_matrix_someday">언젠가</string>
+    <string name="agenda_default_view_title">기본 알림 보기</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-nb/strings.xml
+++ b/ui/ui-common/src/main/res/values-nb/strings.xml
@@ -1372,4 +1372,11 @@
     <string name="critical_reminder">Kritisk påminnelse</string>
     <string name="critical_reminder_description">Gjentas til den avvises, overstyrer Ikke forstyrr og vekker skjermen. For varsler du ikke har råd til å gå glipp av.</string>
     <string name="critical">Kritisk</string>
+    <string name="agenda_matrix_view">Prioritetsmatrise</string>
+    <string name="agenda_list_view">Liste</string>
+    <string name="agenda_matrix_do_first">Gjør først</string>
+    <string name="agenda_matrix_schedule">Planlegg</string>
+    <string name="agenda_matrix_delegate">Deleger</string>
+    <string name="agenda_matrix_someday">En dag</string>
+    <string name="agenda_default_view_title">Standardvisning for påminnelser</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-nl/strings.xml
+++ b/ui/ui-common/src/main/res/values-nl/strings.xml
@@ -1372,4 +1372,11 @@
     <string name="critical_reminder">Kritieke herinnering</string>
     <string name="critical_reminder_description">Herhaalt totdat deze wordt gesloten, omzeilt Niet storen en wekt het scherm. Voor meldingen die u niet mag missen.</string>
     <string name="critical">Kritiek</string>
+    <string name="agenda_matrix_view">Prioriteitenmatrix</string>
+    <string name="agenda_list_view">Lijst</string>
+    <string name="agenda_matrix_do_first">Eerst doen</string>
+    <string name="agenda_matrix_schedule">Plannen</string>
+    <string name="agenda_matrix_delegate">Delegeren</string>
+    <string name="agenda_matrix_someday">Ooit</string>
+    <string name="agenda_default_view_title">Standaardweergave voor herinneringen</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-pl/strings.xml
+++ b/ui/ui-common/src/main/res/values-pl/strings.xml
@@ -1374,4 +1374,11 @@
     <string name="critical_reminder">Krytyczne przypomnienie</string>
     <string name="critical_reminder_description">Powtarza się, dopóki nie zostanie odrzucone, omija tryb Nie przeszkadzać i wybudza ekran. Dla alertów, których nie możesz przegapić.</string>
     <string name="critical">Krytyczne</string>
+    <string name="agenda_matrix_view">Macierz priorytetów</string>
+    <string name="agenda_list_view">Lista</string>
+    <string name="agenda_matrix_do_first">Zrób najpierw</string>
+    <string name="agenda_matrix_schedule">Zaplanuj</string>
+    <string name="agenda_matrix_delegate">Deleguj</string>
+    <string name="agenda_matrix_someday">Kiedyś</string>
+    <string name="agenda_default_view_title">Domyślny widok przypomnień</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-pt/strings.xml
+++ b/ui/ui-common/src/main/res/values-pt/strings.xml
@@ -1374,4 +1374,11 @@
     <string name="critical_reminder">Lembrete crítico</string>
     <string name="critical_reminder_description">Repete até ser dispensado, ignora o modo Não perturbe e ativa a tela. Para alertas que você não pode perder.</string>
     <string name="critical">Crítico</string>
+    <string name="agenda_matrix_view">Matriz de prioridades</string>
+    <string name="agenda_list_view">Lista</string>
+    <string name="agenda_matrix_do_first">Fazer primeiro</string>
+    <string name="agenda_matrix_schedule">Agendar</string>
+    <string name="agenda_matrix_delegate">Delegar</string>
+    <string name="agenda_matrix_someday">Algum dia</string>
+    <string name="agenda_default_view_title">Visualização padrão de lembretes</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-ro/strings.xml
+++ b/ui/ui-common/src/main/res/values-ro/strings.xml
@@ -1374,4 +1374,11 @@
     <string name="critical_reminder">Memento critic</string>
     <string name="critical_reminder_description">Se repetă până este respins, ocolește modul Nu deranja și trezește ecranul. Pentru alerte pe care nu ți le poți permite să le ratezi.</string>
     <string name="critical">Critic</string>
+    <string name="agenda_matrix_view">Matricea priorităților</string>
+    <string name="agenda_list_view">Listă</string>
+    <string name="agenda_matrix_do_first">De făcut primul</string>
+    <string name="agenda_matrix_schedule">Programează</string>
+    <string name="agenda_matrix_delegate">Deleagă</string>
+    <string name="agenda_matrix_someday">Cândva</string>
+    <string name="agenda_default_view_title">Vizualizare implicită a memento-urilor</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-ru/strings.xml
+++ b/ui/ui-common/src/main/res/values-ru/strings.xml
@@ -1373,4 +1373,11 @@
     <string name="critical_reminder">Критическое напоминание</string>
     <string name="critical_reminder_description">Повторяется, пока не будет отклонено, обходит режим «Не беспокоить» и включает экран. Для оповещений, которые нельзя пропустить.</string>
     <string name="critical">Критично</string>
+    <string name="agenda_matrix_view">Матрица приоритетов</string>
+    <string name="agenda_list_view">Список</string>
+    <string name="agenda_matrix_do_first">Сделать в первую очередь</string>
+    <string name="agenda_matrix_schedule">Запланировать</string>
+    <string name="agenda_matrix_delegate">Делегировать</string>
+    <string name="agenda_matrix_someday">Когда-нибудь</string>
+    <string name="agenda_default_view_title">Вид напоминаний по умолчанию</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-sv/strings.xml
+++ b/ui/ui-common/src/main/res/values-sv/strings.xml
@@ -1372,4 +1372,11 @@
     <string name="critical_reminder">Kritisk påminnelse</string>
     <string name="critical_reminder_description">Upprepas tills den avfärdas, kringgår Stör ej och väcker skärmen. För varningar du inte har råd att missa.</string>
     <string name="critical">Kritisk</string>
+    <string name="agenda_matrix_view">Prioritetsmatris</string>
+    <string name="agenda_list_view">Lista</string>
+    <string name="agenda_matrix_do_first">Gör först</string>
+    <string name="agenda_matrix_schedule">Schemalägg</string>
+    <string name="agenda_matrix_delegate">Delegera</string>
+    <string name="agenda_matrix_someday">Någon gång</string>
+    <string name="agenda_default_view_title">Standardvy för påminnelser</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-th/strings.xml
+++ b/ui/ui-common/src/main/res/values-th/strings.xml
@@ -1372,4 +1372,11 @@
     <string name="critical_reminder">การแจ้งเตือนสำคัญ</string>
     <string name="critical_reminder_description">ทำซ้ำจนกว่าจะปิด ข้ามโหมดห้ามรบกวน และปลุกหน้าจอ สำหรับการแจ้งเตือนที่คุณพลาดไม่ได้</string>
     <string name="critical">สำคัญมาก</string>
+    <string name="agenda_matrix_view">เมทริกซ์ลำดับความสำคัญ</string>
+    <string name="agenda_list_view">รายการ</string>
+    <string name="agenda_matrix_do_first">ทำก่อน</string>
+    <string name="agenda_matrix_schedule">กำหนดการ</string>
+    <string name="agenda_matrix_delegate">มอบหมาย</string>
+    <string name="agenda_matrix_someday">สักวันหนึ่ง</string>
+    <string name="agenda_default_view_title">มุมมองการแจ้งเตือนเริ่มต้น</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-tr/strings.xml
+++ b/ui/ui-common/src/main/res/values-tr/strings.xml
@@ -1375,4 +1375,11 @@
     <string name="critical_reminder">Kritik hatırlatıcı</string>
     <string name="critical_reminder_description">Kapatılana kadar tekrarlanır, Rahatsız Etmeyin modunu atlar ve ekranı uyandırır. Kaçırmamanız gereken uyarılar için.</string>
     <string name="critical">Kritik</string>
+    <string name="agenda_matrix_view">Öncelik matrisi</string>
+    <string name="agenda_list_view">Liste</string>
+    <string name="agenda_matrix_do_first">Önce yap</string>
+    <string name="agenda_matrix_schedule">Planla</string>
+    <string name="agenda_matrix_delegate">Devret</string>
+    <string name="agenda_matrix_someday">Bir gün</string>
+    <string name="agenda_default_view_title">Varsayılan hatırlatıcı görünümü</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-uk/strings.xml
+++ b/ui/ui-common/src/main/res/values-uk/strings.xml
@@ -1375,4 +1375,11 @@
     <string name="critical_reminder">Критичне нагадування</string>
     <string name="critical_reminder_description">Повторюється, доки не буде закрито, обходить режим «Не турбувати» і вмикає екран. Для сповіщень, які не можна пропустити.</string>
     <string name="critical">Критично</string>
+    <string name="agenda_matrix_view">Матриця пріоритетів</string>
+    <string name="agenda_list_view">Список</string>
+    <string name="agenda_matrix_do_first">Зробити першим</string>
+    <string name="agenda_matrix_schedule">Запланувати</string>
+    <string name="agenda_matrix_delegate">Делегувати</string>
+    <string name="agenda_matrix_someday">Колись</string>
+    <string name="agenda_default_view_title">Вигляд нагадувань за замовчуванням</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-vi/strings.xml
+++ b/ui/ui-common/src/main/res/values-vi/strings.xml
@@ -1372,4 +1372,11 @@
     <string name="critical_reminder">Nhắc nhở quan trọng</string>
     <string name="critical_reminder_description">Lặp lại cho đến khi bị hủy, bỏ qua chế độ Không làm phiền và đánh thức màn hình. Dành cho các cảnh báo bạn không thể bỏ lỡ.</string>
     <string name="critical">Quan trọng</string>
+    <string name="agenda_matrix_view">Ma trận ưu tiên</string>
+    <string name="agenda_list_view">Danh sách</string>
+    <string name="agenda_matrix_do_first">Làm trước</string>
+    <string name="agenda_matrix_schedule">Lên lịch</string>
+    <string name="agenda_matrix_delegate">Ủy quyền</string>
+    <string name="agenda_matrix_someday">Một ngày nào đó</string>
+    <string name="agenda_default_view_title">Chế độ xem nhắc nhở mặc định</string>
 </resources>

--- a/ui/ui-common/src/main/res/values-zh/strings.xml
+++ b/ui/ui-common/src/main/res/values-zh/strings.xml
@@ -1375,4 +1375,11 @@
     <string name="critical_reminder">紧急提醒</string>
     <string name="critical_reminder_description">在被关闭之前会重复提醒，绕过勿扰模式并唤醒屏幕。适用于您不能错过的提醒。</string>
     <string name="critical">紧急</string>
+    <string name="agenda_matrix_view">优先级矩阵</string>
+    <string name="agenda_list_view">列表</string>
+    <string name="agenda_matrix_do_first">优先处理</string>
+    <string name="agenda_matrix_schedule">安排日程</string>
+    <string name="agenda_matrix_delegate">委派</string>
+    <string name="agenda_matrix_someday">以后再说</string>
+    <string name="agenda_default_view_title">默认提醒视图</string>
 </resources>

--- a/ui/ui-common/src/main/res/values/strings.xml
+++ b/ui/ui-common/src/main/res/values/strings.xml
@@ -1390,4 +1390,11 @@
     <string name="critical_reminder">Critical reminder</string>
     <string name="critical_reminder_description">Repeats until dismissed, bypasses Do Not Disturb, and wakes the screen. For alerts you can\'t afford to miss.</string>
     <string name="critical">Critical</string>
+    <string name="agenda_matrix_view">Priority matrix</string>
+    <string name="agenda_list_view">List</string>
+    <string name="agenda_matrix_do_first">Do first</string>
+    <string name="agenda_matrix_schedule">Schedule</string>
+    <string name="agenda_matrix_delegate">Delegate</string>
+    <string name="agenda_matrix_someday">Someday</string>
+    <string name="agenda_default_view_title">Default reminder view</string>
 </resources>


### PR DESCRIPTION
Adds an Eisenhower-style four-quadrant alternate layout for the reminder
list, built entirely from existing data - resolved notification priority
as the importance axis, overdue/due-today as urgency - toggleable from the
Agenda screen's app bar and persisted as a "Default reminder view" setting
under Reminders settings.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UzFNV8vMGVA2omUdqP6HjH